### PR TITLE
Fix dead Japan Trip link

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,6 @@
             <h2>🌍 Trips</h2>
             <ul class="project-grid">
                 <li class="project-card"><a href="/trips/ChicagoTripItinerary/">Chicago Trip Itinerary</a></li>
-                <li class="project-card"><a href="/trips/JapanTrip/">Japan Trip</a></li>
             </ul>
         </section>
 


### PR DESCRIPTION
## Summary
- remove Japan trip placeholder link from index.html

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6879312f72148320894b5ec4f659f496