### PR TITLE
Add docs, license and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Node and Next.js build outputs
+node_modules/
+.next/
+
+# OS and IDE artifacts
+.DS_Store
+.idea/
+.vscode/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# environment variables
+.env
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 James Berto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# Website-Testing-
+# Personal Website
+
+This repository contains the static files for my personal site. The pages are plain HTML with inline CSS and a few external libraries.
+
+## Local Setup
+
+1. Clone the repository.
+2. No build step is required. Serve the files directly with a static file server of your choice. For example, using Python:
+   ```bash
+   python3 -m http.server 8080
+   ```
+   Then open `http://localhost:8080` in your browser.
+
+## Directory Overview
+
+- `index.html` – Home page linking to all other sections.
+- `games/` – Small experiments and demos.
+  - `noir_detective_idea/` – Prototype for a noir adventure game.
+- `tools/` – Utility pages.
+  - `CalorieTracker/` – 3‑day rolling average nutrition tracker.
+- `trips/` – Itineraries and travel notes.
+  - `ChicagoTripItinerary/` – Example weekend plan for Chicago.
+
+## Deployment on Cloudflare Pages
+
+1. Log into Cloudflare and create a new Pages project.
+2. Connect the project to this repository.
+3. For build settings, leave the build command empty and set the root directory to `/`.
+4. Cloudflare will serve the files from the main branch. Any new commit will trigger a deployment.
+


### PR DESCRIPTION
## Summary
- add a basic `.gitignore` for Node/Next.js and editor cruft
- replace the truncated README with setup, directory overview, and Cloudflare deployment notes
- include an MIT license

## Testing
- `npm test` *(fails: no `package.json` found)*

------
https://chatgpt.com/codex/tasks/task_b_687958f9d5508320aeca689215f6c5bd