### PR TITLE
Add React version of site categories

### DIFF
--- a/hub/app/page.tsx
+++ b/hub/app/page.tsx
@@ -1,103 +1,90 @@
-import Image from "next/image";
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+
+// --- Configuration ---
+type SubItem = { name: string; href: string }
+interface Category { id: string; icon: string; title: string; items: SubItem[] }
+
+const categories: Category[] = [
+  {
+    id: 'trips',
+    icon: '🌍',
+    title: 'Trips',
+    items: [{ name: 'Chicago Trip Itinerary', href: '/trips/ChicagoTripItinerary/' }],
+  },
+  {
+    id: 'tools',
+    icon: '🛠️',
+    title: 'Tools',
+    items: [{ name: 'Calorie Tracker', href: '/tools/CalorieTracker/' }],
+  },
+  {
+    id: 'games',
+    icon: '🎮',
+    title: 'Games',
+    items: [{ name: 'Noir Detective Idea', href: '/games/noir_detective_idea/' }],
+  },
+]
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
+    <div className="min-h-screen font-sans p-4 sm:p-8 mx-auto max-w-3xl">
+      <header className="mb-8 text-center">
+        <h1 className="text-2xl font-bold">Welcome to My Corner of the Web</h1>
+      </header>
+      <main className="space-y-4">
+        {categories.map((cat) => (
+          <CategoryBand key={cat.id} category={cat} />
+        ))}
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
     </div>
-  );
+  )
+}
+
+function CategoryBand({ category }: { category: Category }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="border rounded bg-gray-50">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex justify-between items-center p-4 font-semibold"
+      >
+        <span>
+          {category.icon} {category.title}
+        </span>
+        <span className="text-xl">{open ? '−' : '+'}</span>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="overflow-hidden px-4"
+          >
+            <ul className="grid gap-4 py-4 sm:grid-cols-2">
+              {category.items.map((item) => (
+                <li
+                  key={item.href}
+                  className="bg-white rounded-lg shadow transition-transform hover:-translate-y-1 hover:shadow-lg list-none"
+                >
+                  <Link
+                    href={item.href}
+                    className="block p-4 text-blue-600 font-bold"
+                  >
+                    {item.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- replace default Next.js page with expandable list of categories
- use Framer Motion animations for expanding subcategories
- link to existing HTML tools, games and trips

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_b_6879ac3a2aa483209834c1c416eab422