### PR TITLE
Move Firebase config to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,22 @@ This repository contains the static HTML pages for my website. There is no build
 1. Create a new Pages project and connect it to this repository.
 2. Leave the build command blank and set the root directory to `/`.
 3. Cloudflare will deploy on every commit to the main branch.
+
+## Firebase Config
+
+The Calorie Tracker uses Firebase for authentication and storage. Its `firebaseConfig` object lives in `tools/CalorieTracker/firebaseConfig.js`. These values are public client identifiers and safe to include in the repository.
+
+### React Hub Initialization
+
+If Firebase functionality is later needed in the React hub, create a file such as `hub/firebase.ts` and initialize Firebase there:
+
+```ts
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { firebaseConfig } from '../tools/CalorieTracker/firebaseConfig';
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+```
+
+Import the `auth` instance in your React components wherever authentication is required.

--- a/tools/CalorieTracker/firebaseConfig.js
+++ b/tools/CalorieTracker/firebaseConfig.js
@@ -1,0 +1,9 @@
+export const firebaseConfig = {
+  apiKey: "AIzaSyBHdodVoGI962K1MWeyAp519duJX22ZDss",
+  authDomain: "jlb-calorietracker.firebaseapp.com",
+  projectId: "jlb-calorietracker",
+  storageBucket: "jlb-calorietracker.firebasestorage.app",
+  messagingSenderId: "994744135946",
+  appId: "1:994744135946:web:ccf2aa11ce73c2c77c4af3",
+  measurementId: "G-3SWQ8KQ2EQ"
+};

--- a/tools/CalorieTracker/index.html
+++ b/tools/CalorieTracker/index.html
@@ -45,16 +45,8 @@
 
     <!-- Firebase Config -->
     <script type="module">
+        import { firebaseConfig } from "./firebaseConfig.js";
         // --- Firebase Configuration ---
-        const firebaseConfig = {
-              apiKey:"AIzaSyBHdodVoGI962K1MWeyAp519duJX22ZDss",
-              authDomain: "jlb-calorietracker.firebaseapp.com",
-              projectId: "jlb-calorietracker",
-              storageBucket: "jlb-calorietracker.firebasestorage.app",
-              messagingSenderId: "994744135946",
-              appId: "1:994744135946:web:ccf2aa11ce73c2c77c4af3",
-              measurementId: "G-3SWQ8KQ2EQ"
-            };
     
         // --- Firebase Imports ---
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";


### PR DESCRIPTION
## Summary
- place Firebase client keys in `firebaseConfig.js`
- import the config in CalorieTracker
- document that the keys are safe to expose and show how to initialize Firebase in the React hub

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6879b083570c83209367cc89ec28853a