### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal Website
 
-This repository hosts my static pages along with a small Next.js app that powers the main landing page.
+This repository contains a small Next.js application that serves as an interactive hub along with various static pages.  All content lives in the `hub` folder and is exported to static files under `hub/out` for deployment.
 
 ## Local Development
 
@@ -13,22 +13,24 @@ This repository hosts my static pages along with a small Next.js app that powers
    npm run dev
    ```
    The hub will be available at `http://localhost:3000`.
-3. To view the static pages without a build step, you can run a simple server from the project root:
+3. Build the static site (output goes to `hub/out`):
+   ```bash
+   npm run build
+   ```
+4. To view the static pages without a build step, run a simple server from the project root:
    ```bash
    python3 -m http.server 8080
    ```
 
-## Directory Overview
+## Project Structure
 
 - `index.html` – Redirects visitors to the React hub under `/hub/`.
 - `index_legacy.html` – Previous static landing page kept for reference.
-- `hub/` – Next.js project containing the interactive hub.
-- `games/` – Small demos and experiments.
-  - `noir_detective_idea/` – Prototype noir adventure.
-- `tools/` – Utility pages.
-  - `CalorieTracker/` – Three‑day rolling average nutrition tracker.
-- `trips/` – Travel notes and itineraries.
-  - `ChicagoTripItinerary/` – Example weekend plan for Chicago.
+- `hub/` – Source for the Next.js hub.
+  - `app/` – Application routes and components.
+  - `public/` – Static assets used by the hub.
+  - `out/` – Static export produced by `npm run build`.
+    - `games/`, `tools/`, `trips/` – Demos, utilities, and travel notes copied here during deployment.
 
 ## Deployment on Cloudflare Pages
 

--- a/hub/README.md
+++ b/hub/README.md
@@ -1,36 +1,32 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Hub
 
-## Getting Started
+This directory contains the Next.js application that powers the main site. The app is exported as a set of static files for hosting on services like Cloudflare Pages.
 
-First, run the development server:
+## Development
+
+Install dependencies and run the dev server:
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The site will be available at `http://localhost:3000`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Building for Production
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Generate the static export into the `out/` directory:
 
-## Learn More
+```bash
+npm run build
+```
 
-To learn more about Next.js, take a look at the following resources:
+## Directory Overview
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- `app/` – App router files and components.
+- `public/` – Static assets used by the hub.
+- `out/` – Result of `npm run build`. Contents are ready to deploy.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Customization
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+The links and categories on the landing page are configured in `app/page.tsx`. Edit the `categories` array to add new resources.


### PR DESCRIPTION
## Summary
- clarify project overview and development steps in the main README
- replace the default Next.js README in `hub/` with concise info about building the hub

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687a7831e9288320b0fd91b42a74d078