### PR TITLE
Add JSON hub data option

### DIFF
--- a/content/hubConfig.json
+++ b/content/hubConfig.json
@@ -1,0 +1,35 @@
+[
+  {
+    "slug": "travel",
+    "name": "Travel",
+    "links": [
+      {
+        "title": "Chicago Trip Itinerary",
+        "url": "/trips/ChicagoTripItinerary/",
+        "icon": "🌍"
+      }
+    ]
+  },
+  {
+    "slug": "tools",
+    "name": "Tools",
+    "links": [
+      {
+        "title": "Calorie Tracker",
+        "url": "/tools/CalorieTracker/",
+        "icon": "🛠️"
+      }
+    ]
+  },
+  {
+    "slug": "games",
+    "name": "Games",
+    "links": [
+      {
+        "title": "Noir Detective Idea",
+        "url": "/games/noir_detective_idea/",
+        "icon": "🎮"
+      }
+    ]
+  }
+]

--- a/hub/README.md
+++ b/hub/README.md
@@ -29,4 +29,4 @@ npm run build
 
 ## Customization
 
-The links and categories on the landing page are configured in `app/page.tsx`. Edit the `categories` array to add new resources.
+Hub data is normally assembled from markdown files under `../content/hub`. To load a static JSON file instead, set `useJsonHubData` in `next.config.ts` to `true`. The JSON configuration lives at `content/hubConfig.json` and uses the same `HubCategory[]` structure returned by `getHubData`.

--- a/hub/app/HubClient.tsx
+++ b/hub/app/HubClient.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import type { HubCategory } from '../lib/getHubData'
+
+export default function HubClient({ categories }: { categories: HubCategory[] }) {
+  return (
+    <main className="space-y-4">
+      {categories.map((cat) => (
+        <CategoryBand key={cat.slug} category={cat} />
+      ))}
+    </main>
+  )
+}
+
+function CategoryBand({ category }: { category: HubCategory }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="border rounded bg-gray-50">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex justify-between items-center p-4 font-semibold"
+      >
+        <span>
+          {category.name}
+        </span>
+        <span className="text-xl">{open ? '−' : '+'}</span>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="overflow-hidden px-4"
+          >
+            <ul className="grid gap-4 py-4 sm:grid-cols-2">
+              {category.links.map((item) => (
+                <li
+                  key={item.url}
+                  className="bg-white rounded-lg shadow transition-transform hover:-translate-y-1 hover:shadow-lg list-none"
+                >
+                  <a href={item.url} className="block p-4 text-blue-600 font-bold">
+                    {item.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/hub/app/page.tsx
+++ b/hub/app/page.tsx
@@ -1,86 +1,14 @@
-'use client'
+import HubClient from './HubClient'
+import { loadHubData } from '../lib/loadHubData'
 
-import { useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
-
-// --- Configuration ---
-type SubItem = { name: string; href: string }
-interface Category { id: string; icon: string; title: string; items: SubItem[] }
-
-const categories: Category[] = [
-  {
-    id: 'trips',
-    icon: '🌍',
-    title: 'Trips',
-    items: [{ name: 'Chicago Trip Itinerary', href: '/trips/ChicagoTripItinerary/' }],
-  },
-  {
-    id: 'tools',
-    icon: '🛠️',
-    title: 'Tools',
-    items: [{ name: 'Calorie Tracker', href: '/tools/CalorieTracker/' }],
-  },
-  {
-    id: 'games',
-    icon: '🎮',
-    title: 'Games',
-    items: [{ name: 'Noir Detective Idea', href: '/games/noir_detective_idea/' }],
-  },
-]
-
-export default function Home() {
+export default async function Home() {
+  const categories = await loadHubData()
   return (
     <div className="min-h-screen font-sans p-4 sm:p-8 mx-auto max-w-3xl">
       <header className="mb-8 text-center">
         <h1 className="text-2xl font-bold">Welcome to My Corner of the Web</h1>
       </header>
-      <main className="space-y-4">
-        {categories.map((cat) => (
-          <CategoryBand key={cat.id} category={cat} />
-        ))}
-      </main>
-    </div>
-  )
-}
-
-function CategoryBand({ category }: { category: Category }) {
-  const [open, setOpen] = useState(false)
-  return (
-    <div className="border rounded bg-gray-50">
-      <button
-        onClick={() => setOpen((o) => !o)}
-        className="w-full flex justify-between items-center p-4 font-semibold"
-      >
-        <span>
-          {category.icon} {category.title}
-        </span>
-        <span className="text-xl">{open ? '−' : '+'}</span>
-      </button>
-      <AnimatePresence initial={false}>
-        {open && (
-          <motion.div
-            key="content"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.3 }}
-            className="overflow-hidden px-4"
-          >
-            <ul className="grid gap-4 py-4 sm:grid-cols-2">
-              {category.items.map((item) => (
-                <li
-                  key={item.href}
-                  className="bg-white rounded-lg shadow transition-transform hover:-translate-y-1 hover:shadow-lg list-none"
-                >
-                  <a href={item.href} className="block p-4 text-blue-600 font-bold">
-                    {item.name}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <HubClient categories={categories} />
     </div>
   )
 }

--- a/hub/lib/loadHubData.ts
+++ b/hub/lib/loadHubData.ts
@@ -1,0 +1,13 @@
+import { getHubData, HubCategory } from './getHubData'
+import { useJsonHubData } from '../next.config'
+import fs from 'fs/promises'
+import path from 'path'
+
+export async function loadHubData(): Promise<HubCategory[]> {
+  if (useJsonHubData) {
+    const jsonPath = path.resolve(process.cwd(), '../content/hubConfig.json')
+    const raw = await fs.readFile(jsonPath, 'utf8')
+    return JSON.parse(raw) as HubCategory[]
+  }
+  return getHubData()
+}

--- a/hub/next.config.ts
+++ b/hub/next.config.ts
@@ -1,8 +1,10 @@
-import type { NextConfig } from 'next';
+import type { NextConfig } from 'next'
+
+export const useJsonHubData = false
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: 'export',
-};
+}
 
-export default nextConfig;
+export default nextConfig


### PR DESCRIPTION
## Summary
- add `content/hubConfig.json` describing hub categories
- expose `useJsonHubData` flag in Next config
- load hub data from JSON when enabled
- split interactive code into `HubClient` and update `page.tsx`
- document new flag in hub README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687aa78c8b588320a1263f4988bcaa9d