### PR TITLE
Add hub data provider

### DIFF
--- a/hub/app/layout.tsx
+++ b/hub/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import HubDataProvider from "../lib/HubDataProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <HubDataProvider>
+          {children}
+        </HubDataProvider>
       </body>
     </html>
   );

--- a/hub/lib/HubDataClientProvider.tsx
+++ b/hub/lib/HubDataClientProvider.tsx
@@ -1,0 +1,17 @@
+'use client'
+import HubDataContext from './HubDataContext'
+import type { HubCategory } from './getHubData'
+
+export default function HubDataClientProvider({
+  children,
+  categories,
+}: {
+  children: React.ReactNode
+  categories: HubCategory[]
+}) {
+  return (
+    <HubDataContext.Provider value={categories}>
+      {children}
+    </HubDataContext.Provider>
+  )
+}

--- a/hub/lib/HubDataContext.tsx
+++ b/hub/lib/HubDataContext.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { createContext } from 'react'
+import type { HubCategory } from './getHubData'
+
+const HubDataContext = createContext<HubCategory[] | null>(null)
+export default HubDataContext

--- a/hub/lib/HubDataProvider.tsx
+++ b/hub/lib/HubDataProvider.tsx
@@ -1,0 +1,16 @@
+import { getHubData } from './getHubData'
+import type { HubCategory } from './getHubData'
+import HubDataClientProvider from './HubDataClientProvider'
+
+export default async function HubDataProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const data: HubCategory[] = await getHubData()
+  return (
+    <HubDataClientProvider categories={data}>
+      {children}
+    </HubDataClientProvider>
+  )
+}

--- a/hub/lib/useHubData.ts
+++ b/hub/lib/useHubData.ts
@@ -1,0 +1,11 @@
+'use client'
+import { useContext } from 'react'
+import HubDataContext from './HubDataContext'
+
+export default function useHubData() {
+  const ctx = useContext(HubDataContext)
+  if (ctx === null) {
+    throw new Error('useHubData must be used within HubDataProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- set up HubDataContext and provider
- load hub metadata at build time
- wrap layout with provider for context access

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_687aa9aeeb4c83209999095911ef60be