### PR TITLE
Add hub orbital components

### DIFF
--- a/hub/components/CoreOrb.tsx
+++ b/hub/components/CoreOrb.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { motion } from 'framer-motion'
+
+// --- Configuration ------------------------------------------------------------
+const CONFIG = {
+  size: 80,              // Base diameter of the orb
+  pulseScale: 1.15,      // Maximum scale during pulse
+  duration: 1.6          // Duration of one pulse cycle in seconds
+}
+
+export default function CoreOrb() {
+  return (
+    <motion.div
+      aria-hidden
+      className="rounded-full bg-blue-500 shadow-2xl"
+      style={{ width: CONFIG.size, height: CONFIG.size }}
+      animate={{ scale: [1, CONFIG.pulseScale, 1] }}
+      transition={{ duration: CONFIG.duration, repeat: Infinity }}
+    />
+  )
+}

--- a/hub/components/HubCanvas.tsx
+++ b/hub/components/HubCanvas.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { useState } from 'react'
+import { LayoutGroup, motion } from 'framer-motion'
+import type { HubCategory } from '../lib/getHubData'
+import CoreOrb from './CoreOrb'
+import NeonRing from './NeonRing'
+
+// --- Configuration ------------------------------------------------------------
+const CONFIG = {
+  canvasSize: 300 // Square size of the canvas in pixels
+}
+
+export interface HubCanvasProps {
+  categories: HubCategory[]
+}
+
+export default function HubCanvas({ categories }: HubCanvasProps) {
+  const [active, setActive] = useState<number | null>(null)
+
+  return (
+    <motion.div
+      className="relative mx-auto"
+      style={{ width: CONFIG.canvasSize, height: CONFIG.canvasSize }}
+    >
+      <LayoutGroup id="hub-rings">
+        <CoreOrb />
+        {categories.map((cat, i) => (
+          <NeonRing
+            key={cat.slug}
+            category={cat}
+            index={i}
+            total={categories.length}
+            isDimmed={active !== null && active !== i}
+            setActive={setActive}
+          />
+        ))}
+      </LayoutGroup>
+    </motion.div>
+  )
+}

--- a/hub/components/NeonRing.tsx
+++ b/hub/components/NeonRing.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { motion } from 'framer-motion'
+import type { HubCategory } from '../lib/getHubData'
+
+// --- Configuration ------------------------------------------------------------
+const CONFIG = {
+  radius: 120,           // Distance from center to ring center in pixels
+  size: 60               // Diameter of each ring
+}
+
+export interface NeonRingProps {
+  category: HubCategory
+  index: number
+  total: number
+  isDimmed: boolean
+  setActive: (i: number | null) => void
+}
+
+export default function NeonRing({
+  category,
+  index,
+  total,
+  isDimmed,
+  setActive
+}: NeonRingProps) {
+  const theta = (index / total) * 2 * Math.PI
+  const x = Math.cos(theta) * CONFIG.radius
+  const y = Math.sin(theta) * CONFIG.radius
+
+  return (
+    <motion.button
+      type="button"
+      aria-label={category.name}
+      className="absolute rounded-full border-2 border-pink-500 text-white"
+      style={{
+        width: CONFIG.size,
+        height: CONFIG.size,
+        left: `calc(50% + ${x}px - ${CONFIG.size / 2}px)`,
+        top: `calc(50% + ${y}px - ${CONFIG.size / 2}px)`
+      }}
+      onHoverStart={() => setActive(index)}
+      onHoverEnd={() => setActive(null)}
+      whileHover={{ scale: 1.1 }}
+      whileTap={{ scale: 0.9 }}
+      animate={{ opacity: isDimmed ? 0.3 : 1 }}
+      layoutId={`ring-${index}`}
+    >
+      {category.name}
+    </motion.button>
+  )
+}


### PR DESCRIPTION
## Summary
- add `CoreOrb` with Framer Motion pulse animation
- add `NeonRing` to position category buttons in polar coordinates with hover/tap animations
- add `HubCanvas` using `LayoutGroup` to dim inactive rings

## Testing
- `npx tsc -p hub/tsconfig.json --noEmit`
- `npx next lint` *(fails: no ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_687ab21097088320a88c7a45800f3f45