### PR TITLE
Add hub not-found pages

### DIFF
--- a/hub/app/hub/[category]/not-found.tsx
+++ b/hub/app/hub/[category]/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <h1 className="text-2xl font-bold mb-4">Category Not Found</h1>
+      <a href="/hub" className="text-blue-600 hover:underline">Go Back</a>
+    </div>
+  )
+}

--- a/hub/app/hub/[category]/page.tsx
+++ b/hub/app/hub/[category]/page.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getHubData } from '../../../lib/getHubData'
+
+export const dynamic = 'force-static'
+
+export default async function CategoryPage({ params }: { params: Promise<{ category: string }> }) {
+  const { category: slug } = await params
+  const categories = await getHubData()
+  const category = categories.find(cat => cat.slug === slug)
+  if (!category) return notFound()
+  return (
+    <div className="min-h-screen mx-auto max-w-3xl p-4">
+      <header className="mb-8">
+        <Link href="/hub" className="text-blue-600">&larr; Back</Link>
+        <h1 className="text-2xl font-bold mt-2">{category.name}</h1>
+      </header>
+      <ul className="grid gap-4 sm:grid-cols-2">
+        {category.links.map(link => (
+          <li key={link.url} className="bg-white rounded-lg shadow list-none">
+            <a href={link.url} className="block p-4 hover:underline">
+              {link.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export async function generateStaticParams() {
+  const categories = await getHubData()
+  return categories.map(cat => ({ category: cat.slug }))
+}

--- a/hub/app/hub/not-found.tsx
+++ b/hub/app/hub/not-found.tsx
@@ -1,0 +1,8 @@
+export default function HubNotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <h1 className="text-2xl font-bold mb-4">Not Found</h1>
+      <a href="/hub" className="text-blue-600 hover:underline">Return Home</a>
+    </div>
+  )
+}

--- a/hub/app/hub/page.tsx
+++ b/hub/app/hub/page.tsx
@@ -1,0 +1,13 @@
+import HubCanvas from '../../components/HubCanvas'
+import { getHubData } from '../../lib/getHubData'
+
+export const dynamic = 'force-static'
+
+export default async function HubPage() {
+  const categories = await getHubData()
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <HubCanvas categories={categories} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a global not-found page for hub
- add a category not-found page
- keep hub pages that render from `getHubData`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687ab4dc047483208f5c01bbda961904