### PR TITLE
Add neon theme animations

### DIFF
--- a/hub/components/CoreOrb.tsx
+++ b/hub/components/CoreOrb.tsx
@@ -12,10 +12,8 @@ export default function CoreOrb() {
   return (
     <motion.div
       aria-hidden
-      className="rounded-full bg-blue-500 shadow-2xl"
+      className="rounded-full bg-neon-blue glow pulse"
       style={{ width: CONFIG.size, height: CONFIG.size }}
-      animate={{ scale: [1, CONFIG.pulseScale, 1] }}
-      transition={{ duration: CONFIG.duration, repeat: Infinity }}
     />
   )
 }

--- a/hub/components/NeonRing.tsx
+++ b/hub/components/NeonRing.tsx
@@ -31,7 +31,7 @@ export default function NeonRing({
     <motion.button
       type="button"
       aria-label={category.name}
-      className="absolute rounded-full border-2 border-pink-500 text-white"
+      className="absolute rounded-full border-2 border-neon-pink text-neon-pink glow"
       style={{
         width: CONFIG.size,
         height: CONFIG.size,

--- a/hub/tailwind.config.js
+++ b/hub/tailwind.config.js
@@ -1,13 +1,59 @@
-/** @type {import('tailwindcss').Config} */
-const config = {
-  content: [
+/**
+ * Tailwind configuration for the hub
+ *
+ * Manual settings – adjust here if file locations or animation timings change
+ */
+const CONFIG = {
+  contentPaths: [
     './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
   ],
+  glowDuration: '1.8s',
+  pulseDuration: '1.6s'
+}
+
+const plugin = require('tailwindcss/plugin')
+
+/** @type {import('tailwindcss').Config} */
+const config = {
+  content: CONFIG.contentPaths,
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'neon-blue': '#18ffff',
+        'neon-pink': '#ff48fb'
+      },
+      keyframes: {
+        glow: {
+          '0%, 100%': {
+            boxShadow:
+              '0 0 4px currentColor, 0 0 8px currentColor, 0 0 12px currentColor'
+          },
+          '50%': {
+            boxShadow:
+              '0 0 8px currentColor, 0 0 16px currentColor, 0 0 24px currentColor'
+          }
+        },
+        pulse: {
+          '0%, 100%': { transform: 'scale(1)' },
+          '50%': { transform: 'scale(1.1)' }
+        }
+      },
+      animation: {
+        'neon-glow': `glow ${CONFIG.glowDuration} ease-in-out infinite`,
+        'neon-pulse': `pulse ${CONFIG.pulseDuration} ease-in-out infinite`
+      }
+    }
   },
-  plugins: [],
-};
-module.exports = config;
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        '.glow': { '@apply animate-neon-glow': {} },
+        '.pulse': { '@apply animate-neon-pulse': {} }
+      })
+    })
+  ]
+}
+
+module.exports = config


### PR DESCRIPTION
## Summary
- add neon glow/pulse colors and animations in `tailwind.config.js`
- create `.glow`/`.pulse` utilities via plugin
- update orb and ring components to use the new neon classes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687aba696a2c8320b56e9e6083c8b080