### PR TITLE
Improve ring accessibility and mobile layout

### DIFF
--- a/hub/components/HubCanvas.tsx
+++ b/hub/components/HubCanvas.tsx
@@ -19,7 +19,7 @@ export default function HubCanvas({ categories }: HubCanvasProps) {
 
   return (
     <motion.div
-      className="relative mx-auto"
+      className="mx-auto flex flex-col items-center gap-4 sm:relative sm:block min-w-[48px] min-h-[48px]"
       style={{ width: CONFIG.canvasSize, height: CONFIG.canvasSize }}
     >
       <LayoutGroup id="hub-rings">

--- a/hub/components/NeonRing.tsx
+++ b/hub/components/NeonRing.tsx
@@ -31,7 +31,7 @@ export default function NeonRing({
     <motion.button
       type="button"
       aria-label={category.name}
-      className="absolute rounded-full border-2 border-neon-pink text-neon-pink glow"
+      className="block sm:absolute rounded-full border-2 border-neon-pink text-neon-pink glow min-w-[48px] min-h-[48px]"
       style={{
         width: CONFIG.size,
         height: CONFIG.size,
@@ -41,7 +41,7 @@ export default function NeonRing({
       onHoverStart={() => setActive(index)}
       onHoverEnd={() => setActive(null)}
       whileHover={{ scale: 1.1 }}
-      whileTap={{ scale: 0.9 }}
+      whileTap={{ scale: 0.9, x: 16 }}
       animate={{ opacity: isDimmed ? 0.3 : 1 }}
       layoutId={`ring-${index}`}
     >


### PR DESCRIPTION
## Summary
- ensure clickable rings keep a 48px target size
- allow rings to stack on small screens
- slide rings a bit when tapped

## Testing
- `npm run lint` *(fails: requires ESLint setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687abc28ab0883209a9062e1babd1739