### PR TITLE
Add dynamic Hub stage with particle effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,12 @@ export const auth = getAuth(app);
 ```
 
 Import the `auth` instance in your React components wherever authentication is required.
+
+### How to add animation layers
+
+Animation layers are controlled by the `HubStage` component inside `hub/components`. Create new client components that render `OrbLayer` and update the `layerStack` when selected. New orb elements use the shared `popSpring` transition.
+
+Install particle dependencies with:
+```bash
+npm install react-tsparticles tsparticles-engine
+```

--- a/hub/README.md
+++ b/hub/README.md
@@ -30,3 +30,13 @@ npm run build
 ## Customization
 
 Hub data is normally assembled from markdown files under `../content/hub`. To load a static JSON file instead, set `useJsonHubData` in `next.config.ts` to `true`. The JSON configuration lives at `content/hubConfig.json` and uses the same `HubCategory[]` structure returned by `getHubData`.
+
+### How to add animation layers
+
+Animations use Framer Motion and Tailwind utilities. Add new layers by creating a client component that renders `OrbLayer` with your items and push its key onto the `layerStack` in `HubStage`. Each layer appears with the `popSpring` transition defined in `components/Orb.tsx`.
+
+To enable particle ambience run:
+```bash
+npm install react-tsparticles tsparticles-engine
+```
+This repository already includes those packages.

--- a/hub/app/globals.css
+++ b/hub/app/globals.css
@@ -24,3 +24,39 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@layer utilities {
+  .bg-gradient-radial {
+    background: radial-gradient(
+      circle at center,
+      #0c2038 0%,
+      #0a0f1a 60%,
+      #000 100%
+    );
+  }
+}
+
+@layer components {
+  .orb {
+    position: relative;
+    transform-style: preserve-3d;
+  }
+  .orb::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: 0 0 12px currentColor;
+    filter: blur(12px);
+    z-index: -1;
+  }
+  .orb::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    z-index: -1;
+    transform: translateZ(-1px);
+  }
+}

--- a/hub/app/page.tsx
+++ b/hub/app/page.tsx
@@ -1,17 +1,14 @@
-import HubCanvas from '../components/HubCanvas'
+import HubStage from '../components/HubStage'
+import HubDataClientProvider from '../lib/HubDataClientProvider'
 import { loadHubData } from '../lib/loadHubData'
 
 export const dynamic = 'force-static'
-export default async function Home() {
-  await loadHubData()
-  return (
-    <div className="min-h-screen flex items-center justify-center p-4">
-      <HubCanvas />
-    </div>
-  )
-}
 
-export async function generateStaticParams() {
+export default async function Home() {
   const categories = await loadHubData()
-  return categories.map(cat => ({ category: cat.slug }))
+  return (
+    <HubDataClientProvider categories={categories}>
+      <HubStage />
+    </HubDataClientProvider>
+  )
 }

--- a/hub/components/HubCanvas.tsx
+++ b/hub/components/HubCanvas.tsx
@@ -1,18 +1,17 @@
 'use client'
-import { useState } from 'react'
 import { LayoutGroup, motion, AnimatePresence } from 'framer-motion'
 import useHubData from '../lib/useHubData'
 import CoreOrb from './CoreOrb'
-import NeonRing from './NeonRing'
+import Orb from './Orb'
 
 // --- Configuration ------------------------------------------------------------
 const CONFIG = {
-  canvasSize: 300 // Square size of the canvas in pixels
+  canvasSize: 300, // Square size of the canvas in pixels
+  radius: 120 // distance from center to orb layer
 }
 
 export default function HubCanvas() {
   const categories = useHubData()
-  const [active, setActive] = useState<number | null>(null)
 
   return (
     <motion.div
@@ -23,13 +22,15 @@ export default function HubCanvas() {
         <CoreOrb />
         <AnimatePresence>
           {categories.map((cat, i) => (
-            <NeonRing
+            <Orb
               key={cat.slug}
-              category={cat}
-              index={i}
-              total={categories.length}
-              isDimmed={active !== null && active !== i}
-              setActive={setActive}
+              label={cat.name}
+              style={{
+                position: 'absolute',
+                left: `calc(50% + ${Math.cos((i / categories.length) * 2 * Math.PI) * CONFIG.radius}px)`,
+                top: `calc(50% + ${Math.sin((i / categories.length) * 2 * Math.PI) * CONFIG.radius}px)`
+              }}
+              onSelect={() => null}
             />
           ))}
         </AnimatePresence>

--- a/hub/components/HubStage.tsx
+++ b/hub/components/HubStage.tsx
@@ -1,0 +1,55 @@
+"use client"
+import { useState } from 'react'
+import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
+import useHubData from '../lib/useHubData'
+import OrbLayer from './OrbLayer'
+import Orb from './Orb'
+import ParticleField from './ParticleField'
+
+export default function HubStage() {
+  const categories = useHubData()
+  const [stack, setStack] = useState<string[]>(['hub'])
+
+  const current = stack[stack.length - 1]
+
+  const handleSelect = (key: string) => setStack([...stack, key])
+  const handleBack = () => setStack(stack.slice(0, -1))
+
+  let items: { key: string; label: string }[] = []
+  let title = 'Hub'
+
+  if (current === 'hub') {
+    items = categories.map(c => ({ key: c.slug, label: c.name }))
+  } else {
+    const cat = categories.find(c => c.slug === current)
+    if (cat) {
+      title = cat.name
+      items = cat.links.map(l => ({ key: l.url, label: l.title }))
+    }
+  }
+
+  return (
+    <div className="relative flex items-center justify-center h-screen bg-gradient-radial overflow-hidden">
+      <ParticleField />
+      <LayoutGroup>
+        <AnimatePresence>
+          {current !== 'hub' && (
+            <motion.button
+              key="back"
+              type="button"
+              onClick={handleBack}
+              className="absolute top-4 left-4 text-white/80"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+            >
+              &larr; Back
+            </motion.button>
+          )}
+        </AnimatePresence>
+        <Orb key={title} size="lg" label={title} />
+        <OrbLayer items={items} radius={150} onSelect={handleSelect} />
+      </LayoutGroup>
+    </div>
+  )
+}

--- a/hub/components/Orb.tsx
+++ b/hub/components/Orb.tsx
@@ -1,0 +1,41 @@
+"use client"
+import { motion } from 'framer-motion'
+import type { Transition } from 'framer-motion'
+import type { CSSProperties } from 'react'
+
+// --- Configuration -----------------------------------------------------------
+const CONFIG = {
+  sizes: { sm: 40, md: 64, lg: 96 }
+}
+
+export const popSpring: Transition = {
+  type: 'spring',
+  mass: 0.7,
+  stiffness: 180,
+  damping: 20
+}
+
+export interface OrbProps {
+  label: string
+  size?: keyof typeof CONFIG.sizes
+  onSelect?: () => void
+  style?: CSSProperties
+}
+
+export default function Orb({ label, size = 'md', onSelect, style }: OrbProps) {
+  const dim = CONFIG.sizes[size]
+  return (
+    <motion.button
+      type="button"
+      aria-label={label}
+      onClick={onSelect}
+      className="orb flex items-center justify-center rounded-full text-white bg-neonPink glow"
+      style={{ width: dim, height: dim, ...style }}
+      whileHover={{ scale: 1.15 }}
+      whileTap={{ scale: 0.95 }}
+      transition={popSpring}
+    >
+      {label}
+    </motion.button>
+  )
+}

--- a/hub/components/OrbLayer.tsx
+++ b/hub/components/OrbLayer.tsx
@@ -1,0 +1,34 @@
+"use client"
+import { AnimatePresence } from 'framer-motion'
+import Orb from './Orb'
+
+export interface OrbItem {
+  key: string
+  label: string
+}
+
+export interface OrbLayerProps {
+  items: OrbItem[]
+  radius: number
+  onSelect: (key: string) => void
+}
+
+export default function OrbLayer({ items, radius, onSelect }: OrbLayerProps) {
+  return (
+    <AnimatePresence>
+      {items.map((item, i) => {
+        const theta = (i / items.length) * 2 * Math.PI
+        const x = Math.cos(theta) * radius
+        const y = Math.sin(theta) * radius
+        return (
+          <Orb
+            key={item.key}
+            label={item.label}
+            style={{ position: 'absolute', left: `calc(50% + ${x}px)`, top: `calc(50% + ${y}px)` }}
+            onSelect={() => onSelect(item.key)}
+          />
+        )
+      })}
+    </AnimatePresence>
+  )
+}

--- a/hub/components/ParticleField.tsx
+++ b/hub/components/ParticleField.tsx
@@ -1,0 +1,34 @@
+"use client"
+import { useCallback } from 'react'
+import Particles from 'react-tsparticles'
+import type { Engine } from 'tsparticles-engine'
+import { loadSlim } from 'tsparticles-slim'
+
+// --- Configuration -----------------------------------------------------------
+const CONFIG = {
+  count: 30 // number of particles
+}
+
+export default function ParticleField() {
+  const init = useCallback(async (engine: Engine) => {
+    await loadSlim(engine)
+  }, [])
+
+  return (
+    <Particles
+      id="particle-field"
+      init={init}
+      className="absolute inset-0 -z-10"
+      options={{
+        fullScreen: false,
+        particles: {
+          number: { value: CONFIG.count },
+          opacity: { value: 0.3 },
+          size: { value: { min: 1, max: 3 } },
+          color: { value: '#fff' },
+          move: { enable: true, speed: 0.2 }
+        }
+      }}
+    />
+  )
+}

--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -12,7 +12,10 @@
         "gray-matter": "^4.0.3",
         "next": "15.4.1",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "react-tsparticles": "^2.12.2",
+        "tsparticles-engine": "^2.12.0",
+        "tsparticles-slim": "^2.12.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.11",
@@ -4578,6 +4581,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-tsparticles": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/react-tsparticles/-/react-tsparticles-2.12.2.tgz",
+      "integrity": "sha512-/nrEbyL8UROXKIMXe+f+LZN2ckvkwV2Qa+GGe/H26oEIc+wq/ybSG9REDwQiSt2OaDQGu0MwmA4BKmkL6wAWcA==",
+      "deprecated": "@tsparticles/react is the new version, please use that",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5237,6 +5268,452 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsparticles-basic": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-basic/-/tsparticles-basic-2.12.0.tgz",
+      "integrity": "sha512-pN6FBpL0UsIUXjYbiui5+IVsbIItbQGOlwyGV55g6IYJBgdTNXgFX0HRYZGE9ZZ9psEXqzqwLM37zvWnb5AG9g==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0",
+        "tsparticles-move-base": "^2.12.0",
+        "tsparticles-shape-circle": "^2.12.0",
+        "tsparticles-updater-color": "^2.12.0",
+        "tsparticles-updater-opacity": "^2.12.0",
+        "tsparticles-updater-out-modes": "^2.12.0",
+        "tsparticles-updater-size": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-engine": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-engine/-/tsparticles-engine-2.12.0.tgz",
+      "integrity": "sha512-ZjDIYex6jBJ4iMc9+z0uPe7SgBnmb6l+EJm83MPIsOny9lPpetMsnw/8YJ3xdxn8hV+S3myTpTN1CkOVmFv0QQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
+    "node_modules/tsparticles-interaction-external-attract": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-attract/-/tsparticles-interaction-external-attract-2.12.0.tgz",
+      "integrity": "sha512-0roC6D1QkFqMVomcMlTaBrNVjVOpyNzxIUsjMfshk2wUZDAvTNTuWQdUpmsLS4EeSTDN3rzlGNnIuuUQqyBU5w==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-bounce": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bounce/-/tsparticles-interaction-external-bounce-2.12.0.tgz",
+      "integrity": "sha512-MMcqKLnQMJ30hubORtdq+4QMldQ3+gJu0bBYsQr9BsThsh8/V0xHc1iokZobqHYVP5tV77mbFBD8Z7iSCf0TMQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-bubble": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bubble/-/tsparticles-interaction-external-bubble-2.12.0.tgz",
+      "integrity": "sha512-5kImCSCZlLNccXOHPIi2Yn+rQWTX3sEa/xCHwXW19uHxtILVJlnAweayc8+Zgmb7mo0DscBtWVFXHPxrVPFDUA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-connect": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-connect/-/tsparticles-interaction-external-connect-2.12.0.tgz",
+      "integrity": "sha512-ymzmFPXz6AaA1LAOL5Ihuy7YSQEW8MzuSJzbd0ES13U8XjiU3HlFqlH6WGT1KvXNw6WYoqrZt0T3fKxBW3/C3A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-grab": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-grab/-/tsparticles-interaction-external-grab-2.12.0.tgz",
+      "integrity": "sha512-iQF/A947hSfDNqAjr49PRjyQaeRkYgTYpfNmAf+EfME8RsbapeP/BSyF6mTy0UAFC0hK2A2Hwgw72eT78yhXeQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-pause": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-pause/-/tsparticles-interaction-external-pause-2.12.0.tgz",
+      "integrity": "sha512-4SUikNpsFROHnRqniL+uX2E388YTtfRWqqqZxRhY0BrijH4z04Aii3YqaGhJxfrwDKkTQlIoM2GbFT552QZWjw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-push": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-push/-/tsparticles-interaction-external-push-2.12.0.tgz",
+      "integrity": "sha512-kqs3V0dgDKgMoeqbdg+cKH2F+DTrvfCMrPF1MCCUpBCqBiH+TRQpJNNC86EZYHfNUeeLuIM3ttWwIkk2hllR/Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-remove": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-remove/-/tsparticles-interaction-external-remove-2.12.0.tgz",
+      "integrity": "sha512-2eNIrv4m1WB2VfSVj46V2L/J9hNEZnMgFc+A+qmy66C8KzDN1G8aJUAf1inW8JVc0lmo5+WKhzex4X0ZSMghBg==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-repulse": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-repulse/-/tsparticles-interaction-external-repulse-2.12.0.tgz",
+      "integrity": "sha512-rSzdnmgljeBCj5FPp4AtGxOG9TmTsK3AjQW0vlyd1aG2O5kSqFjR+FuT7rfdSk9LEJGH5SjPFE6cwbuy51uEWA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-slow": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-slow/-/tsparticles-interaction-external-slow-2.12.0.tgz",
+      "integrity": "sha512-2IKdMC3om7DttqyroMtO//xNdF0NvJL/Lx7LDo08VpfTgJJozxU+JAUT8XVT7urxhaDzbxSSIROc79epESROtA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-attract": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-attract/-/tsparticles-interaction-particles-attract-2.12.0.tgz",
+      "integrity": "sha512-Hl8qwuwF9aLq3FOkAW+Zomu7Gb8IKs6Y3tFQUQScDmrrSCaeRt2EGklAiwgxwgntmqzL7hbMWNx06CHHcUQKdQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-collisions": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-collisions/-/tsparticles-interaction-particles-collisions-2.12.0.tgz",
+      "integrity": "sha512-Se9nPWlyPxdsnHgR6ap4YUImAu3W5MeGKJaQMiQpm1vW8lSMOUejI1n1ioIaQth9weKGKnD9rvcNn76sFlzGBA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-links": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-links/-/tsparticles-interaction-particles-links-2.12.0.tgz",
+      "integrity": "sha512-e7I8gRs4rmKfcsHONXMkJnymRWpxHmeaJIo4g2NaDRjIgeb2AcJSWKWZvrsoLnm7zvaf/cMQlbN6vQwCixYq3A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-move-base": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-move-base/-/tsparticles-move-base-2.12.0.tgz",
+      "integrity": "sha512-oSogCDougIImq+iRtIFJD0YFArlorSi8IW3HD2gO3USkH+aNn3ZqZNTqp321uB08K34HpS263DTbhLHa/D6BWw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-move-parallax": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-move-parallax/-/tsparticles-move-parallax-2.12.0.tgz",
+      "integrity": "sha512-58CYXaX8Ih5rNtYhpnH0YwU4Ks7gVZMREGUJtmjhuYN+OFr9FVdF3oDIJ9N6gY5a5AnAKz8f5j5qpucoPRcYrQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-particles.js": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-particles.js/-/tsparticles-particles.js-2.12.0.tgz",
+      "integrity": "sha512-LyOuvYdhbUScmA4iDgV3LxA0HzY1DnOwQUy3NrPYO393S2YwdDjdwMod6Btq7EBUjg9FVIh+sZRizgV5elV2dg==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-plugin-easing-quad": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-plugin-easing-quad/-/tsparticles-plugin-easing-quad-2.12.0.tgz",
+      "integrity": "sha512-2mNqez5pydDewMIUWaUhY5cNQ80IUOYiujwG6qx9spTq1D6EEPLbRNAEL8/ecPdn2j1Um3iWSx6lo340rPkv4Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-circle": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-circle/-/tsparticles-shape-circle-2.12.0.tgz",
+      "integrity": "sha512-L6OngbAlbadG7b783x16ns3+SZ7i0SSB66M8xGa5/k+YcY7zm8zG0uPt1Hd+xQDR2aNA3RngVM10O23/Lwk65Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-image": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-image/-/tsparticles-shape-image-2.12.0.tgz",
+      "integrity": "sha512-iCkSdUVa40DxhkkYjYuYHr9MJGVw+QnQuN5UC+e/yBgJQY+1tQL8UH0+YU/h0GHTzh5Sm+y+g51gOFxHt1dj7Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-line": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-line/-/tsparticles-shape-line-2.12.0.tgz",
+      "integrity": "sha512-RcpKmmpKlk+R8mM5wA2v64Lv1jvXtU4SrBDv3vbdRodKbKaWGGzymzav1Q0hYyDyUZgplEK/a5ZwrfrOwmgYGA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-polygon": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-polygon/-/tsparticles-shape-polygon-2.12.0.tgz",
+      "integrity": "sha512-5YEy7HVMt1Obxd/jnlsjajchAlYMr9eRZWN+lSjcFSH6Ibra7h59YuJVnwxOxAobpijGxsNiBX0PuGQnB47pmA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-square": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-square/-/tsparticles-shape-square-2.12.0.tgz",
+      "integrity": "sha512-33vfajHqmlODKaUzyPI/aVhnAOT09V7nfEPNl8DD0cfiNikEuPkbFqgJezJuE55ebtVo7BZPDA9o7GYbWxQNuw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-star": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-star/-/tsparticles-shape-star-2.12.0.tgz",
+      "integrity": "sha512-4sfG/BBqm2qBnPLASl2L5aBfCx86cmZLXeh49Un+TIR1F5Qh4XUFsahgVOG0vkZQa+rOsZPEH04xY5feWmj90g==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-text": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-text/-/tsparticles-shape-text-2.12.0.tgz",
+      "integrity": "sha512-v2/FCA+hyTbDqp2ymFOe97h/NFb2eezECMrdirHWew3E3qlvj9S/xBibjbpZva2gnXcasBwxn0+LxKbgGdP0rA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-slim": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-slim/-/tsparticles-slim-2.12.0.tgz",
+      "integrity": "sha512-27w9aGAAAPKHvP4LHzWFpyqu7wKyulayyaZ/L6Tuuejy4KP4BBEB4rY5GG91yvAPsLtr6rwWAn3yS+uxnBDpkA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-basic": "^2.12.0",
+        "tsparticles-engine": "^2.12.0",
+        "tsparticles-interaction-external-attract": "^2.12.0",
+        "tsparticles-interaction-external-bounce": "^2.12.0",
+        "tsparticles-interaction-external-bubble": "^2.12.0",
+        "tsparticles-interaction-external-connect": "^2.12.0",
+        "tsparticles-interaction-external-grab": "^2.12.0",
+        "tsparticles-interaction-external-pause": "^2.12.0",
+        "tsparticles-interaction-external-push": "^2.12.0",
+        "tsparticles-interaction-external-remove": "^2.12.0",
+        "tsparticles-interaction-external-repulse": "^2.12.0",
+        "tsparticles-interaction-external-slow": "^2.12.0",
+        "tsparticles-interaction-particles-attract": "^2.12.0",
+        "tsparticles-interaction-particles-collisions": "^2.12.0",
+        "tsparticles-interaction-particles-links": "^2.12.0",
+        "tsparticles-move-base": "^2.12.0",
+        "tsparticles-move-parallax": "^2.12.0",
+        "tsparticles-particles.js": "^2.12.0",
+        "tsparticles-plugin-easing-quad": "^2.12.0",
+        "tsparticles-shape-circle": "^2.12.0",
+        "tsparticles-shape-image": "^2.12.0",
+        "tsparticles-shape-line": "^2.12.0",
+        "tsparticles-shape-polygon": "^2.12.0",
+        "tsparticles-shape-square": "^2.12.0",
+        "tsparticles-shape-star": "^2.12.0",
+        "tsparticles-shape-text": "^2.12.0",
+        "tsparticles-updater-color": "^2.12.0",
+        "tsparticles-updater-life": "^2.12.0",
+        "tsparticles-updater-opacity": "^2.12.0",
+        "tsparticles-updater-out-modes": "^2.12.0",
+        "tsparticles-updater-rotate": "^2.12.0",
+        "tsparticles-updater-size": "^2.12.0",
+        "tsparticles-updater-stroke-color": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-color": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-color/-/tsparticles-updater-color-2.12.0.tgz",
+      "integrity": "sha512-KcG3a8zd0f8CTiOrylXGChBrjhKcchvDJjx9sp5qpwQK61JlNojNCU35xoaSk2eEHeOvFjh0o3CXWUmYPUcBTQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-life": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-life/-/tsparticles-updater-life-2.12.0.tgz",
+      "integrity": "sha512-J7RWGHAZkowBHpcLpmjKsxwnZZJ94oGEL2w+wvW1/+ZLmAiFFF6UgU0rHMC5CbHJT4IPx9cbkYMEHsBkcRJ0Bw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-opacity": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-opacity/-/tsparticles-updater-opacity-2.12.0.tgz",
+      "integrity": "sha512-YUjMsgHdaYi4HN89LLogboYcCi1o9VGo21upoqxq19yRy0hRCtx2NhH22iHF/i5WrX6jqshN0iuiiNefC53CsA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-out-modes": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-out-modes/-/tsparticles-updater-out-modes-2.12.0.tgz",
+      "integrity": "sha512-owBp4Gk0JNlSrmp12XVEeBroDhLZU+Uq3szbWlHGSfcR88W4c/0bt0FiH5bHUqORIkw+m8O56hCjbqwj69kpOQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-rotate": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-rotate/-/tsparticles-updater-rotate-2.12.0.tgz",
+      "integrity": "sha512-waOFlGFmEZOzsQg4C4VSejNVXGf4dMf3fsnQrEROASGf1FCd8B6WcZau7JtXSTFw0OUGuk8UGz36ETWN72DkCw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-size": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-size/-/tsparticles-updater-size-2.12.0.tgz",
+      "integrity": "sha512-B0yRdEDd/qZXCGDL/ussHfx5YJ9UhTqNvmS5X2rR2hiZhBAE2fmsXLeWkdtF2QusjPeEqFDxrkGiLOsh6poqRA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-stroke-color": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-stroke-color/-/tsparticles-updater-stroke-color-2.12.0.tgz",
+      "integrity": "sha512-MPou1ZDxsuVq6SN1fbX+aI5yrs6FyP2iPCqqttpNbWyL+R6fik1rL0ab/x02B57liDXqGKYomIbBQVP3zUTW1A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/hub/package.json
+++ b/hub/package.json
@@ -13,7 +13,10 @@
     "gray-matter": "^4.0.3",
     "next": "15.4.1",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-tsparticles": "^2.12.2",
+    "tsparticles-engine": "^2.12.0",
+    "tsparticles-slim": "^2.12.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/hub/tailwind.config.ts
+++ b/hub/tailwind.config.ts
@@ -3,6 +3,9 @@
  *
  * Manual settings – adjust here if file locations or animation timings change
  */
+import type { Config } from 'tailwindcss'
+import plugin from 'tailwindcss/plugin'
+
 const CONFIG = {
   contentPaths: [
     './app/**/*.{js,ts,jsx,tsx}',
@@ -13,16 +16,13 @@ const CONFIG = {
   pulseDuration: '1.6s'
 }
 
-const plugin = require('tailwindcss/plugin')
-
-/** @type {import('tailwindcss').Config} */
-const config = {
+const config: Config = {
   content: CONFIG.contentPaths,
   theme: {
     extend: {
       colors: {
-        'neon-blue': '#18ffff',
-        'neon-pink': '#ff48fb'
+        neonBlue: '#18ffff',
+        neonPink: '#ff48fb'
       },
       keyframes: {
         glow: {
@@ -38,11 +38,16 @@ const config = {
         pulse: {
           '0%, 100%': { transform: 'scale(1)' },
           '50%': { transform: 'scale(1.1)' }
+        },
+        orbPulse: {
+          '0%, 100%': { transform: 'scale(1)' },
+          '50%': { transform: 'scale(1.05)' }
         }
       },
       animation: {
         'neon-glow': `glow ${CONFIG.glowDuration} ease-in-out infinite`,
-        'neon-pulse': `pulse ${CONFIG.pulseDuration} ease-in-out infinite`
+        'neon-pulse': `pulse ${CONFIG.pulseDuration} ease-in-out infinite`,
+        'orb-pulse': 'orbPulse 2s ease-in-out infinite'
       }
     }
   },
@@ -50,10 +55,14 @@ const config = {
     plugin(function ({ addUtilities }) {
       addUtilities({
         '.glow': { '@apply animate-neon-glow': {} },
-        '.pulse': { '@apply animate-neon-pulse': {} }
+        '.pulse': { '@apply animate-neon-pulse': {} },
+        '.bg-gradient-radial': {
+          background:
+            'radial-gradient(circle at center, #0c2038 0%, #0a0f1a 60%, #000 100%)'
+        }
       })
     })
   ]
 }
 
-module.exports = config
+export default config


### PR DESCRIPTION
## Summary
- switch Tailwind config to TypeScript and extend colors/animations
- add radial gradient and orb utilities in global CSS
- create Orb, OrbLayer, ParticleField, and HubStage components
- update hub landing to use HubStage
- document animation layers and particle dependencies

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687ae07e30a08320af9e737d6a4727fd