### PR TITLE
Implement neon orb hub stage

### DIFF
--- a/hub/app/hub/page.tsx
+++ b/hub/app/hub/page.tsx
@@ -1,0 +1,15 @@
+import ParticleField from '../../components/ParticleField'
+import HubStage from '../../components/HubStage'
+import { getHubData } from '../../lib/getHubData'
+
+export const dynamic = 'force-static'
+
+export default async function HubPage() {
+  const categories = await getHubData()
+  return (
+    <div className="relative h-screen bg-gradient-radial overflow-hidden">
+      <ParticleField />
+      <HubStage initialData={categories} />
+    </div>
+  )
+}

--- a/hub/app/page.tsx
+++ b/hub/app/page.tsx
@@ -1,14 +1,7 @@
-import HubStage from '../components/HubStage'
-import HubDataClientProvider from '../lib/HubDataClientProvider'
-import { loadHubData } from '../lib/loadHubData'
+import { redirect } from 'next/navigation'
 
 export const dynamic = 'force-static'
 
-export default async function Home() {
-  const categories = await loadHubData()
-  return (
-    <HubDataClientProvider categories={categories}>
-      <HubStage />
-    </HubDataClientProvider>
-  )
+export default function Home() {
+  redirect('/hub')
 }

--- a/hub/components/HubCanvas.tsx
+++ b/hub/components/HubCanvas.tsx
@@ -2,7 +2,7 @@
 import { LayoutGroup, motion, AnimatePresence } from 'framer-motion'
 import useHubData from '../lib/useHubData'
 import CoreOrb from './CoreOrb'
-import Orb from './Orb'
+import { Orb } from './Orb'
 
 // --- Configuration ------------------------------------------------------------
 const CONFIG = {
@@ -25,6 +25,7 @@ export default function HubCanvas() {
             <Orb
               key={cat.slug}
               label={cat.name}
+              kind="folder"
               style={{
                 position: 'absolute',
                 left: `calc(50% + ${Math.cos((i / categories.length) * 2 * Math.PI) * CONFIG.radius}px)`,

--- a/hub/components/Orb.tsx
+++ b/hub/components/Orb.tsx
@@ -1,39 +1,19 @@
 "use client"
-import { motion } from 'framer-motion'
-import type { Transition } from 'framer-motion'
-import type { CSSProperties } from 'react'
+import { motion } from "framer-motion"
 
-// --- Configuration -----------------------------------------------------------
-const CONFIG = {
-  sizes: { sm: 40, md: 64, lg: 96 }
-}
+type Kind = "folder" | "link"
 
-export const popSpring: Transition = {
-  type: 'spring',
-  mass: 0.7,
-  stiffness: 180,
-  damping: 20
-}
-
-export interface OrbProps {
-  label: string
-  size?: keyof typeof CONFIG.sizes
-  onSelect?: () => void
-  style?: CSSProperties
-}
-
-export default function Orb({ label, size = 'md', onSelect, style }: OrbProps) {
-  const dim = CONFIG.sizes[size]
+export function Orb({ label, kind, onSelect, layoutId, style }: { label: string; kind: Kind; onSelect: () => void; layoutId?: string; style?: React.CSSProperties }) {
+  const base = kind === "link" ? "rounded-xl" : "rounded-full"
   return (
     <motion.button
-      type="button"
+      layoutId={layoutId}
+      style={style}
       aria-label={label}
-      onClick={onSelect}
-      className="orb flex items-center justify-center rounded-full text-white bg-neonPink glow"
-      style={{ width: dim, height: dim, ...style }}
+      className={`${base} w-16 h-16 sm:w-20 sm:h-20 flex items-center justify-center font-medium text-neonBlue shadow-[0_0_8px_3px_theme(colors.neonBlue/0.7)] relative before:absolute before:inset-0 before:rounded-inherit before:blur-lg before:bg-neonBlue/60`}
       whileHover={{ scale: 1.15 }}
       whileTap={{ scale: 0.95 }}
-      transition={popSpring}
+      onClick={onSelect}
     >
       {label}
     </motion.button>

--- a/hub/components/OrbLayer.tsx
+++ b/hub/components/OrbLayer.tsx
@@ -1,19 +1,24 @@
 "use client"
-import { AnimatePresence } from 'framer-motion'
-import Orb from './Orb'
+import { AnimatePresence, motion } from "framer-motion"
+import { Orb } from "./Orb"
 
 export interface OrbItem {
-  key: string
+  id: string
   label: string
+  kind: "folder" | "link"
 }
 
-export interface OrbLayerProps {
+export function OrbLayer({
+  items,
+  radius,
+  onSelect,
+  dimmedIndex
+}: {
   items: OrbItem[]
   radius: number
-  onSelect: (key: string) => void
-}
-
-export default function OrbLayer({ items, radius, onSelect }: OrbLayerProps) {
+  onSelect: (item: OrbItem) => void
+  dimmedIndex?: number | null
+}) {
   return (
     <AnimatePresence>
       {items.map((item, i) => {
@@ -21,12 +26,16 @@ export default function OrbLayer({ items, radius, onSelect }: OrbLayerProps) {
         const x = Math.cos(theta) * radius
         const y = Math.sin(theta) * radius
         return (
-          <Orb
-            key={item.key}
-            label={item.label}
-            style={{ position: 'absolute', left: `calc(50% + ${x}px)`, top: `calc(50% + ${y}px)` }}
-            onSelect={() => onSelect(item.key)}
-          />
+          <motion.div
+            key={item.id}
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: dimmedIndex === undefined || dimmedIndex === i ? 1 : 0.2 }}
+            exit={{ scale: 0, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 260, damping: 20 }}
+            style={{ position: "absolute", left: `calc(50% + ${x}px)`, top: `calc(50% + ${y}px)` }}
+          >
+            <Orb label={item.label} kind={item.kind} onSelect={() => onSelect(item)} />
+          </motion.div>
         )
       })}
     </AnimatePresence>

--- a/hub/components/ParticleField.tsx
+++ b/hub/components/ParticleField.tsx
@@ -6,7 +6,7 @@ import { loadSlim } from 'tsparticles-slim'
 
 // --- Configuration -----------------------------------------------------------
 const CONFIG = {
-  count: 30 // number of particles
+  count: 25 // number of particles
 }
 
 export default function ParticleField() {

--- a/hub/tailwind.config.ts
+++ b/hub/tailwind.config.ts
@@ -21,7 +21,8 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        neonBlue: '#18ffff',
+        neonBlue: '#3ab4ff',
+        neonBlueDark: '#1577ff',
         neonPink: '#ff48fb'
       },
       keyframes: {
@@ -40,8 +41,9 @@ const config: Config = {
           '50%': { transform: 'scale(1.1)' }
         },
         orbPulse: {
-          '0%, 100%': { transform: 'scale(1)' },
-          '50%': { transform: 'scale(1.05)' }
+          '0%': { opacity: 0.9 },
+          '50%': { opacity: 1 },
+          '100%': { opacity: 0.9 }
         }
       },
       animation: {
@@ -58,7 +60,7 @@ const config: Config = {
         '.pulse': { '@apply animate-neon-pulse': {} },
         '.bg-gradient-radial': {
           background:
-            'radial-gradient(circle at center, #0c2038 0%, #0a0f1a 60%, #000 100%)'
+            'radial-gradient(circle at center, #1e293b 0%, #0f172a 60%, #000 100%)'
         }
       })
     })


### PR DESCRIPTION
## Summary
- update Tailwind theme for neon blue styles
- add simpler particle field
- replace NeonRing with Orb
- show folders & links with OrbLayer
- rewrite HubStage to animate between layers
- adjust routing with `/hub` page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687ae5bb3ea88320ae512191e2ed721b