### PR TITLE
Enable Orb links

### DIFF
--- a/hub/components/HubStage.tsx
+++ b/hub/components/HubStage.tsx
@@ -20,12 +20,12 @@ export default function HubStage({ initialData }: { initialData: HubCategory[] }
     }
     const cat = categories.find(c => c.slug === key)
     if (!cat) return []
-    return cat.links.map(l => ({ id: l.url, label: l.title, kind: "link" as const }))
+    return cat.links.map(l => ({ id: l.url, label: l.title, kind: "link" as const, url: l.url }))
   }
 
   function handleSelect(item: OrbItem) {
     if (item.kind === "link") {
-      router.push(item.id)
+      router.push(item.url ?? item.id)
       return
     }
     setAnimatingTo(item.id)

--- a/hub/components/Orb.tsx
+++ b/hub/components/Orb.tsx
@@ -3,18 +3,48 @@ import { motion } from "framer-motion"
 
 type Kind = "folder" | "link"
 
-export function Orb({ label, kind, onSelect, layoutId, style }: { label: string; kind: Kind; onSelect: () => void; layoutId?: string; style?: React.CSSProperties }) {
+export function Orb({
+  label,
+  kind,
+  onSelect,
+  layoutId,
+  style,
+  url
+}: {
+  label: string
+  kind: Kind
+  onSelect: () => void
+  layoutId?: string
+  style?: React.CSSProperties
+  url?: string
+}) {
   const base = kind === "link" ? "rounded-xl" : "rounded-full"
+  const commonProps = {
+    layoutId,
+    style,
+    "aria-label": label,
+    className: `${base} w-16 h-16 sm:w-20 sm:h-20 flex items-center justify-center font-medium text-neonBlue shadow-[0_0_8px_3px_theme(colors.neonBlue/0.7)] relative before:absolute before:inset-0 before:rounded-inherit before:blur-lg before:bg-neonBlue/60`,
+    whileHover: { scale: 1.15 },
+    whileTap: { scale: 0.95 }
+  }
+
+  if (kind === "link") {
+    return (
+      <motion.a
+        {...commonProps}
+        href={url}
+        onClick={e => {
+          e.preventDefault()
+          onSelect()
+        }}
+      >
+        {label}
+      </motion.a>
+    )
+  }
+
   return (
-    <motion.button
-      layoutId={layoutId}
-      style={style}
-      aria-label={label}
-      className={`${base} w-16 h-16 sm:w-20 sm:h-20 flex items-center justify-center font-medium text-neonBlue shadow-[0_0_8px_3px_theme(colors.neonBlue/0.7)] relative before:absolute before:inset-0 before:rounded-inherit before:blur-lg before:bg-neonBlue/60`}
-      whileHover={{ scale: 1.15 }}
-      whileTap={{ scale: 0.95 }}
-      onClick={onSelect}
-    >
+    <motion.button {...commonProps} onClick={onSelect}>
       {label}
     </motion.button>
   )

--- a/hub/components/OrbLayer.tsx
+++ b/hub/components/OrbLayer.tsx
@@ -6,6 +6,7 @@ export interface OrbItem {
   id: string
   label: string
   kind: "folder" | "link"
+  url?: string
 }
 
 export function OrbLayer({
@@ -39,6 +40,7 @@ export function OrbLayer({
               kind={item.kind}
               onSelect={() => onSelect(item)}
               layoutId={item.id}
+              url={item.url}
             />
           </motion.div>
         )


### PR DESCRIPTION
## Summary
- support link type orbs and pass URLs to them
- update orb layer and hub stage to provide link URLs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687c3a5da0b083209374f2ef80d2c90a