### PR TITLE
Respect reduced motion in hub

### DIFF
--- a/hub/components/HubStage.tsx
+++ b/hub/components/HubStage.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState, useRef, useEffect } from "react"
-import { AnimatePresence, LayoutGroup, motion } from "framer-motion"
+import { AnimatePresence, LayoutGroup, motion, useReducedMotion } from "framer-motion"
 import { useRouter } from "next/navigation"
 import type { HubCategory } from "../lib/getHubData"
 import { OrbLayer, OrbItem } from "./OrbLayer"
@@ -12,6 +12,7 @@ export default function HubStage({ initialData }: { initialData: HubCategory[] }
   const [animatingTo, setAnimatingTo] = useState<string | null>(null)
   const backButtonRef = useRef<HTMLButtonElement | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const prefersReducedMotion = useReducedMotion()
 
   useEffect(() => {
     if (layerStack.length > 1) {
@@ -70,6 +71,7 @@ export default function HubStage({ initialData }: { initialData: HubCategory[] }
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
+            transition={prefersReducedMotion ? { duration: 0.2 } : undefined}
           >
             ← Back
           </motion.button>
@@ -78,6 +80,10 @@ export default function HubStage({ initialData }: { initialData: HubCategory[] }
           key={currentKey}
           className="absolute inset-0 flex items-center justify-center"
           onAnimationComplete={handleAnimationComplete}
+          initial={prefersReducedMotion ? { opacity: 0, scale: 0.95 } : undefined}
+          animate={prefersReducedMotion ? { opacity: 1, scale: 1 } : undefined}
+          exit={prefersReducedMotion ? { opacity: 0, scale: 0.95 } : undefined}
+          transition={prefersReducedMotion ? { duration: 0.2 } : undefined}
         >
           <Orb
             label={activeLabel}

--- a/hub/components/Orb.tsx
+++ b/hub/components/Orb.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { motion } from "framer-motion"
+import { motion, useReducedMotion } from "framer-motion"
 
 type Kind = "folder" | "link"
 
@@ -18,14 +18,16 @@ export function Orb({
   style?: React.CSSProperties
   url?: string
 }) {
+  const prefersReducedMotion = useReducedMotion()
   const base = kind === "link" ? "rounded-xl" : "rounded-full"
   const commonProps = {
     layoutId,
     style,
     "aria-label": label,
     className: `${base} w-16 h-16 sm:w-20 sm:h-20 flex items-center justify-center font-medium text-neonBlue shadow-[0_0_8px_3px_theme(colors.neonBlue/0.7)] relative before:absolute before:inset-0 before:rounded-inherit before:blur-lg before:bg-neonBlue/60`,
-    whileHover: { scale: 1.15 },
-    whileTap: { scale: 0.95 }
+    whileHover: prefersReducedMotion ? { opacity: 0.8 } : { scale: 1.15 },
+    whileTap: prefersReducedMotion ? { opacity: 0.6 } : { scale: 0.95 },
+    transition: prefersReducedMotion ? { duration: 0.2 } : undefined
   }
 
   if (kind === "link") {

--- a/hub/components/OrbLayer.tsx
+++ b/hub/components/OrbLayer.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
 import { Orb } from "./Orb"
 
 export interface OrbItem {
@@ -20,6 +20,7 @@ export function OrbLayer({
   onSelect: (item: OrbItem) => void
   dimmedIndex?: number | null
 }) {
+  const prefersReducedMotion = useReducedMotion()
   return (
     <AnimatePresence>
       {items.map((item, i) => {
@@ -32,7 +33,11 @@ export function OrbLayer({
             initial={{ scale: 0, opacity: 0 }}
             animate={{ scale: 1, opacity: dimmedIndex === undefined || dimmedIndex === i ? 1 : 0.2 }}
             exit={{ scale: 0, opacity: 0 }}
-            transition={{ type: "spring", stiffness: 260, damping: 20 }}
+            transition={
+              prefersReducedMotion
+                ? { duration: 0.2 }
+                : { type: "spring", stiffness: 260, damping: 20 }
+            }
             style={{ position: "absolute", left: `calc(50% + ${x}px)`, top: `calc(50% + ${y}px)` }}
           >
             <Orb


### PR DESCRIPTION
## Summary
- implement `useReducedMotion` support in `Orb`
- use reduced motion hook in `OrbLayer`
- add reduced motion handling in `HubStage`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687c3ec3f49483209e8ff3aafb13e924