### PR TITLE
Remove duplicate radial gradient utility

### DIFF
--- a/hub/tailwind.config.ts
+++ b/hub/tailwind.config.ts
@@ -57,11 +57,7 @@ const config: Config = {
     plugin(function ({ addUtilities }) {
       addUtilities({
         '.glow': { '@apply animate-neon-glow': {} },
-        '.pulse': { '@apply animate-neon-pulse': {} },
-        '.bg-gradient-radial': {
-          background:
-            'radial-gradient(circle at center, #1e293b 0%, #0f172a 60%, #000 100%)'
-        }
+        '.pulse': { '@apply animate-neon-pulse': {} }
       })
     })
   ]


### PR DESCRIPTION
## Summary
- delete extra `.bg-gradient-radial` class from Tailwind config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687c402037c083208b6b55e77c6e08ac