### PR TITLE
Add interface for category route params

### DIFF
--- a/hub/app/hub/[category]/page.tsx
+++ b/hub/app/hub/[category]/page.tsx
@@ -4,9 +4,14 @@ import { loadHubData } from '../../../lib/loadHubData'
 
 export const dynamic = 'force-static'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async function CategoryPage({ params }: any) {
-  const { category: slug } = params as { category: string }
+interface CategoryPageProps {
+  params: {
+    category: string
+  }
+}
+
+export default async function CategoryPage({ params }: CategoryPageProps) {
+  const { category: slug } = params
   const categories = await loadHubData()
   const category = categories.find(cat => cat.slug === slug)
   if (!category) return notFound()


### PR DESCRIPTION
## Summary
- define an interface for route parameters in `CategoryPage`
- remove `any` usage and corresponding ESLint comment

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687c411f63a0832084155e78654411fe