### PR TITLE
Read USE_JSON_HUB_DATA from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ icon: "✨"
 Short description here.
 ```
 
-Alternatively, you can maintain a single JSON configuration by editing `content/hubConfig.json` and enabling the `useJsonHubData` flag in `hub/next.config.ts`.
+Alternatively, you can maintain a single JSON configuration by editing `content/hubConfig.json` and setting the `USE_JSON_HUB_DATA` environment variable to `true`.
 
 ## Deployment on Cloudflare Pages
 

--- a/hub/next.config.ts
+++ b/hub/next.config.ts
@@ -1,6 +1,6 @@
 import type { NextConfig } from 'next'
 
-export const useJsonHubData = false
+export const useJsonHubData = process.env.USE_JSON_HUB_DATA === 'true'
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,


### PR DESCRIPTION
## Summary
- read `process.env.USE_JSON_HUB_DATA` in `next.config.ts`
- document `USE_JSON_HUB_DATA` variable in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687c411d79ec832092c7aa817df2e6a5