### PR TITLE
feat: improve trip cost management

### DIFF
--- a/app/tools/trip-cost/TripContext.tsx
+++ b/app/tools/trip-cost/TripContext.tsx
@@ -100,7 +100,7 @@ export const TripProvider = ({
     if (!selectedTripId) return;
     const unsub = onSnapshot(tripDoc(selectedTripId), (snap) => {
       if (snap.exists()) {
-        const data = snap.data() as Trip;
+        const data = snap.data() as Omit<Trip, 'id'>;
         setTrip({ id: snap.id, ...data });
         setExpenses(data.expenses || []);
         setPayments(data.payments || []);
@@ -115,7 +115,7 @@ export const TripProvider = ({
     const q = query(tripAuditCol(selectedTripId), orderBy('ts', 'desc'));
     const unsub = onSnapshot(q, (snap) => {
       setAuditEntries(
-        snap.docs.map((d) => ({ id: d.id, ...(d.data() as AuditEntry) }))
+        snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<AuditEntry, 'id'>) }))
       );
     });
     return () => unsub();

--- a/app/tools/trip-cost/components/TripDetail/AuditLog.tsx
+++ b/app/tools/trip-cost/components/TripDetail/AuditLog.tsx
@@ -11,36 +11,28 @@ import type { AuditEntry } from '../../pageTypes';
 export default function AuditLog({
   entries,
   show,
-  onToggle,
 }: {
   entries: AuditEntry[];
   show: boolean;
-  onToggle: () => void;
 }) {
+  if (!show) return null;
   return (
-    <section className="bg-white rounded shadow p-4">
-      <header className="flex justify-between items-center mb-2">
-        <h2 className="text-lg font-semibold">Audit Log</h2>
-        <button onClick={onToggle} className="text-blue-600">
-          {show ? 'Hide' : 'Show'}
-        </button>
-      </header>
-      {show && (
-        <ul className="max-h-40 overflow-y-auto text-gray-800 text-sm">
-          {entries.length ? (
-            entries.map((e) => (
-              <li key={e.id} className="border-b py-1 last:border-b-0">
-                {e.type} - {e.actorEmail}{' '}
-                <span className="text-gray-600">
-                  {e.ts ? new Date(e.ts.toDate()).toLocaleString() : ''}
-                </span>
-              </li>
-            ))
-          ) : (
-            <li>No audit entries yet.</li>
-          )}
-        </ul>
-      )}
+    <section className="bg-white rounded shadow p-4 mt-2">
+      <h2 className="text-lg font-semibold mb-2">Audit Log</h2>
+      <ul className="max-h-40 overflow-y-auto text-gray-800 text-sm">
+        {entries.length ? (
+          entries.map((e) => (
+            <li key={e.id} className="border-b py-1 last:border-b-0">
+              {e.type} - {e.actorEmail}{' '}
+              <span className="text-gray-600">
+                {e.ts ? new Date(e.ts.toDate()).toLocaleString() : ''}
+              </span>
+            </li>
+          ))
+        ) : (
+          <li>No audit entries yet.</li>
+        )}
+      </ul>
     </section>
   );
 }

--- a/app/tools/trip-cost/components/TripDetail/ExpenseForm.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ExpenseForm.tsx
@@ -73,6 +73,95 @@ export default function ExpenseForm({
           placeholder="Amount"
         />
       </div>
+      <div className="border-t pt-2">
+        <p className="font-medium">Paid By</p>
+        {participants.map((p) => (
+          <div key={p.id} className="flex items-center gap-2 mt-1">
+            <input
+              type="number"
+              step="0.01"
+              className="border p-1 w-24"
+              value={newExpense.paidBy[p.id] || ''}
+              onChange={(e) =>
+                setNewExpense({
+                  ...newExpense,
+                  paidBy: { ...newExpense.paidBy, [p.id]: e.target.value },
+                })
+              }
+              placeholder="0.00"
+            />
+            <span>{p.name}</span>
+          </div>
+        ))}
+      </div>
+      <div className="border-t pt-2">
+        <p className="font-medium">Split</p>
+        <div className="flex gap-4 mb-2">
+          <label className="flex items-center gap-1">
+            <input
+              type="radio"
+              checked={newExpense.splitType === 'even'}
+              onChange={() =>
+                setNewExpense({ ...newExpense, splitType: 'even' })
+              }
+            />
+            Evenly
+          </label>
+          <label className="flex items-center gap-1">
+            <input
+              type="radio"
+              checked={newExpense.splitType === 'manual'}
+              onChange={() =>
+                setNewExpense({ ...newExpense, splitType: 'manual' })
+              }
+            />
+            Manual
+          </label>
+        </div>
+        <div className="space-y-1">
+          {participants.map((p) => {
+            const included = newExpense.splitParticipants.includes(p.id);
+            return (
+              <div key={p.id} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={included}
+                  onChange={() => {
+                    const set = new Set(newExpense.splitParticipants);
+                    if (included) set.delete(p.id);
+                    else set.add(p.id);
+                    setNewExpense({
+                      ...newExpense,
+                      splitParticipants: Array.from(set),
+                    });
+                  }}
+                />
+                <span className="flex-1">{p.name}</span>
+                {newExpense.splitType === 'manual' && included && (
+                  <input
+                    type="number"
+                    step="0.01"
+                    className="border p-1 w-20"
+                    value={
+                      newExpense.manualSplit[p.id]?.value || ''
+                    }
+                    onChange={(e) =>
+                      setNewExpense({
+                        ...newExpense,
+                        manualSplit: {
+                          ...newExpense.manualSplit,
+                          [p.id]: { type: 'amount', value: e.target.value },
+                        },
+                      })
+                    }
+                    placeholder="Amount"
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
       <button
         type="submit"
         className="bg-green-600 text-white px-3 py-1 rounded disabled:opacity-50"

--- a/app/tools/trip-cost/components/TripDetail/ExpensesList.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ExpensesList.tsx
@@ -8,10 +8,49 @@
 import React from 'react';
 import { useTrip } from '../../TripContext';
 import { CURRENCY_SYMBOL } from '../../constants';
+import type { UserProfile, Expense } from '../../pageTypes';
 
-export default function ExpensesList() {
-  const { expenses } = useTrip();
+export default function ExpensesList({
+  userProfile,
+  onDeleteExpense,
+}: {
+  userProfile: UserProfile | null;
+  onDeleteExpense: (id: string) => void;
+}) {
+  const { expenses, participants } = useTrip();
   if (!expenses.length) return null;
+
+  const name = (id: string) =>
+    participants.find((p) => p.id === id)?.name || 'Unknown';
+
+  const payersText = (e: Expense) => {
+    const entries = Object.entries(e.paidBy || {});
+    return entries.length
+      ? entries
+          .map(
+            ([id, amt]) => `${name(id)} (${CURRENCY_SYMBOL}${Number(amt).toFixed(2)})`
+          )
+          .join(', ')
+      : '—';
+  };
+
+  const splitText = (e: Expense) => {
+    if (e.splitType === 'even') {
+      return `Split evenly among ${e.splitParticipants
+        .map((id: string) => name(id))
+        .join(', ')}`;
+    }
+    return 'Split: ' +
+      e.splitParticipants
+        .map((id: string) => {
+          const share = e.manualSplit[id];
+          if (!share) return name(id);
+          return share.type === 'percent'
+            ? `${name(id)} ${share.value}%`
+            : `${name(id)} ${CURRENCY_SYMBOL}${share.value.toFixed(2)}`;
+        })
+        .join(', ');
+  };
   return (
     <section className="bg-white rounded shadow p-4">
       <h2 className="text-lg font-semibold mb-2">Expenses</h2>
@@ -21,16 +60,32 @@ export default function ExpensesList() {
             <th className="py-1">Category</th>
             <th className="py-1">Description</th>
             <th className="py-1 text-right">Amount</th>
+            <th className="py-1"></th>
           </tr>
         </thead>
         <tbody>
           {expenses.map((e) => (
             <tr key={e.id} className="border-b last:border-b-0">
-              <td className="py-1">{e.category}</td>
-              <td className="py-1">{e.description}</td>
-              <td className="py-1 text-right">
+              <td className="py-1 align-top">{e.category}</td>
+              <td className="py-1">
+                <div>{e.description}</div>
+                <div className="text-xs italic text-gray-600">
+                  Paid by {payersText(e)}; {splitText(e)}
+                </div>
+              </td>
+              <td className="py-1 text-right align-top">
                 {CURRENCY_SYMBOL}
                 {e.totalAmount.toFixed(2)}
+              </td>
+              <td className="py-1 text-right align-top">
+                {(userProfile?.isAdmin || e.createdBy === userProfile?.uid) && (
+                  <button
+                    onClick={() => onDeleteExpense(e.id)}
+                    className="text-red-600 text-xs"
+                  >
+                    Delete
+                  </button>
+                )}
               </td>
             </tr>
           ))}

--- a/app/tools/trip-cost/components/TripDetail/ParticipantsSection.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ParticipantsSection.tsx
@@ -11,15 +11,12 @@ import type { UserProfile } from '../../pageTypes';
 
 export default function ParticipantsSection({
   userProfile,
+  onDeleteParticipant,
 }: {
   userProfile: UserProfile | null;
+  onDeleteParticipant: (id: string) => void;
 }) {
-  const {
-    participants,
-    addParticipant,
-    deleteParticipant,
-    updateParticipant,
-  } = useTrip();
+  const { participants, addParticipant, updateParticipant } = useTrip();
   const [name, setName] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
@@ -95,7 +92,7 @@ export default function ParticipantsSection({
                 </span>
                 {userProfile?.isAdmin && (
                   <button
-                    onClick={() => deleteParticipant(p.id)}
+                    onClick={() => onDeleteParticipant(p.id)}
                     className="text-red-600 px-2"
                     aria-label="Remove participant"
                   >

--- a/app/tools/trip-cost/components/TripDetail/PaymentHistory.tsx
+++ b/app/tools/trip-cost/components/TripDetail/PaymentHistory.tsx
@@ -8,8 +8,15 @@
 import React from 'react';
 import { useTrip } from '../../TripContext';
 import { CURRENCY_SYMBOL } from '../../constants';
+import type { UserProfile } from '../../pageTypes';
 
-export default function PaymentHistory() {
+export default function PaymentHistory({
+  userProfile,
+  onDeletePayment,
+}: {
+  userProfile: UserProfile | null;
+  onDeletePayment: (id: string) => void;
+}) {
   const { payments, participants } = useTrip();
   if (!payments.length) return null;
   const name = (id: string) =>
@@ -19,12 +26,22 @@ export default function PaymentHistory() {
       <h2 className="text-lg font-semibold mb-2">Payments</h2>
       <ul className="space-y-1 text-gray-800">
         {payments.map((p) => (
-          <li key={p.id}>
-            {name(p.payerId)} paid {name(p.payeeId)} {CURRENCY_SYMBOL}
-            {p.amount.toFixed(2)}{' '}
-            <span className="text-gray-600 text-sm ml-2">
-              ({new Date(p.date).toLocaleDateString()})
+          <li key={p.id} className="flex items-center">
+            <span className="flex-1">
+              {name(p.payerId)} paid {name(p.payeeId)} {CURRENCY_SYMBOL}
+              {p.amount.toFixed(2)}{' '}
+              <span className="text-gray-600 text-sm ml-2">
+                ({new Date(p.date).toLocaleDateString()})
+              </span>
             </span>
+            {userProfile?.isAdmin && (
+              <button
+                onClick={() => onDeletePayment(p.id)}
+                className="text-red-600 text-xs ml-2"
+              >
+                Delete
+              </button>
+            )}
           </li>
         ))}
       </ul>

--- a/app/tools/trip-cost/components/TripDetail/TripDetail.tsx
+++ b/app/tools/trip-cost/components/TripDetail/TripDetail.tsx
@@ -24,7 +24,15 @@ export default function TripDetail({
   onBack: () => void;
   userProfile: UserProfile | null;
 }) {
-  const { trip, expenses, payments, auditEntries } = useTrip();
+  const {
+    trip,
+    expenses,
+    payments,
+    auditEntries,
+    deleteExpense,
+    deletePayment,
+    deleteParticipant,
+  } = useTrip();
   const [showAuditLog, setShowAuditLog] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<{
     type: string;
@@ -47,25 +55,46 @@ export default function TripDetail({
           {expenses.length} expenses · {payments.length} payments
         </div>
       </header>
-      <ParticipantsSection userProfile={userProfile} />
+      <ParticipantsSection
+        userProfile={userProfile}
+        onDeleteParticipant={(id) =>
+          setConfirmDelete({ type: 'participant', id })
+        }
+      />
       <ExpenseForm userProfile={userProfile} />
-      <ExpensesList />
+      <ExpensesList
+        userProfile={userProfile}
+        onDeleteExpense={(id) => setConfirmDelete({ type: 'expense', id })}
+      />
       <BalanceSummary userProfile={userProfile} />
       <SettlementSuggestions />
-      <PaymentHistory />
+      <PaymentHistory
+        userProfile={userProfile}
+        onDeletePayment={(id) => setConfirmDelete({ type: 'payment', id })}
+      />
       {userProfile?.isAdmin && (
-        <AuditLog
-          entries={auditEntries}
-          show={showAuditLog}
-          onToggle={() => setShowAuditLog((s) => !s)}
-        />
+        <>
+          <button
+            onClick={() => setShowAuditLog((s) => !s)}
+            className="text-sm text-blue-600 underline"
+          >
+            {showAuditLog ? 'Hide Audit Log' : 'Show Audit Log'}
+          </button>
+          <AuditLog entries={auditEntries} show={showAuditLog} />
+        </>
       )}
       {confirmDelete && (
         <ConfirmDeleteModal
           itemType={confirmDelete.type}
           onCancel={() => setConfirmDelete(null)}
           onConfirm={() => {
-            // deletion handled externally
+            if (confirmDelete.type === 'expense') {
+              deleteExpense(confirmDelete.id);
+            } else if (confirmDelete.type === 'payment') {
+              deletePayment(confirmDelete.id);
+            } else if (confirmDelete.type === 'participant') {
+              deleteParticipant(confirmDelete.id);
+            }
             setConfirmDelete(null);
           }}
         />


### PR DESCRIPTION
## Summary
- fix Firestore collection references and replace window.confirm with modal for trip deletion
- allow specifying payers and split types for expenses and show payer/split info
- add delete actions for expenses, payments, and participants with audit log toggle

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_689a9d66612c8320a59665915920a51f