### PR TITLE
Ensure expense edits default to current user and refine delete modal

### DIFF
--- a/app/tools/trip-cost/TripContext.tsx
+++ b/app/tools/trip-cost/TripContext.tsx
@@ -266,6 +266,10 @@ export const TripProvider = ({
     } else if (Math.abs(sumPaid - totalAmount) > 0.01) {
       throw new Error('Payer amounts must sum to the total amount.');
     }
+    const currentUserId = userProfile?.uid ?? 'unknown';
+    if (Object.keys(paidBy).length === 0) {
+      paidBy[currentUserId] = totalAmount;
+    }
     const splitType = draft.splitType === 'manual' ? 'manual' : 'even';
     let splitParticipants = Array.isArray(draft.splitParticipants)
       ? draft.splitParticipants.slice()
@@ -290,10 +294,6 @@ export const TripProvider = ({
       }
     }
     if (totalAmount <= 0) throw new Error('Enter an amount greater than 0.');
-    const currentUserId = userProfile?.uid ?? 'unknown';
-    if (Object.keys(paidBy).length === 0) {
-      paidBy[currentUserId] = totalAmount;
-    }
     const updated = expenses.map((e) =>
       e.id === id
         ? {

--- a/app/tools/trip-cost/components/TripDetail/ConfirmDeleteModal.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ConfirmDeleteModal.tsx
@@ -24,10 +24,14 @@ export default function ConfirmDeleteModal({
     <div
       role="dialog"
       aria-modal="true"
+      aria-labelledby="confirm-title"
       className="fixed inset-0 flex items-center justify-center bg-black/50"
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
+      onKeyDown={(e) => e.key === 'Escape' && onCancel()}
+      tabIndex={-1}
     >
       <div className="bg-white p-4 rounded shadow space-y-4">
-        <p>Are you sure you want to delete this {itemType}?</p>
+        <p id="confirm-title">Are you sure you want to delete this {itemType}?</p>
         <div className="flex gap-2 justify-end">
           <button
             ref={btnRef}


### PR DESCRIPTION
## Summary
- default current user as payer if none provided when editing expenses
- connect delete confirmation dialog text with aria-labelledby and handle escape/overlay cancel

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b4e2fe694832084d084706674304c