### PR TITLE
Restore centered layouts and add loading splash

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -26,7 +26,7 @@ export default function GamesPage() {
   return (
     <main className="bg-bg text-text min-h-dvh">
       <Nav />
-      <section className="max-w-content mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
+      <section className="container-tight py-16 sm:py-24">
         <div className="text-center mb-12">
           <h1 className="text-4xl sm:text-5xl font-semibold bg-gradient-to-r from-accent to-purple text-transparent bg-clip-text">Games</h1>
           <p className="mt-4 max-w-2xl mx-auto text-lg text-text-2">A collection of interactive projects and games.</p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -74,3 +74,24 @@ html, body {
   li { color: #1f2937 !important; }
   .text-muted { color: #4b5563 !important; }
 }
+
+/* ------------------------------------------------------------ */
+/* CONFIGURATION-INDEPENDENT CONTAINER UTILITIES                */
+/* ------------------------------------------------------------ */
+@layer utilities {
+  .container-tight { @apply mx-auto max-w-[72rem] px-4; }
+  @screen sm { .container-tight { @apply px-6; } }
+  @screen lg { .container-tight { @apply px-8; } }
+
+  .section { @apply py-16; }
+  @screen sm { .section { @apply py-20; } }
+
+  .section-xl { @apply py-24; }
+  @screen sm { .section-xl { @apply py-28; } }
+}
+
+/* Neon progress bar animation for the loading screen */
+@keyframes progress {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(100%); }
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,24 @@
+import type { CSSProperties } from 'react';
+
+/* ------------------------------------------------------------ */
+/* CONFIGURATION: progress bar width (px) and animation duration */
+/* ------------------------------------------------------------ */
+const BAR_WIDTH = 256;
+const ANIMATION_DURATION = 1500; // ms
+
+export default function Loading() {
+  const barStyle = { '--duration': `${ANIMATION_DURATION}ms` } as CSSProperties;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg text-text min-h-dvh">
+      <div
+        className="overflow-hidden rounded-full bg-surface-2"
+        style={{ width: BAR_WIDTH, height: 4 }}
+      >
+        <div
+          className="h-full w-full animate-[progress_var(--duration)_ease-in-out_infinite] bg-gradient-to-r from-accent via-purple to-magenta"
+          style={barStyle}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,13 @@
+import Link from 'next/link';
 import Nav from '@/components/Nav';
-import ProjectCard from '@/components/ProjectCard';
 
 /* ------------------------------------------------------------ */
-/* CONFIGURATION: featured projects shown on the home page      */
+/* CONFIGURATION: hero call-to-action links                      */
 /* ------------------------------------------------------------ */
-const featuredProjects = [
-  { title: 'Game Prototype', description: 'Fast-paced browser game built with React + Canvas.', tags: ['React','Game','WebGL'], imageUrl: '/images/game.jpg' },
-  { title: 'Automation Tool', description: 'CLI + dashboard to streamline workflows.', tags: ['Next.js','API','CLI'], imageUrl: '/images/tool.jpg' },
-  { title: 'Data Viz', description: 'Interactive charts with polished interactions.', tags: ['D3','Charts','UX'], imageUrl: '/images/viz.jpg' },
+const ctaLinks = [
+  { href: '/games', label: 'Games' },
+  { href: '/tools', label: 'Tools' },
+  { href: '/trips', label: 'Trips' },
 ];
 
 export default function Home() {
@@ -18,23 +18,22 @@ export default function Home() {
       {/* Hero */}
       <section className="relative isolate">
         <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(40%_40%_at_60%_20%,_hsl(var(--accent)/0.25)_0%,_transparent_60%),radial-gradient(30%_30%_at_30%_70%,_hsl(var(--purple)/0.18)_0%,_transparent_60%)]" />
-        <div className="mx-auto max-w-content px-4 sm:px-6 lg:px-8 py-28 sm:py-36">
+        <div className="container-tight py-28 sm:py-36">
           <h1 className="text-[clamp(2.5rem,6vw,4.25rem)] font-semibold tracking-tight">Projects, games, and experiments</h1>
           <p className="mt-4 max-w-2xl text-text-2">A polished playground for things I am building and breaking. Clean UI, strong contrast, neon accents.</p>
-          <div className="mt-8 flex gap-4">
-            <a href="#projects" className="rounded-xl3 bg-accent text-black px-6 py-3 font-medium shadow-glow transition hover:brightness-110 focus-ring">View projects</a>
-            <a href="#about" className="rounded-xl3 border border-border text-text-2 px-6 py-3 transition hover:border-accent hover:text-text focus-ring">About me</a>
-          </div>
-        </div>
-      </section>
-
-      {/* Featured projects */}
-      <section id="projects" className="py-16 sm:py-20">
-        <div className="mx-auto max-w-content px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-semibold">Featured projects</h2>
-          <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {featuredProjects.map((project) => (
-              <ProjectCard key={project.title} {...project} />
+          <div className="mt-8 flex flex-wrap gap-4">
+            {ctaLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={
+                  link.href === '/games'
+                    ? 'rounded-xl3 bg-accent text-black px-6 py-3 font-medium shadow-glow transition hover:brightness-110 focus-ring'
+                    : 'rounded-xl3 border border-border text-text-2 px-6 py-3 transition hover:border-accent hover:text-text focus-ring'
+                }
+              >
+                {link.label}
+              </Link>
             ))}
           </div>
         </div>

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -38,7 +38,7 @@ export default function ToolsPage() {
   return (
     <main className="bg-bg text-text min-h-dvh">
       <Nav />
-      <section className="max-w-content mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
+      <section className="container-tight py-16 sm:py-24">
         <div className="text-center mb-12">
           <h1 className="text-4xl sm:text-5xl font-semibold bg-gradient-to-r from-accent to-purple text-transparent bg-clip-text">Tools &amp; Utilities</h1>
           <p className="mt-4 max-w-2xl mx-auto text-lg text-text-2">A collection of useful apps I&apos;ve built.</p>

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -20,7 +20,7 @@ export default function TripsPage() {
   return (
     <main className="bg-bg text-text min-h-dvh">
       <Nav />
-      <section className="max-w-content mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
+      <section className="container-tight py-16 sm:py-24">
         <div className="text-center mb-12">
           <h1 className="text-4xl sm:text-5xl font-semibold bg-gradient-to-r from-accent to-purple text-transparent bg-clip-text">Trips</h1>
           <p className="mt-4 max-w-2xl mx-auto text-lg text-text-2">A collection of travel logs and itineraries.</p>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -3,15 +3,19 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 /* ------------------------------------------------------------ */
-/* CONFIGURATION: navigation labels                             */
+/* CONFIGURATION: navigation links                              */
 /* ------------------------------------------------------------ */
-const navLinks = ['Projects', 'Games', 'About', 'Contact'];
+const navLinks = [
+  { label: 'Games', href: '/games' },
+  { label: 'Tools', href: '/tools' },
+  { label: 'Trips', href: '/trips' },
+];
 
 export default function Nav() {
   const [open, setOpen] = useState(false);
   return (
-    <header className="sticky top-0 z-50 backdrop-blur supports-[backdrop-filter:blur(0)]:bg-surface-2/80 border-b border-border">
-      <nav className="mx-auto max-w-content flex items-center justify-between px-4 py-3">
+    <header className="sticky top-0 z-50 backdrop-blur bg-surface-2/80 border-b border-border">
+      <nav className="container-tight flex items-center justify-between py-3">
         <Link href="/" className="text-lg font-semibold focus-ring">
           JB
         </Link>
@@ -24,13 +28,13 @@ export default function Nav() {
           ☰
         </button>
         <ul className="hidden md:flex gap-6 text-text-2">
-          {navLinks.map((label) => (
-            <li key={label}>
+          {navLinks.map((link) => (
+            <li key={link.href}>
               <Link
                 className="hover:text-text transition focus-ring"
-                href={`/#${label.toLowerCase()}`}
+                href={link.href}
               >
-                {label}
+                {link.label}
               </Link>
             </li>
           ))}
@@ -39,14 +43,14 @@ export default function Nav() {
       {open && (
         <div className="md:hidden border-t border-border bg-surface-2">
           <ul className="px-4 py-2 space-y-2">
-            {navLinks.map((label) => (
-              <li key={label}>
+            {navLinks.map((link) => (
+              <li key={link.href}>
                 <Link
                   className="block py-2 text-text-2 hover:text-text focus-ring"
-                  href={`/#${label.toLowerCase()}`}
+                  href={link.href}
                   onClick={() => setOpen(false)} // Close menu on link click
                 >
-                  {label}
+                  {link.label}
                 </Link>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- add container-tight and section utilities for consistent centered layouts
- clean up home page and nav, wiring CTAs to real sections
- add neon progress loading screen and use container layout across pages
- fix navigation to point to real routes

## Testing
- `npm run lint`
- `npm run build` *(non-blocking Tailwind warning about `px-4`)*

------
https://chatgpt.com/codex/tasks/task_b_689bb0cd29208320b6da5849da201c1a