### PR TITLE
feat: add reusable Button component

### DIFF
--- a/app/tools/trip-cost/components/AuthForm.tsx
+++ b/app/tools/trip-cost/components/AuthForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Button from '@/components/Button';
 
 // ===============================
 // CONFIGURATION (manual inputs)
@@ -102,28 +103,35 @@ export default function AuthForm({
             </div>
           )}
 
-          <button
-            type="submit"
-            className="w-full bg-purple-600 text-white py-3 rounded-md hover:bg-purple-700 transition-colors font-medium"
-          >
+          <Button type="submit" className="w-full">
             {isLogin ? 'Log In' : 'Sign Up'}
-          </button>
+          </Button>
         </form>
 
         <div className="mt-6 text-center text-sm text-gray-700">
           {isLogin ? (
             <>
               Don&apos;t have an account?{' '}
-              <button onClick={toggleMode} className="text-purple-600 hover:underline font-medium">
+              <Button
+                onClick={toggleMode}
+                variant="ghost"
+                size="sm"
+                className="text-purple-600 hover:underline p-0 h-auto"
+              >
                 Sign up
-              </button>
+              </Button>
             </>
           ) : (
             <>
               Already have an account?{' '}
-              <button onClick={toggleMode} className="text-purple-600 hover:underline font-medium">
+              <Button
+                onClick={toggleMode}
+                variant="ghost"
+                size="sm"
+                className="text-purple-600 hover:underline p-0 h-auto"
+              >
                 Log in
-              </button>
+              </Button>
             </>
           )}
         </div>

--- a/app/tools/trip-cost/components/TripDetail/AuditLog.tsx
+++ b/app/tools/trip-cost/components/TripDetail/AuditLog.tsx
@@ -6,6 +6,7 @@
 // None
 
 import React from 'react';
+import Button from '@/components/Button';
 import type { AuditEntry } from '../../pageTypes';
 
 export default function AuditLog({
@@ -21,9 +22,14 @@ export default function AuditLog({
     <section className="bg-white rounded shadow p-4">
       <header className="flex justify-between items-center mb-2">
         <h2 className="text-lg font-semibold">Audit Log</h2>
-        <button onClick={onToggle} className="text-blue-600">
+        <Button
+          onClick={onToggle}
+          variant="ghost"
+          size="sm"
+          className="text-blue-600 p-0 h-auto"
+        >
           {show ? 'Hide' : 'Show'}
-        </button>
+        </Button>
       </header>
       {show ? (
         <ul className="max-h-40 overflow-y-auto text-gray-800 text-sm">

--- a/app/tools/trip-cost/components/TripDetail/BalanceSummary.tsx
+++ b/app/tools/trip-cost/components/TripDetail/BalanceSummary.tsx
@@ -6,6 +6,7 @@
 // None
 
 import React, { useState } from 'react';
+import Button from '@/components/Button';
 import { useTrip } from '../../TripContext';
 import { CURRENCY_SYMBOL } from '../../constants';
 import type { UserProfile } from '../../pageTypes';
@@ -103,13 +104,15 @@ export default function BalanceSummary({
                     className="border border-gray-300 rounded px-2 py-1 w-24 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     placeholder="Amount"
                   />
-                  <button
+                  <Button
                     onClick={() => submit(b.personId)}
-                    className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded transition-colors font-medium"
+                    variant="success"
+                    size="sm"
+                    className="px-3 py-1"
                     aria-label="Record payment"
                   >
                     Pay
-                  </button>
+                  </Button>
                 </div>
               )}
             </li>

--- a/app/tools/trip-cost/components/TripDetail/ConfirmDeleteModal.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ConfirmDeleteModal.tsx
@@ -6,6 +6,7 @@
 // None
 
 import React, { useEffect, useRef } from 'react';
+import Button from '@/components/Button';
 
 export default function ConfirmDeleteModal({
   itemType,
@@ -33,19 +34,23 @@ export default function ConfirmDeleteModal({
       <div className="bg-white p-4 rounded shadow space-y-4">
         <p id="confirm-title">Are you sure you want to delete this {itemType}?</p>
         <div className="flex gap-2 justify-end">
-          <button
+          <Button
             ref={btnRef}
             onClick={onConfirm}
-            className="bg-red-600 text-white px-3 py-1 rounded"
+            variant="danger"
+            size="sm"
+            className="px-3 py-1"
           >
             Delete
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={onCancel}
-            className="px-3 py-1 border rounded"
+            variant="ghost"
+            size="sm"
+            className="px-3 py-1 border"
           >
             Cancel
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/app/tools/trip-cost/components/TripDetail/ExpenseForm.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ExpenseForm.tsx
@@ -6,6 +6,7 @@
 // None
 
 import React, { useState, useEffect } from 'react';
+import Button from '@/components/Button';
 import { useTrip } from '../../TripContext';
 import { EXPENSE_CATEGORIES, CURRENCY_SYMBOL } from '../../constants';
 
@@ -223,20 +224,21 @@ export default function ExpenseForm() {
       )}
 
       {/* Submit button */}
-      <button
+      <Button
         type="submit"
-        className="mt-4 w-full bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        variant="success"
+        className="mt-4 w-full"
+        loading={isSubmitting}
         disabled={
-          !newExpense.description || 
-          !newExpense.totalAmount || 
-          isSubmitting ||
+          !newExpense.description ||
+          !newExpense.totalAmount ||
           payerMismatch ||
           manualMismatch ||
           newExpense.splitParticipants.length === 0
         }
       >
         {isSubmitting ? 'Adding...' : 'Add Expense'}
-      </button>
+      </Button>
     </form>
   );
 }

--- a/app/tools/trip-cost/components/TripDetail/ExpensesList.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ExpensesList.tsx
@@ -6,6 +6,7 @@
 // None
 
 import React from 'react';
+import Button from '@/components/Button';
 import { useTrip } from '../../TripContext';
 import { CURRENCY_SYMBOL } from '../../constants';
 import type { UserProfile, Expense } from '../../pageTypes';
@@ -92,12 +93,14 @@ export default function ExpensesList({
                 </td>
                 <td className="py-3 px-1 text-right align-top">
                   {(userProfile?.isAdmin || e.createdBy === userProfile?.uid) && (
-                    <button
+                    <Button
                       onClick={() => onDeleteExpense(e.id)}
-                      className="text-red-600 hover:text-red-700 text-sm font-medium hover:underline"
+                      variant="ghost"
+                      size="sm"
+                      className="text-red-600 hover:text-red-700 hover:underline p-0 h-auto"
                     >
                       Delete
-                    </button>
+                    </Button>
                   )}
                 </td>
               </tr>

--- a/app/tools/trip-cost/components/TripDetail/ParticipantsSection.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ParticipantsSection.tsx
@@ -6,6 +6,7 @@
 // None
 
 import React, { useState, useEffect, useRef } from 'react';
+import Button from '@/components/Button';
 import { useTrip } from '../../TripContext';
 import type { UserProfile } from '../../pageTypes';
 import { query, getDocs, limit } from 'firebase/firestore';
@@ -187,26 +188,30 @@ export default function ParticipantsSection({
         <div className="space-y-3 mb-4">
           {/* Mode Toggle */}
           <div className="flex gap-2">
-            <button
+            <Button
               onClick={() => setIsSearchMode(false)}
-              className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
-                !isSearchMode 
-                  ? 'bg-blue-100 text-blue-800 border border-blue-200' 
+              variant="ghost"
+              size="sm"
+              className={`px-3 py-1 text-sm ${
+                !isSearchMode
+                  ? 'bg-blue-100 text-blue-800 border border-blue-200'
                   : 'bg-gray-100 text-gray-700 border border-gray-200 hover:bg-gray-200'
               }`}
             >
               Add by Name
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={() => setIsSearchMode(true)}
-              className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
-                isSearchMode 
-                  ? 'bg-blue-100 text-blue-800 border border-blue-200' 
+              variant="ghost"
+              size="sm"
+              className={`px-3 py-1 text-sm ${
+                isSearchMode
+                  ? 'bg-blue-100 text-blue-800 border border-blue-200'
                   : 'bg-gray-100 text-gray-700 border border-gray-200 hover:bg-gray-200'
               }`}
             >
               Add Registered User
-            </button>
+            </Button>
           </div>
 
           {/* Add by Name Mode */}
@@ -219,13 +224,14 @@ export default function ParticipantsSection({
                 className="border border-gray-300 p-2 flex-1 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
                 placeholder="Enter participant name"
               />
-              <button
+              <Button
                 onClick={addManualParticipant}
-                className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                variant="success"
+                className="px-4 py-2"
                 disabled={!name.trim()}
               >
                 Add
-              </button>
+              </Button>
             </div>
           )}
 
@@ -245,13 +251,14 @@ export default function ParticipantsSection({
                   className="border border-gray-300 p-2 flex-1 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
                   placeholder="Search by email or name..."
                 />
-                <button
+                <Button
                   onClick={() => selectedUser && addRegisteredUser(selectedUser)}
-                  className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  variant="success"
+                  className="px-4 py-2"
                   disabled={!selectedUser}
                 >
                   Add User
-                </button>
+                </Button>
               </div>
 
               {/* Dropdown */}
@@ -261,18 +268,20 @@ export default function ParticipantsSection({
                     <div className="p-3 text-gray-600">Loading users...</div>
                   ) : filteredUsers.length > 0 ? (
                     filteredUsers.map((user) => (
-                      <button
+                      <Button
                         key={user.uid}
                         onClick={() => {
                           setSelectedUser(user);
                           setSearchQuery(user.displayName);
                           setShowDropdown(false);
                         }}
-                        className="w-full text-left p-3 hover:bg-gray-50 border-b border-gray-100 last:border-b-0 focus:bg-blue-50 focus:outline-none"
+                        variant="ghost"
+                        size="sm"
+                        className="w-full text-left p-3 hover:bg-gray-50 border-b border-gray-100 last:border-b-0 focus:bg-blue-50"
                       >
                         <div className="font-medium text-gray-900">{user.displayName}</div>
                         <div className="text-sm text-gray-600">{user.email}</div>
-                      </button>
+                      </Button>
                     ))
                   ) : searchQuery.trim() ? (
                       <div className="p-3 text-gray-600">No users found matching &quot;{searchQuery}&quot;</div>
@@ -307,15 +316,22 @@ export default function ParticipantsSection({
                     className="border border-gray-300 p-1 flex-1 rounded text-gray-900"
                     autoFocus
                   />
-                  <button onClick={saveEdit} className="text-blue-600 hover:text-blue-700 px-2">
+                  <Button
+                    onClick={saveEdit}
+                    variant="ghost"
+                    size="sm"
+                    className="text-blue-600 hover:text-blue-700 px-2 h-auto"
+                  >
                     Save
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={() => setEditingId(null)}
-                    className="text-gray-600 hover:text-gray-700 px-2"
+                    variant="ghost"
+                    size="sm"
+                    className="text-gray-600 hover:text-gray-700 px-2 h-auto"
                   >
                     Cancel
-                  </button>
+                  </Button>
                 </>
               ) : (
                 <>
@@ -333,13 +349,15 @@ export default function ParticipantsSection({
                     )}
                   </span>
                   {userProfile?.isAdmin && (
-                    <button
+                    <Button
                       onClick={() => onDeleteParticipant(p.id)}
-                      className="text-red-600 hover:text-red-700 px-2 text-xl font-bold"
+                      variant="ghost"
+                      size="sm"
+                      className="text-red-600 hover:text-red-700 px-2 text-xl font-bold h-auto"
                       aria-label={`Remove ${p.name}`}
                     >
                       ×
-                    </button>
+                    </Button>
                   )}
                 </>
               )}

--- a/app/tools/trip-cost/components/TripDetail/PaymentHistory.tsx
+++ b/app/tools/trip-cost/components/TripDetail/PaymentHistory.tsx
@@ -6,6 +6,7 @@
 // None
 
 import React from 'react';
+import Button from '@/components/Button';
 import { useTrip } from '../../TripContext';
 import { CURRENCY_SYMBOL } from '../../constants';
 import type { UserProfile } from '../../pageTypes';
@@ -35,12 +36,14 @@ export default function PaymentHistory({
               </span>
             </span>
             {userProfile?.isAdmin && (
-              <button
+              <Button
                 onClick={() => onDeletePayment(p.id)}
-                className="text-red-600 text-xs ml-2"
+                variant="ghost"
+                size="sm"
+                className="text-red-600 text-xs ml-2 p-0 h-auto"
               >
                 Delete
-              </button>
+              </Button>
             )}
           </li>
         ))}

--- a/app/tools/trip-cost/components/TripDetail/TripDetail.tsx
+++ b/app/tools/trip-cost/components/TripDetail/TripDetail.tsx
@@ -16,6 +16,7 @@ import PaymentHistory from './PaymentHistory';
 import AuditLog from './AuditLog';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
 import type { UserProfile } from '../../pageTypes';
+import Button from '@/components/Button';
 
 export default function TripDetail({
   onBack,
@@ -54,12 +55,14 @@ export default function TripDetail({
           {/* Header */}
           <header className="bg-white rounded-lg shadow p-4">
             <div className="flex items-center justify-between">
-              <button
+              <Button
                 onClick={onBack}
-                className="text-blue-600 hover:underline"
+                variant="ghost"
+                size="sm"
+                className="text-blue-600 hover:underline p-0 h-auto"
               >
                 ← Back to trips
-              </button>
+              </Button>
               <h1 className="text-2xl font-bold text-gray-800">{trip.name}</h1>
               <div className="text-gray-600 text-sm">
                 {expenses.length} expense{expenses.length !== 1 ? 's' : ''} · {payments.length} payment{payments.length !== 1 ? 's' : ''}

--- a/app/tools/trip-cost/components/TripList.tsx
+++ b/app/tools/trip-cost/components/TripList.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Trip, UserProfile } from '../pageTypes';
+import Button from '@/components/Button';
 
 // ===============================
 // CONFIGURATION (manual inputs)
@@ -43,12 +44,14 @@ export default function TripList({
                   <span className="ml-2 text-xs bg-purple-100 text-purple-700 px-2 py-1 rounded">Admin</span>
                 )}
               </span>
-              <button
+              <Button
                 onClick={onLogout}
-                className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300 transition-colors text-sm text-gray-900"
+                variant="secondary"
+                size="sm"
+                className="px-4 py-2 text-sm text-gray-900"
               >
                 Log out
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -64,13 +67,14 @@ export default function TripList({
                 placeholder="Enter trip name..."
                 className="flex-1 p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent text-gray-900"
               />
-              <button
+              <Button
                 onClick={onCreateTrip}
                 disabled={!newTripName.trim()}
-                className="bg-green-600 text-white px-6 py-3 rounded-md hover:bg-green-700 transition-colors font-medium disabled:opacity-50"
+                variant="success"
+                className="px-6 py-3"
               >
                 Create Trip
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -87,19 +91,20 @@ export default function TripList({
                   <p>{trip.payments.length} payment{trip.payments.length !== 1 && 's'}</p>
                 </div>
                 <div className="flex gap-2">
-                  <button
+                  <Button
                     onClick={() => onOpenTrip(trip)}
-                    className="flex-1 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors"
+                    className="flex-1"
                   >
                     Open
-                  </button>
+                  </Button>
                   {userProfile?.isAdmin && (
-                    <button
+                    <Button
                       onClick={() => onDeleteTrip(trip)}
-                      className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition-colors"
+                      variant="danger"
+                      className="px-4 py-2"
                     >
                       Delete
-                    </button>
+                    </Button>
                   )}
                 </div>
               </div>

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Loader2 } from 'lucide-react';
+
+/* ------------------------------------------------------------ */
+/* CONFIGURATION: button variant and size classes               */
+/* ------------------------------------------------------------ */
+const buttonVariants = cva(
+  'inline-flex items-center justify-center font-medium rounded-lg focus-ring transition disabled:opacity-50 disabled:pointer-events-none',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-accent text-black hover:bg-accent-600',
+        secondary: 'bg-surface-2 text-text hover:bg-surface-3',
+        danger: 'bg-error text-white hover:bg-error/90',
+        success: 'bg-success text-white hover:bg-success/90',
+        ghost: 'bg-transparent text-text hover:bg-surface-2',
+      },
+      size: {
+        sm: 'px-3 py-1.5 text-sm',
+        md: 'px-4 py-2',
+        lg: 'px-6 py-3 rounded-xl text-lg',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  loading?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, loading, disabled, children, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        disabled={disabled || loading}
+        className={buttonVariants({ variant, size, className })}
+        {...props}
+      >
+        {loading && (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+        )}
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };
+export default Button;
+

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { useState } from 'react';
+import Button from '@/components/Button';
 
 /* ------------------------------------------------------------ */
 /* CONFIGURATION: navigation links                              */
@@ -19,14 +20,16 @@ export default function Nav() {
         <Link href="/" className="text-lg font-semibold focus-ring">
           JB
         </Link>
-        <button
+        <Button
           aria-label="Toggle menu"
-          className="md:hidden p-2 rounded-lg border border-border hover:border-accent transition focus-ring"
+          variant="ghost"
+          size="sm"
+          className="md:hidden p-2 border border-border hover:border-accent"
           onClick={() => setOpen(!open)}
         >
           {/* A more accessible and scalable approach would be to use an SVG icon here */}
           ☰
-        </button>
+        </Button>
         <ul className="hidden md:flex gap-6 text-text-2">
           {navLinks.map((link) => (
             <li key={link.href}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "website",
       "version": "0.1.0",
       "dependencies": {
+        "class-variance-authority": "^0.7.1",
         "firebase": "^12.1.0",
         "lucide-react": "^0.525.0",
         "next": "15.4.3",
@@ -3014,6 +3015,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3032,6 +3045,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
     "firebase": "^12.1.0",
     "lucide-react": "^0.525.0",
     "next": "15.4.3",


### PR DESCRIPTION
## Summary
- add configurable Button component with variant and size support
- replace button elements across trip cost tool and navigation with Button
- install class-variance-authority for variant management

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689bc2fb844c83209de9047e1e202aea