### PR TITLE
feat: add shared form components

### DIFF
--- a/app/tools/trip-cost/components/AuthForm.tsx
+++ b/app/tools/trip-cost/components/AuthForm.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Button from '@/components/Button';
+import Input from '@/components/Input';
 
 // ===============================
 // CONFIGURATION (manual inputs)
@@ -51,55 +52,47 @@ export default function AuthForm({
         )}
 
         <form onSubmit={onSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-            <input
-              type="email"
-              autoComplete="email"
-              value={authEmail}
-              onChange={(e) => setAuthEmail(e.target.value)}
-              className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-              required
-            />
-          </div>
+          <Input
+            label="Email"
+            type="email"
+            autoComplete="email"
+            value={authEmail}
+            onChange={(e) => setAuthEmail(e.target.value)}
+            required
+          />
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
-            <input
-              type="password"
-              autoComplete={isLogin ? 'current-password' : 'new-password'}
-              value={authPassword}
-              onChange={(e) => setAuthPassword(e.target.value)}
-              className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-              required
-            />
-          </div>
+          <Input
+            label="Password"
+            type="password"
+            autoComplete={isLogin ? 'current-password' : 'new-password'}
+            value={authPassword}
+            onChange={(e) => setAuthPassword(e.target.value)}
+            required
+          />
 
           {!isLogin && (
             <div className="flex gap-3">
-              <div className="flex-1">
-                <label className="block text-sm font-medium text-gray-700 mb-1">First Name</label>
-                <input
-                  type="text"
-                  autoComplete="given-name"
-                  value={firstName}
-                  onChange={(e) => setFirstName(e.target.value)}
-                  className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                  required
-                />
-              </div>
-              <div className="w-24">
-                <label className="block text-sm font-medium text-gray-700 mb-1">Initial</label>
-                <input
-                  type="text"
-                  autoComplete="family-name"
-                  value={lastInitial}
-                  onChange={(e) => setLastInitial(e.target.value.slice(0, 1))}
-                  className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                  maxLength={1}
-                  required
-                />
-              </div>
+              <Input
+                label="First Name"
+                type="text"
+                autoComplete="given-name"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                className="w-full"
+                wrapperClassName="flex-1"
+                required
+              />
+              <Input
+                label="Initial"
+                type="text"
+                autoComplete="family-name"
+                value={lastInitial}
+                onChange={(e) => setLastInitial(e.target.value.slice(0, 1))}
+                className="w-full"
+                wrapperClassName="w-24"
+                maxLength={1}
+                required
+              />
             </div>
           )}
 

--- a/app/tools/trip-cost/components/TripDetail/BalanceSummary.tsx
+++ b/app/tools/trip-cost/components/TripDetail/BalanceSummary.tsx
@@ -7,6 +7,8 @@
 
 import React, { useState } from 'react';
 import Button from '@/components/Button';
+import Input from '@/components/Input';
+import Select from '@/components/Select';
 import { useTrip } from '../../TripContext';
 import { CURRENCY_SYMBOL } from '../../constants';
 import type { UserProfile } from '../../pageTypes';
@@ -78,12 +80,12 @@ export default function BalanceSummary({
               
               {!isNeutral && (
                 <div className="flex gap-2 mt-2">
-                  <select
+                  <Select
                     value={forms[b.personId]?.payeeId || ''}
                     onChange={(e) =>
                       handleChange(b.personId, 'payeeId', e.target.value)
                     }
-                    className="border border-gray-300 rounded px-2 py-1 flex-1 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="flex-1 px-2 py-1"
                   >
                     <option value="">Select recipient...</option>
                     {participants
@@ -93,15 +95,15 @@ export default function BalanceSummary({
                           {p.name}
                         </option>
                       ))}
-                  </select>
-                  <input
+                  </Select>
+                  <Input
                     value={forms[b.personId]?.amount || ''}
                     onChange={(e) =>
                       handleChange(b.personId, 'amount', e.target.value)
                     }
                     type="number"
                     step="0.01"
-                    className="border border-gray-300 rounded px-2 py-1 w-24 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="px-2 py-1 w-24"
                     placeholder="Amount"
                   />
                   <Button

--- a/app/tools/trip-cost/components/TripDetail/ExpenseForm.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ExpenseForm.tsx
@@ -7,6 +7,8 @@
 
 import React, { useState, useEffect } from 'react';
 import Button from '@/components/Button';
+import Input from '@/components/Input';
+import Select from '@/components/Select';
 import { useTrip } from '../../TripContext';
 import { EXPENSE_CATEGORIES, CURRENCY_SYMBOL } from '../../constants';
 
@@ -65,29 +67,27 @@ export default function ExpenseForm() {
       {/* Main inputs */}
       <div className="space-y-3">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
-          <select
+          <Select
             value={newExpense.category}
             onChange={(e) =>
               setNewExpense({ ...newExpense, category: e.target.value })
             }
-            className="border border-gray-300 p-2 rounded-md focus:ring-2 focus:ring-blue-500"
           >
             {EXPENSE_CATEGORIES.map((c) => (
               <option key={c} value={c}>{c}</option>
             ))}
-          </select>
-          
-          <input
+          </Select>
+
+          <Input
             value={newExpense.description}
             onChange={(e) =>
               setNewExpense({ ...newExpense, description: e.target.value })
             }
-            className="border border-gray-300 p-2 rounded-md focus:ring-2 focus:ring-blue-500"
             placeholder="Description"
             required
           />
-          
-          <input
+
+          <Input
             value={newExpense.totalAmount}
             onChange={(e) =>
               setNewExpense({ ...newExpense, totalAmount: e.target.value })
@@ -95,7 +95,6 @@ export default function ExpenseForm() {
             type="number"
             step="0.01"
             min="0.01"
-            className="border border-gray-300 p-2 rounded-md focus:ring-2 focus:ring-blue-500"
             placeholder="Total Amount"
             required
           />
@@ -114,11 +113,11 @@ export default function ExpenseForm() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
             {participants.map((p) => (
               <div key={p.id} className="flex items-center gap-2">
-                <input
+                <Input
                   type="number"
                   step="0.01"
                   min="0"
-                  className="border border-gray-300 p-1 w-24 rounded"
+                  className="p-1 w-24"
                   value={newExpense.paidBy[p.id] || ''}
                   onChange={(e) =>
                     setNewExpense({
@@ -139,7 +138,7 @@ export default function ExpenseForm() {
           <p className="font-medium text-gray-700 mb-2">How to split?</p>
           <div className="flex gap-4 mb-3">
             <label className="flex items-center gap-2 cursor-pointer">
-              <input
+              <Input
                 type="radio"
                 checked={newExpense.splitType === 'even'}
                 onChange={() =>
@@ -150,7 +149,7 @@ export default function ExpenseForm() {
               <span>Split Evenly</span>
             </label>
             <label className="flex items-center gap-2 cursor-pointer">
-              <input
+              <Input
                 type="radio"
                 checked={newExpense.splitType === 'manual'}
                 onChange={() =>
@@ -173,7 +172,7 @@ export default function ExpenseForm() {
               const included = newExpense.splitParticipants.includes(p.id);
               return (
                 <div key={p.id} className="flex items-center gap-2">
-                  <input
+                  <Input
                     type="checkbox"
                     checked={included}
                     onChange={() => {
@@ -189,11 +188,11 @@ export default function ExpenseForm() {
                   />
                   <span className="flex-1 text-gray-700">{p.name}</span>
                   {newExpense.splitType === 'manual' && included && (
-                    <input
+                    <Input
                       type="number"
                       step="0.01"
                       min="0"
-                      className="border border-gray-300 p-1 w-24 rounded"
+                      className="p-1 w-24"
                       value={
                         newExpense.manualSplit[p.id]?.value || ''
                       }

--- a/app/tools/trip-cost/components/TripDetail/ParticipantsSection.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ParticipantsSection.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import Button from '@/components/Button';
+import Input from '@/components/Input';
 import { useTrip } from '../../TripContext';
 import type { UserProfile } from '../../pageTypes';
 import { query, getDocs, limit } from 'firebase/firestore';
@@ -217,12 +218,12 @@ export default function ParticipantsSection({
           {/* Add by Name Mode */}
           {!isSearchMode && (
             <div className="flex gap-2">
-              <input
+              <Input
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 onKeyPress={handleKeyPress}
-                className="border border-gray-300 p-2 flex-1 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
                 placeholder="Enter participant name"
+                className="flex-1"
               />
               <Button
                 onClick={addManualParticipant}
@@ -239,7 +240,7 @@ export default function ParticipantsSection({
           {isSearchMode && (
             <div className="relative" ref={dropdownRef}>
               <div className="flex gap-2">
-                <input
+                <Input
                   ref={searchInputRef}
                   value={searchQuery}
                   onChange={(e) => {
@@ -248,8 +249,8 @@ export default function ParticipantsSection({
                   }}
                   onKeyPress={handleSearchKeyPress}
                   onFocus={() => setShowDropdown(true)}
-                  className="border border-gray-300 p-2 flex-1 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
                   placeholder="Search by email or name..."
+                  className="flex-1"
                 />
                 <Button
                   onClick={() => selectedUser && addRegisteredUser(selectedUser)}
@@ -310,10 +311,10 @@ export default function ParticipantsSection({
             <li key={p.id} className="flex items-center gap-2 py-2">
               {editingId === p.id ? (
                 <>
-                  <input
+                  <Input
                     value={editName}
                     onChange={(e) => setEditName(e.target.value)}
-                    className="border border-gray-300 p-1 flex-1 rounded text-gray-900"
+                    className="p-1 flex-1"
                     autoFocus
                   />
                   <Button

--- a/app/tools/trip-cost/components/TripList.tsx
+++ b/app/tools/trip-cost/components/TripList.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Trip, UserProfile } from '../pageTypes';
 import Button from '@/components/Button';
+import Input from '@/components/Input';
 
 // ===============================
 // CONFIGURATION (manual inputs)
@@ -60,12 +61,12 @@ export default function TripList({
         {userProfile?.isAdmin && (
           <div className="bg-white rounded-lg shadow mb-6 p-4">
             <div className="flex gap-3">
-              <input
+              <Input
                 type="text"
                 value={newTripName}
                 onChange={(e) => setNewTripName(e.target.value)}
                 placeholder="Enter trip name..."
-                className="flex-1 p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent text-gray-900"
+                className="flex-1"
               />
               <Button
                 onClick={onCreateTrip}

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+// ===============================
+// CONFIGURATION
+// ===============================
+// None
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  wrapperClassName?: string;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, className = '', id, wrapperClassName = '', ...props }, ref) => {
+    const autoId = React.useId();
+    const inputId = id ?? autoId;
+
+    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-3 py-2 focus:border-accent focus:ring-2 focus:ring-accent`;
+
+    const inputElement = (
+      <input
+        id={inputId}
+        ref={ref}
+        className={`${baseClasses} ${className}`.trim()}
+        {...props}
+      />
+    );
+
+    if (!label && !error) {
+      return inputElement;
+    }
+
+    return (
+      <div className={wrapperClassName ? wrapperClassName : 'flex flex-col'}>
+        {label && (
+          <label htmlFor={inputId} className="text-text-2 text-sm font-medium mb-1">
+            {label}
+          </label>
+        )}
+        {inputElement}
+        {error && <p className="text-error text-sm mt-1">{error}</p>}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input';
+export default Input;

--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+// ===============================
+// CONFIGURATION
+// ===============================
+// None
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  label?: string;
+  error?: string;
+  wrapperClassName?: string;
+}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ label, error, className = '', id, wrapperClassName = '', children, ...props }, ref) => {
+    const autoId = React.useId();
+    const selectId = id ?? autoId;
+
+    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-3 py-2 focus:border-accent focus:ring-2 focus:ring-accent`;
+
+    const selectElement = (
+      <select
+        id={selectId}
+        ref={ref}
+        className={`${baseClasses} ${className}`.trim()}
+        {...props}
+      >
+        {children}
+      </select>
+    );
+
+    if (!label && !error) {
+      return selectElement;
+    }
+
+    return (
+      <div className={wrapperClassName ? wrapperClassName : 'flex flex-col'}>
+        {label && (
+          <label htmlFor={selectId} className="text-text-2 text-sm font-medium mb-1">
+            {label}
+          </label>
+        )}
+        {selectElement}
+        {error && <p className="text-error text-sm mt-1">{error}</p>}
+      </div>
+    );
+  }
+);
+
+Select.displayName = 'Select';
+export default Select;


### PR DESCRIPTION
## Summary
- add reusable `Input` and `Select` components with shared styles and label/error support
- replace raw form fields in trip cost tools with the new components for consistent UX

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689bc5545f708320a282613535b76d05