### PR TITLE
refactor: theme tokens in trip cost tool

### DIFF
--- a/app/tools/trip-cost/components/AuthForm.tsx
+++ b/app/tools/trip-cost/components/AuthForm.tsx
@@ -39,14 +39,14 @@ export default function AuthForm({
   toggleMode,
 }: AuthFormProps) {
   return (
-    <div className="min-h-screen bg-gray-50 flex justify-center items-center p-4">
-      <div className="w-full max-w-md bg-white p-6 rounded-lg shadow-lg">
-        <h2 className="text-2xl font-bold mb-6 text-center text-gray-800">
+    <div className="min-h-screen bg-surface-2 flex justify-center items-center p-4">
+      <div className="w-full max-w-md bg-surface-1 p-6 rounded-lg shadow-lg">
+        <h2 className="text-2xl font-bold mb-6 text-center text-text">
           {isLogin ? 'Log in to Trip Cost' : 'Create Account'}
         </h2>
 
         {authError && (
-          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+          <div className="bg-error/10 border border-error/20 text-error px-4 py-3 rounded mb-4">
             {authError}
           </div>
         )}
@@ -101,7 +101,7 @@ export default function AuthForm({
           </Button>
         </form>
 
-        <div className="mt-6 text-center text-sm text-gray-700">
+        <div className="mt-6 text-center text-sm text-text-2">
           {isLogin ? (
             <>
               Don&apos;t have an account?{' '}
@@ -109,7 +109,7 @@ export default function AuthForm({
                 onClick={toggleMode}
                 variant="ghost"
                 size="sm"
-                className="text-purple-600 hover:underline p-0 h-auto"
+                className="text-purple hover:underline p-0 h-auto"
               >
                 Sign up
               </Button>
@@ -121,7 +121,7 @@ export default function AuthForm({
                 onClick={toggleMode}
                 variant="ghost"
                 size="sm"
-                className="text-purple-600 hover:underline p-0 h-auto"
+                className="text-purple hover:underline p-0 h-auto"
               >
                 Log in
               </Button>

--- a/app/tools/trip-cost/components/TripDetail/AuditLog.tsx
+++ b/app/tools/trip-cost/components/TripDetail/AuditLog.tsx
@@ -19,25 +19,25 @@ export default function AuditLog({
   onToggle: () => void;
 }) {
   return (
-    <section className="bg-white rounded shadow p-4">
+    <section className="bg-surface-1 rounded shadow p-4">
       <header className="flex justify-between items-center mb-2">
         <h2 className="text-lg font-semibold">Audit Log</h2>
         <Button
           onClick={onToggle}
           variant="ghost"
           size="sm"
-          className="text-blue-600 p-0 h-auto"
+          className="text-accent p-0 h-auto"
         >
           {show ? 'Hide' : 'Show'}
         </Button>
       </header>
       {show ? (
-        <ul className="max-h-40 overflow-y-auto text-gray-800 text-sm">
+        <ul className="max-h-40 overflow-y-auto text-text text-sm">
           {entries.length ? (
             entries.map((e) => (
-              <li key={e.id} className="border-b py-1 last:border-b-0">
+              <li key={e.id} className="border-b border-border py-1 last:border-b-0">
                 {e.type} - {e.actorEmail}{' '}
-                <span className="text-gray-600">
+                <span className="text-text-3">
                   {e.ts ? new Date(e.ts.toDate()).toLocaleString() : ''}
                 </span>
               </li>

--- a/app/tools/trip-cost/components/TripDetail/BalanceSummary.tsx
+++ b/app/tools/trip-cost/components/TripDetail/BalanceSummary.tsx
@@ -49,11 +49,11 @@ export default function BalanceSummary({
   };
 
   return (
-    <section className="bg-white rounded-lg shadow p-4">
-      <h2 className="text-xl font-semibold mb-3 text-gray-900">Balances</h2>
+    <section className="bg-surface-1 rounded-lg shadow p-4">
+      <h2 className="text-xl font-semibold mb-3 text-text">Balances</h2>
       
       {error && (
-        <div className="mb-3 p-2 bg-red-50 border border-red-200 text-red-700 rounded text-sm">
+        <div className="mb-3 p-2 bg-error/10 border border-error/20 text-error rounded text-sm">
           {error}
         </div>
       )}
@@ -65,13 +65,13 @@ export default function BalanceSummary({
           const isNeutral = Math.abs(b.balance) < 0.01;
           
           return (
-            <li key={b.personId} className="border-b border-gray-100 pb-3 last:border-0">
+            <li key={b.personId} className="border-b border-border pb-3 last:border-0">
               <div className="flex items-center justify-between mb-2">
-                <span className="text-gray-900 font-medium">{b.name}</span>
+                <span className="text-text font-medium">{b.name}</span>
                 <span className={`font-semibold ${
-                  isPositive ? 'text-green-600' : 
-                  isNegative ? 'text-red-600' : 
-                  'text-gray-600'
+                  isPositive ? 'text-success' :
+                  isNegative ? 'text-error' :
+                  'text-text-3'
                 }`}>
                   {isPositive && '+'}{CURRENCY_SYMBOL}{Math.abs(b.balance).toFixed(2)}
                   {isNeutral && ' (settled)'}

--- a/app/tools/trip-cost/components/TripDetail/ConfirmDeleteModal.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ConfirmDeleteModal.tsx
@@ -31,7 +31,7 @@ export default function ConfirmDeleteModal({
       onKeyDown={(e) => e.key === 'Escape' && onCancel()}
       tabIndex={-1}
     >
-      <div className="bg-white p-4 rounded shadow space-y-4">
+      <div className="bg-surface-1 p-4 rounded shadow space-y-4">
         <p id="confirm-title">Are you sure you want to delete this {itemType}?</p>
         <div className="flex gap-2 justify-end">
           <Button
@@ -47,7 +47,7 @@ export default function ConfirmDeleteModal({
             onClick={onCancel}
             variant="ghost"
             size="sm"
-            className="px-3 py-1 border"
+            className="px-3 py-1 border border-border"
           >
             Cancel
           </Button>

--- a/app/tools/trip-cost/components/TripDetail/ExpenseForm.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ExpenseForm.tsx
@@ -61,8 +61,8 @@ export default function ExpenseForm() {
     manualTotal > 0 && Math.abs(manualTotal - totalAmount) > 0.01;
 
   return (
-    <form onSubmit={submit} className="bg-white p-4 rounded-lg shadow">
-      <h2 className="text-lg font-semibold mb-3 text-gray-800">Add Expense</h2>
+    <form onSubmit={submit} className="bg-surface-1 p-4 rounded-lg shadow">
+      <h2 className="text-lg font-semibold mb-3 text-text">Add Expense</h2>
       
       {/* Main inputs */}
       <div className="space-y-3">
@@ -102,10 +102,10 @@ export default function ExpenseForm() {
 
         {/* Paid By Section */}
         <div className="border-t pt-3">
-          <p className="font-medium text-gray-700 mb-2">
+          <p className="font-medium text-text-2 mb-2">
             Who paid? (Leave blank to default to you)
             {payerMismatch && (
-              <span className="text-red-600 text-sm ml-2">
+              <span className="text-error text-sm ml-2">
                 Amounts must sum to {CURRENCY_SYMBOL}{totalAmount.toFixed(2)}
               </span>
             )}
@@ -127,7 +127,7 @@ export default function ExpenseForm() {
                   }
                   placeholder="0.00"
                 />
-                <span className="text-gray-700">{p.name}</span>
+                <span className="text-text-2">{p.name}</span>
               </div>
             ))}
           </div>
@@ -135,7 +135,7 @@ export default function ExpenseForm() {
 
         {/* Split Section */}
         <div className="border-t pt-3">
-          <p className="font-medium text-gray-700 mb-2">How to split?</p>
+          <p className="font-medium text-text-2 mb-2">How to split?</p>
           <div className="flex gap-4 mb-3">
             <label className="flex items-center gap-2 cursor-pointer">
               <Input
@@ -144,7 +144,7 @@ export default function ExpenseForm() {
                 onChange={() =>
                   setNewExpense({ ...newExpense, splitType: 'even' })
                 }
-                className="text-blue-600"
+                className="text-accent"
               />
               <span>Split Evenly</span>
             </label>
@@ -155,14 +155,14 @@ export default function ExpenseForm() {
                 onChange={() =>
                   setNewExpense({ ...newExpense, splitType: 'manual' })
                 }
-                className="text-blue-600"
+                className="text-accent"
               />
               <span>Manual Split</span>
             </label>
           </div>
           
           {manualMismatch && (
-            <div className="text-red-600 text-sm mb-2">
+            <div className="text-error text-sm mb-2">
               Manual split must sum to {CURRENCY_SYMBOL}{totalAmount.toFixed(2)}
             </div>
           )}
@@ -184,9 +184,9 @@ export default function ExpenseForm() {
                         splitParticipants: Array.from(set),
                       });
                     }}
-                    className="text-blue-600"
+                    className="text-accent"
                   />
-                  <span className="flex-1 text-gray-700">{p.name}</span>
+                  <span className="flex-1 text-text-2">{p.name}</span>
                   {newExpense.splitType === 'manual' && included && (
                     <Input
                       type="number"
@@ -217,7 +217,7 @@ export default function ExpenseForm() {
 
       {/* Error display */}
       {error && (
-        <div className="mt-3 p-2 bg-red-50 border border-red-200 text-red-700 rounded text-sm" aria-live="polite">
+        <div className="mt-3 p-2 bg-error/10 border border-error/20 text-error rounded text-sm" aria-live="polite">
           {error}
         </div>
       )}

--- a/app/tools/trip-cost/components/TripDetail/ExpensesList.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ExpensesList.tsx
@@ -57,37 +57,37 @@ export default function ExpensesList({
   };
   
   return (
-    <section className="bg-white rounded-lg shadow p-4">
-      <h2 className="text-xl font-semibold mb-3 text-gray-900">Expenses</h2>
+    <section className="bg-surface-1 rounded-lg shadow p-4">
+      <h2 className="text-xl font-semibold mb-3 text-text">Expenses</h2>
       <div className="overflow-x-auto">
         <table className="w-full text-left">
           <thead>
-            <tr className="border-b-2 border-gray-200">
-              <th className="py-2 px-1 text-sm font-semibold text-gray-900">Category</th>
-              <th className="py-2 px-1 text-sm font-semibold text-gray-900">Description</th>
-              <th className="py-2 px-1 text-sm font-semibold text-gray-900 text-right">Amount</th>
+            <tr className="border-b-2 border-border">
+              <th className="py-2 px-1 text-sm font-semibold text-text">Category</th>
+              <th className="py-2 px-1 text-sm font-semibold text-text">Description</th>
+              <th className="py-2 px-1 text-sm font-semibold text-text text-right">Amount</th>
               <th className="py-2 px-1"></th>
             </tr>
           </thead>
           <tbody>
             {expenses.map((e) => (
-              <tr key={e.id} className="border-b border-gray-100 hover:bg-gray-50 transition-colors">
+              <tr key={e.id} className="border-b border-border hover:bg-surface-2 transition-colors">
                 <td className="py-3 px-1 align-top">
-                  <span className="inline-block px-2 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-800">
+                  <span className="inline-block px-2 py-1 text-xs font-medium rounded-full bg-accent/10 text-accent">
                     {e.category}
                   </span>
                 </td>
                 <td className="py-3 px-1">
-                  <div className="text-gray-900 font-medium">{e.description}</div>
-                  <div className="text-xs text-gray-600 mt-1">
+                  <div className="text-text font-medium">{e.description}</div>
+                  <div className="text-xs text-text-3 mt-1">
                     <span className="font-medium">Paid by:</span> {payersText(e)}
                   </div>
-                  <div className="text-xs text-gray-600">
+                  <div className="text-xs text-text-3">
                     {splitText(e)}
                   </div>
                 </td>
                 <td className="py-3 px-1 text-right align-top">
-                  <span className="text-gray-900 font-semibold">
+                  <span className="text-text font-semibold">
                     {CURRENCY_SYMBOL}{e.totalAmount.toFixed(2)}
                   </span>
                 </td>
@@ -97,7 +97,7 @@ export default function ExpensesList({
                       onClick={() => onDeleteExpense(e.id)}
                       variant="ghost"
                       size="sm"
-                      className="text-red-600 hover:text-red-700 hover:underline p-0 h-auto"
+                      className="text-error hover:text-error/90 hover:underline p-0 h-auto"
                     >
                       Delete
                     </Button>

--- a/app/tools/trip-cost/components/TripDetail/ParticipantsSection.tsx
+++ b/app/tools/trip-cost/components/TripDetail/ParticipantsSection.tsx
@@ -181,8 +181,8 @@ export default function ParticipantsSection({
   };
 
   return (
-    <section className="bg-white rounded-lg shadow p-4">
-      <h2 className="text-lg font-semibold mb-3 text-gray-900">Participants</h2>
+    <section className="bg-surface-1 rounded-lg shadow p-4">
+      <h2 className="text-lg font-semibold mb-3 text-text">Participants</h2>
       
       {/* Add Participant Section */}
       {userProfile && (
@@ -195,8 +195,8 @@ export default function ParticipantsSection({
               size="sm"
               className={`px-3 py-1 text-sm ${
                 !isSearchMode
-                  ? 'bg-blue-100 text-blue-800 border border-blue-200'
-                  : 'bg-gray-100 text-gray-700 border border-gray-200 hover:bg-gray-200'
+                  ? 'bg-accent/10 text-accent border border-accent/20'
+                  : 'bg-surface-3 text-text-2 border border-border hover:bg-surface-2'
               }`}
             >
               Add by Name
@@ -207,8 +207,8 @@ export default function ParticipantsSection({
               size="sm"
               className={`px-3 py-1 text-sm ${
                 isSearchMode
-                  ? 'bg-blue-100 text-blue-800 border border-blue-200'
-                  : 'bg-gray-100 text-gray-700 border border-gray-200 hover:bg-gray-200'
+                  ? 'bg-accent/10 text-accent border border-accent/20'
+                  : 'bg-surface-3 text-text-2 border border-border hover:bg-surface-2'
               }`}
             >
               Add Registered User
@@ -264,9 +264,9 @@ export default function ParticipantsSection({
 
               {/* Dropdown */}
               {showDropdown && (
-                <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
+                <div className="absolute z-10 w-full mt-1 bg-surface-1 border border-border rounded-md shadow-lg max-h-60 overflow-y-auto">
                   {loadingUsers ? (
-                    <div className="p-3 text-gray-600">Loading users...</div>
+                    <div className="p-3 text-text-3">Loading users...</div>
                   ) : filteredUsers.length > 0 ? (
                     filteredUsers.map((user) => (
                       <Button
@@ -278,16 +278,16 @@ export default function ParticipantsSection({
                         }}
                         variant="ghost"
                         size="sm"
-                        className="w-full text-left p-3 hover:bg-gray-50 border-b border-gray-100 last:border-b-0 focus:bg-blue-50"
+                        className="w-full text-left p-3 hover:bg-surface-2 border-b border-border last:border-b-0 focus:bg-accent/10"
                       >
-                        <div className="font-medium text-gray-900">{user.displayName}</div>
-                        <div className="text-sm text-gray-600">{user.email}</div>
+                        <div className="font-medium text-text">{user.displayName}</div>
+                        <div className="text-sm text-text-3">{user.email}</div>
                       </Button>
                     ))
                   ) : searchQuery.trim() ? (
-                      <div className="p-3 text-gray-600">No users found matching &quot;{searchQuery}&quot;</div>
+                      <div className="p-3 text-text-3">No users found matching &quot;{searchQuery}&quot;</div>
                   ) : (
-                    <div className="p-3 text-gray-600">Start typing to search users...</div>
+                    <div className="p-3 text-text-3">Start typing to search users...</div>
                   )}
                 </div>
               )}
@@ -297,7 +297,7 @@ export default function ParticipantsSection({
       )}
       
       {error && (
-        <div className="text-red-600 text-sm mb-3 bg-red-50 border border-red-200 rounded p-2">
+        <div className="text-error text-sm mb-3 bg-error/10 border border-error/20 rounded p-2">
           {error}
         </div>
       )}
@@ -305,7 +305,7 @@ export default function ParticipantsSection({
       {/* Participants List */}
       <ul className="space-y-2">
         {participants.length === 0 ? (
-          <li className="text-gray-700 italic py-2">No participants yet. Add someone above!</li>
+          <li className="text-text-2 italic py-2">No participants yet. Add someone above!</li>
         ) : (
           participants.map((p) => (
             <li key={p.id} className="flex items-center gap-2 py-2">
@@ -321,7 +321,7 @@ export default function ParticipantsSection({
                     onClick={saveEdit}
                     variant="ghost"
                     size="sm"
-                    className="text-blue-600 hover:text-blue-700 px-2 h-auto"
+                    className="text-accent hover:text-accent/80 px-2 h-auto"
                   >
                     Save
                   </Button>
@@ -329,7 +329,7 @@ export default function ParticipantsSection({
                     onClick={() => setEditingId(null)}
                     variant="ghost"
                     size="sm"
-                    className="text-gray-600 hover:text-gray-700 px-2 h-auto"
+                    className="text-text-3 hover:text-text-2 px-2 h-auto"
                   >
                     Cancel
                   </Button>
@@ -337,14 +337,14 @@ export default function ParticipantsSection({
               ) : (
                 <>
                   <span
-                    className={`flex-1 text-gray-900 ${userProfile?.isAdmin ? 'cursor-pointer hover:text-blue-600' : ''}`}
+                    className={`flex-1 text-text ${userProfile?.isAdmin ? 'cursor-pointer hover:text-accent' : ''}`}
                     onClick={() =>
                       userProfile?.isAdmin && startEdit(p.id, p.name)
                     }
                   >
                     {p.name}
                     {p.isRegistered && (
-                      <span className="ml-2 text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded font-medium">
+                      <span className="ml-2 text-xs bg-success/10 text-success px-2 py-0.5 rounded font-medium">
                         Registered
                       </span>
                     )}
@@ -354,7 +354,7 @@ export default function ParticipantsSection({
                       onClick={() => onDeleteParticipant(p.id)}
                       variant="ghost"
                       size="sm"
-                      className="text-red-600 hover:text-red-700 px-2 text-xl font-bold h-auto"
+                      className="text-error hover:text-error/90 px-2 text-xl font-bold h-auto"
                       aria-label={`Remove ${p.name}`}
                     >
                       ×

--- a/app/tools/trip-cost/components/TripDetail/PaymentHistory.tsx
+++ b/app/tools/trip-cost/components/TripDetail/PaymentHistory.tsx
@@ -23,15 +23,15 @@ export default function PaymentHistory({
   const name = (id: string) =>
     participants.find((p) => p.id === id)?.name || 'Unknown';
   return (
-    <section className="bg-white rounded shadow p-4">
+    <section className="bg-surface-1 rounded shadow p-4">
       <h2 className="text-lg font-semibold mb-2">Payments</h2>
-      <ul className="space-y-1 text-gray-800">
+      <ul className="space-y-1 text-text">
         {payments.map((p) => (
           <li key={p.id} className="flex items-center">
             <span className="flex-1">
               {name(p.payerId)} paid {name(p.payeeId)} {CURRENCY_SYMBOL}
               {p.amount.toFixed(2)}{' '}
-              <span className="text-gray-600 text-sm ml-2">
+              <span className="text-text-3 text-sm ml-2">
                 ({new Date(p.date).toLocaleDateString()})
               </span>
             </span>
@@ -40,7 +40,7 @@ export default function PaymentHistory({
                 onClick={() => onDeletePayment(p.id)}
                 variant="ghost"
                 size="sm"
-                className="text-red-600 text-xs ml-2 p-0 h-auto"
+                className="text-error hover:text-error/90 text-xs ml-2 p-0 h-auto"
               >
                 Delete
               </Button>

--- a/app/tools/trip-cost/components/TripDetail/SettlementSuggestions.tsx
+++ b/app/tools/trip-cost/components/TripDetail/SettlementSuggestions.tsx
@@ -14,28 +14,28 @@ export default function SettlementSuggestions() {
   
   if (!settlements.length) {
     return (
-      <section className="bg-white rounded-lg shadow p-4">
-        <h2 className="text-xl font-semibold mb-3 text-gray-900">Settlement Suggestions</h2>
-        <p className="text-gray-600 italic">All balances are settled!</p>
+      <section className="bg-surface-1 rounded-lg shadow p-4">
+        <h2 className="text-xl font-semibold mb-3 text-text">Settlement Suggestions</h2>
+        <p className="text-text-3 italic">All balances are settled!</p>
       </section>
     );
   }
-  
+
   return (
-    <section className="bg-white rounded-lg shadow p-4">
-      <h2 className="text-xl font-semibold mb-3 text-gray-900">Settlement Suggestions</h2>
-      <p className="text-sm text-gray-600 mb-3">
+    <section className="bg-surface-1 rounded-lg shadow p-4">
+      <h2 className="text-xl font-semibold mb-3 text-text">Settlement Suggestions</h2>
+      <p className="text-sm text-text-3 mb-3">
         Optimal payments to settle all balances:
       </p>
       <ul className="space-y-2">
         {settlements.map((s, idx) => (
-          <li key={idx} className="flex items-center p-2 bg-amber-50 rounded-lg border border-amber-200">
+          <li key={idx} className="flex items-center p-2 bg-warning/10 rounded-lg border border-warning/20">
             <div className="flex-1">
-              <span className="font-medium text-gray-900">{s.from}</span>
-              <span className="text-gray-600 mx-2">→</span>
-              <span className="font-medium text-gray-900">{s.to}</span>
+              <span className="font-medium text-text">{s.from}</span>
+              <span className="text-text-3 mx-2">→</span>
+              <span className="font-medium text-text">{s.to}</span>
             </div>
-            <span className="font-semibold text-amber-700">
+            <span className="font-semibold text-warning">
               {CURRENCY_SYMBOL}{s.amount.toFixed(2)}
             </span>
           </li>

--- a/app/tools/trip-cost/components/TripDetail/TripDetail.tsx
+++ b/app/tools/trip-cost/components/TripDetail/TripDetail.tsx
@@ -42,29 +42,29 @@ export default function TripDetail({
 
   if (!trip) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-gray-600">Loading trip details...</div>
+      <div className="min-h-screen bg-surface-2 flex items-center justify-center">
+        <div className="text-text-3">Loading trip details...</div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-surface-2">
       <div className="max-w-7xl mx-auto p-4">
         <div className="space-y-4">
           {/* Header */}
-          <header className="bg-white rounded-lg shadow p-4">
+          <header className="bg-surface-1 rounded-lg shadow p-4">
             <div className="flex items-center justify-between">
               <Button
                 onClick={onBack}
                 variant="ghost"
                 size="sm"
-                className="text-blue-600 hover:underline p-0 h-auto"
+                className="text-accent hover:underline p-0 h-auto"
               >
                 ← Back to trips
               </Button>
-              <h1 className="text-2xl font-bold text-gray-800">{trip.name}</h1>
-              <div className="text-gray-600 text-sm">
+              <h1 className="text-2xl font-bold text-text">{trip.name}</h1>
+              <div className="text-text-3 text-sm">
                 {expenses.length} expense{expenses.length !== 1 ? 's' : ''} · {payments.length} payment{payments.length !== 1 ? 's' : ''}
               </div>
             </div>

--- a/app/tools/trip-cost/components/TripList.tsx
+++ b/app/tools/trip-cost/components/TripList.tsx
@@ -32,24 +32,24 @@ export default function TripList({
   onLogout,
 }: TripListProps) {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-surface-2">
       <div className="max-w-7xl mx-auto p-4">
         {/* Header */}
-        <div className="bg-white rounded-lg shadow mb-6 p-4">
+        <div className="bg-surface-1 rounded-lg shadow mb-6 p-4">
           <div className="flex justify-between items-center">
-            <h1 className="text-2xl font-bold text-gray-900">Trip Cost Calculator</h1>
+            <h1 className="text-2xl font-bold text-text">Trip Cost Calculator</h1>
             <div className="flex items-center gap-4">
-              <span className="text-gray-900">
+              <span className="text-text">
                 {userProfile?.displayName}
                 {userProfile?.isAdmin && (
-                  <span className="ml-2 text-xs bg-purple-100 text-purple-700 px-2 py-1 rounded">Admin</span>
+                  <span className="ml-2 text-xs bg-purple/10 text-purple px-2 py-1 rounded">Admin</span>
                 )}
               </span>
               <Button
                 onClick={onLogout}
                 variant="secondary"
                 size="sm"
-                className="px-4 py-2 text-sm text-gray-900"
+                className="px-4 py-2 text-sm text-text"
               >
                 Log out
               </Button>
@@ -59,7 +59,7 @@ export default function TripList({
 
         {/* Create Trip (Admin) */}
         {userProfile?.isAdmin && (
-          <div className="bg-white rounded-lg shadow mb-6 p-4">
+          <div className="bg-surface-1 rounded-lg shadow mb-6 p-4">
             <div className="flex gap-3">
               <Input
                 type="text"
@@ -83,10 +83,10 @@ export default function TripList({
         {/* Trip Cards */}
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {trips.map((trip) => (
-            <div key={trip.id} className="bg-white rounded-lg shadow hover:shadow-lg transition-shadow">
+            <div key={trip.id} className="bg-surface-1 rounded-lg shadow hover:shadow-lg transition-shadow">
               <div className="p-4">
-                <h2 className="text-lg font-semibold text-gray-900 mb-2">{trip.name}</h2>
-                <div className="space-y-1 text-sm text-gray-800 mb-4">
+                <h2 className="text-lg font-semibold text-text mb-2">{trip.name}</h2>
+                <div className="space-y-1 text-sm text-text mb-4">
                   <p>{trip.participants.length} participant{trip.participants.length !== 1 && 's'}</p>
                   <p>{trip.expenses.length} expense{trip.expenses.length !== 1 && 's'}</p>
                   <p>{trip.payments.length} payment{trip.payments.length !== 1 && 's'}</p>
@@ -113,7 +113,7 @@ export default function TripList({
           ))}
 
           {trips.length === 0 && (
-            <div className="col-span-full text-center py-12 text-gray-800">
+            <div className="col-span-full text-center py-12 text-text">
               {userProfile?.isAdmin
                 ? 'No trips yet. Create your first trip above!'
                 : 'No trips available. Ask an admin to add you to a trip.'}

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -6,7 +6,7 @@ import { Loader2 } from 'lucide-react';
 /* CONFIGURATION: button variant and size classes               */
 /* ------------------------------------------------------------ */
 const buttonVariants = cva(
-  'inline-flex items-center justify-center font-medium rounded-lg focus-ring transition disabled:opacity-50 disabled:pointer-events-none',
+  'inline-flex items-center justify-center font-medium rounded-lg transition focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
   {
     variants: {
       variant: {

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -16,7 +16,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const autoId = React.useId();
     const inputId = id ?? autoId;
 
-    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-3 py-2 focus:border-accent focus:ring-2 focus:ring-accent`;
+    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-3 py-2 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2`;
 
     const inputElement = (
       <input

--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -16,7 +16,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     const autoId = React.useId();
     const selectId = id ?? autoId;
 
-    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-3 py-2 focus:border-accent focus:ring-2 focus:ring-accent`;
+    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-3 py-2 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2`;
 
     const selectElement = (
       <select


### PR DESCRIPTION
## Summary
- refactor trip cost calculator to use theme text, surface, and border colors
- add focus ring styling to buttons and form controls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689bc718ef048320aa3c9b93d01ca21b