### PR TITLE
refactor: remove tailwind cdn and add shared styles

### DIFF
--- a/public/games/Emeril_A_World_Divided/index.html
+++ b/public/games/Emeril_A_World_Divided/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Emeril: A World Divided</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/shared-styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700;800&family=Lato:wght@300;400;700&display=swap" rel="stylesheet">

--- a/public/games/noir_detective_idea/index.html
+++ b/public/games/noir_detective_idea/index.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Shadows Over Boston: A Monster Noir Adventure</title>
-
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/shared-styles.css">
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/shared-styles.css
+++ b/public/shared-styles.css
@@ -1,0 +1,107 @@
+/* Configuration: theme variables */
+:root {
+  --bg: 210 40% 98%;
+  --surface-1: 0 0% 100%;
+  --surface-2: 210 40% 96%;
+  --surface-3: 210 40% 94%;
+  --border: 214 32% 91%;
+
+  --text: 222 47% 11%;
+  --text-2: 215 25% 27%;
+  --text-3: 215 16% 47%;
+
+  --accent: 186 100% 40%;
+  --accent-600: 186 100% 30%;
+  --magenta: 334 100% 45%;
+  --purple: 278 100% 47%;
+
+  --success: 142 72% 45%;
+  --warning: 42 96% 50%;
+  --error: 0 84% 60%;
+  --info: 199 92% 60%;
+}
+
+[data-theme="dark"] {
+  --bg: 220 43% 8%;
+  --surface-1: 222 47% 13%;
+  --surface-2: 220 28% 12%;
+  --surface-3: 215 28% 17%;
+  --border: 214 30% 20%;
+
+  --text: 210 20% 92%;
+  --text-2: 215 14% 63%;
+  --text-3: 220 9% 46%;
+
+  --accent: 186 100% 50%;
+  --accent-600: 186 100% 42%;
+  --magenta: 334 100% 55%;
+  --purple: 278 100% 57%;
+}
+
+/* Base styles */
+body {
+  background: hsl(var(--bg));
+  color: hsl(var(--text));
+  font-family: sans-serif;
+}
+
+/* Color utilities */
+.text-primary { color: hsl(var(--text)); }
+.text-secondary { color: hsl(var(--text-2)); }
+.text-tertiary { color: hsl(var(--text-3)); }
+.text-accent { color: hsl(var(--accent)); }
+
+.bg-background { background-color: hsl(var(--bg)); }
+.bg-surface { background-color: hsl(var(--surface-1)); }
+.border-default { border-color: hsl(var(--border)); }
+
+/* Wildcard fallbacks for legacy classes */
+[class*="text-gray"] { color: hsl(var(--text)); }
+[class*="text-blue"] { color: hsl(var(--accent)); }
+[class*="text-red"] { color: hsl(var(--accent)); }
+[class*="bg-white"], [class*="bg-gray"] { background-color: hsl(var(--surface-1)); }
+[class*="border-gray"] { border-color: hsl(var(--border)); }
+
+/* Simple typography utilities */
+.text-center { text-align: center; }
+.font-bold { font-weight: 700; }
+.text-sm { font-size: 0.875rem; }
+.text-lg { font-size: 1.125rem; }
+.text-xl { font-size: 1.25rem; }
+.text-2xl { font-size: 1.5rem; }
+.text-3xl { font-size: 1.875rem; }
+.text-4xl { font-size: 2.25rem; }
+
+/* Spacing utilities */
+.p-2 { padding: 0.5rem; }
+.p-3 { padding: 0.75rem; }
+.p-4 { padding: 1rem; }
+.p-6 { padding: 1.5rem; }
+.p-8 { padding: 2rem; }
+.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.pt-6 { padding-top: 1.5rem; }
+.pb-6 { padding-bottom: 1.5rem; }
+.mt-2 { margin-top: 0.5rem; }
+.mb-6 { margin-bottom: 1.5rem; }
+.mb-8 { margin-bottom: 2rem; }
+.mb-10 { margin-bottom: 2.5rem; }
+.mb-12 { margin-bottom: 3rem; }
+.mt-10 { margin-top: 2.5rem; }
+.my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+
+/* Layout utilities */
+.flex { display: flex; }
+.items-center { align-items: center; }
+.grid { display: grid; }
+.gap-8 { gap: 2rem; }
+.w-full { width: 100%; }
+.rounded-lg { border-radius: 0.5rem; }
+.rounded-md { border-radius: 0.375rem; }
+.rounded-xl { border-radius: 0.75rem; }
+.shadow-lg { box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1); }
+.shadow-2xl { box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25); }
+.border { border-width: 1px; }
+.border-4 { border-width: 4px; }
+.border-double { border-style: double; }
+.underline-on-hover:hover { text-decoration: underline; }
+

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -7,7 +7,7 @@
   <title>3-Day Rolling Average Nutrition Tracker</title>
 
   <!-- UI libs -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/shared-styles.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">

--- a/public/tools/social-security-calculator/index.html
+++ b/public/tools/social-security-calculator/index.html
@@ -5,8 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Social Security Financial Planner — Fixed</title>
 
-  <!-- Tailwind (CDN) -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/shared-styles.css">
 
   <!-- Chart.js v4 and compatible Annotation plugin v3 -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>

--- a/public/tools/social-security/index.html
+++ b/public/tools/social-security/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>An Interactive Guide to Your Social Security</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/shared-styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/public/trips/ChicagoTripItinerary/index.html
+++ b/public/trips/ChicagoTripItinerary/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chicago Weekend Itinerary!</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/shared-styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -15,7 +15,6 @@
         }
         body {
             font-family: 'Poppins', sans-serif;
-            background-color: #f0f2f5;
         }
         .timeline-item::before {
             content: '';
@@ -26,11 +25,11 @@
             width: 20px;
             height: 20px;
             border-radius: 50%;
-            background-color: #FC913A;
-            border: 4px solid #E1F5C4;
+            background-color: hsl(var(--accent));
+            border: 4px solid hsl(var(--surface-1));
         }
         .day-card {
-            border-left: 4px solid #FC913A;
+            border-left: 4px solid hsl(var(--accent));
         }
         .schedule-grid {
             position: relative;
@@ -45,21 +44,21 @@
             justify-content: flex-end;
             padding-right: 10px;
             font-size: 12px;
-            color: #6b7280;
+            color: hsl(var(--text-2));
             position: relative;
             transform: translateY(-50%);
             z-index: 15;
         }
         .time-label-hour {
             font-weight: 600;
-            color: #374151;
+            color: hsl(var(--text));
         }
         .time-label-hour span {
-            background-color: #fff;
+            background-color: hsl(var(--surface-1));
             padding: 0 4px;
         }
          .time-label-half {
-            color: #9ca3af;
+            color: hsl(var(--text-3));
         }
         .day-header {
             text-align: center;
@@ -67,12 +66,12 @@
             padding: 8px 0;
             position: sticky;
             top: 0;
-            background-color: #f0f2f5;
+            background-color: hsl(var(--surface-2));
             z-index: 20;
         }
         .activity-block {
             border-radius: 8px;
-            color: #374151;
+            color: hsl(var(--text));
             padding: 4px 8px;
             font-size: 12px;
             line-height: 1.2;
@@ -84,7 +83,7 @@
             position: relative;
         }
         .grid-line {
-            border-top: 1px solid #e5e7eb;
+            border-top: 1px solid hsl(var(--border));
             grid-column: 2 / -1;
             z-index: 1;
         }
@@ -102,24 +101,24 @@
             transition: all 0.3s ease;
         }
         .tab-button.active {
-            border-color: #FF4E50;
-            background-color: #FF4E50;
+            border-color: hsl(var(--accent));
+            background-color: hsl(var(--accent));
             color: white;
         }
     </style>
 </head>
-<body class="text-gray-800">
-    <nav class="p-2 text-sm"><a href="/" class="text-blue-600 hover:underline">Back to Hub</a></nav>
+<body class="text-primary">
+    <nav class="p-2 text-sm"><a href="/" class="text-accent underline-on-hover">Back to Hub</a></nav>
 
-    <div class="p-4 md:p-8 w-full">
+    <div class="p-4 w-full">
 
         <header class="text-center mb-12">
-            <h1 class="text-4xl md:text-5xl font-bold text-[#FF4E50]">Welcome to Chicago!</h1>
-            <p class="text-lg text-gray-600 mt-2">A Visual Itinerary for Your July 4th Weekend Visit</p>
+            <h1 class="text-4xl font-bold text-accent">Welcome to Chicago!</h1>
+            <p class="text-lg text-secondary mt-2">A Visual Itinerary for Your July 4th Weekend Visit</p>
         </header>
 
-        <section class="mb-12 bg-white rounded-xl shadow-lg p-4 md:p-6">
-            <h2 class="text-2xl font-bold text-gray-800 mb-4 text-center">Weekend at a Glance</h2>
+        <section class="mb-12 bg-surface rounded-xl shadow-lg p-4">
+            <h2 class="text-2xl font-bold text-primary mb-4 text-center">Weekend at a Glance</h2>
             
             <!-- This container will scroll horizontally on smaller screens -->
             <div class="overflow-x-auto">


### PR DESCRIPTION
## Summary
- add shared-styles.css with theme variables and basic utilities
- remove Tailwind CDN from public HTML pages and reference shared stylesheet
- align Chicago trip itinerary colors with main theme

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689bcae723d08320bed099338fccb784