### PR TITLE
style: unify card styling

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -5,20 +5,22 @@ import Nav from '@/components/Nav';
 import { ArrowRight, Drama, Swords } from 'lucide-react';
 
 /* ------------------------------------------------------------ */
-/* CONFIGURATION: list of available games                       */
+/* CONFIGURATION: icon size and list of available games          */
 /* ------------------------------------------------------------ */
+const cardIconSize = 24;
+
 const gameList = [
   {
     name: 'Noir Detective Idea',
     description: 'An interactive detective story concept (Static HTML).',
     href: '/games/noir_detective_idea/index.html',
-    icon: <Drama size={24} className="text-purple" />,
+    icon: <Drama size={cardIconSize} className="text-accent" />,
   },
   {
     name: 'Emeril: A World Divided',
     description: 'An interactive lore page for a world of lost magic and warring factions.',
     href: '/games/Emeril_A_World_Divided/index.html',
-    icon: <Swords size={24} className="text-accent" />,
+    icon: <Swords size={cardIconSize} className="text-accent" />,
   },
 ];
 
@@ -37,10 +39,10 @@ export default function GamesPage() {
             <Link
               href={game.href}
               key={game.name}
-              className="group block rounded-xl3 border border-border bg-surface-1 p-6 shadow-1 transition duration-200 ease-linear hover:shadow-2 hover:shadow-glow focus-ring"
+              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-shadow transition-transform duration-200 hover:shadow-xl hover:scale-[1.02] focus-ring"
             >
               <div className="flex items-start">
-                <div className="mr-6 flex-shrink-0">{game.icon}</div>
+                <div className="mr-6 flex-shrink-0 text-accent">{game.icon}</div>
                 <div>
                   <h2 className="text-xl font-semibold">{game.name}</h2>
                   <p className="mt-1 text-text-2">{game.description}</p>

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -5,32 +5,34 @@ import Nav from '@/components/Nav';
 import { ArrowRight, Calculator, HeartPulse, BarChart } from 'lucide-react';
 
 /* ------------------------------------------------------------ */
-/* CONFIGURATION: list of available tools                       */
+/* CONFIGURATION: icon size and list of available tools          */
 /* ------------------------------------------------------------ */
+const cardIconSize = 24;
+
 const toolList = [
   {
     name: 'Trip Cost Calculator',
     description: 'Split expenses and calculate balances for a group trip.',
     href: '/tools/trip-cost',
-    icon: <Calculator size={24} className="text-purple" />,
+    icon: <Calculator size={cardIconSize} className="text-accent" />,
   },
   {
     name: 'Calorie Tracker',
     description: 'A simple tool to track daily calorie intake (Static HTML).',
     href: '/tools/CalorieTracker/index.html',
-    icon: <HeartPulse size={24} className="text-error" />,
+    icon: <HeartPulse size={cardIconSize} className="text-accent" />,
   },
   {
     name: 'Social Security (interactive guide)',
     description: 'Learn how benefits and earnings interact through simulations.',
     href: '/tools/social-security/index.html',
-    icon: <BarChart size={24} className="text-info" />,
+    icon: <BarChart size={cardIconSize} className="text-accent" />,
   },
   {
     name: 'Social Security (calculator)',
     description: 'Visualize the financial impact of different claiming strategies.',
     href: '/tools/social-security-calculator/index.html',
-    icon: <BarChart size={24} className="text-success" />,
+    icon: <BarChart size={cardIconSize} className="text-accent" />,
   },
 ];
 
@@ -49,10 +51,10 @@ export default function ToolsPage() {
             <Link
               href={tool.href}
               key={tool.name}
-              className="group block rounded-xl3 border border-border bg-surface-1 p-6 shadow-1 transition duration-200 ease-linear hover:shadow-2 hover:shadow-glow focus-ring"
+              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-shadow transition-transform duration-200 hover:shadow-xl hover:scale-[1.02] focus-ring"
             >
               <div className="flex items-start">
-                <div className="mr-6 flex-shrink-0">{tool.icon}</div>
+                <div className="mr-6 flex-shrink-0 text-accent">{tool.icon}</div>
                 <div>
                   <h2 className="text-xl font-semibold">{tool.name}</h2>
                   <p className="mt-1 text-text-2">{tool.description}</p>

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -5,14 +5,16 @@ import Nav from '@/components/Nav';
 import { ArrowRight, Map } from 'lucide-react';
 
 /* ------------------------------------------------------------ */
-/* CONFIGURATION: list of trips                                 */
+/* CONFIGURATION: icon size and list of trips                    */
 /* ------------------------------------------------------------ */
+const cardIconSize = 24;
+
 const tripList = [
   {
     name: 'Chicago Trip Itinerary',
     description: 'An itinerary for a trip to Chicago (Static HTML).',
     href: '/trips/ChicagoTripItinerary/index.html',
-    icon: <Map size={24} className="text-accent" />,
+    icon: <Map size={cardIconSize} className="text-accent" />,
   },
 ];
 
@@ -31,10 +33,10 @@ export default function TripsPage() {
             <Link
               href={trip.href}
               key={trip.name}
-              className="group block rounded-xl3 border border-border bg-surface-1 p-6 shadow-1 transition duration-200 ease-linear hover:shadow-2 hover:shadow-glow focus-ring"
+              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-shadow transition-transform duration-200 hover:shadow-xl hover:scale-[1.02] focus-ring"
             >
               <div className="flex items-start">
-                <div className="mr-6 flex-shrink-0">{trip.icon}</div>
+                <div className="mr-6 flex-shrink-0 text-accent">{trip.icon}</div>
                 <div>
                   <h2 className="text-xl font-semibold">{trip.name}</h2>
                   <p className="mt-1 text-text-2">{trip.description}</p>


### PR DESCRIPTION
## Summary
- unify card padding, rounding, shadows, and hover scale across Games, Tools, and Trips pages
- standardize card icons with a shared size and color

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689bcc474cc8832092829f3e8e1cb9df