### PR TITLE
Polish layout with Poppins, spacing, and transitions

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -39,16 +39,16 @@ export default function GamesPage() {
             <Link
               href={game.href}
               key={game.name}
-              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-shadow transition-transform duration-200 hover:shadow-xl hover:scale-[1.02] focus-ring"
+              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-all duration-200 ease-in-out hover:shadow-xl hover:scale-[1.02] focus-ring"
             >
               <div className="flex items-start">
                 <div className="mr-6 flex-shrink-0 text-accent">{game.icon}</div>
                 <div>
                   <h2 className="text-xl font-semibold">{game.name}</h2>
-                  <p className="mt-1 text-text-2">{game.description}</p>
+                  <p className="mt-4 text-text-2">{game.description}</p>
                 </div>
                 <div className="ml-auto pl-4 flex-shrink-0">
-                  <ArrowRight size={24} className="text-text-3 transition-transform duration-200 group-hover:translate-x-1 group-hover:text-accent" />
+                  <ArrowRight size={24} className="text-text-3 transition-all duration-200 ease-in-out group-hover:translate-x-1 group-hover:text-accent" />
                 </div>
               </div>
             </Link>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" data-theme="dark">
-      <body className={`${poppins.variable} min-h-dvh bg-bg text-text`}>
+      <body className={`${poppins.variable} min-h-dvh bg-bg text-text font-sans`}>
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,8 +28,8 @@ export default function Home() {
                 href={link.href}
                 className={
                   link.href === '/games'
-                    ? 'rounded-xl3 bg-accent text-black px-6 py-3 font-medium shadow-glow transition hover:brightness-110 focus-ring'
-                    : 'rounded-xl3 border border-border text-text-2 px-6 py-3 transition hover:border-accent hover:text-text focus-ring'
+                    ? 'rounded-xl3 bg-accent text-black px-6 py-4 font-medium shadow-glow transition-all duration-200 ease-in-out hover:brightness-110 focus-ring'
+                    : 'rounded-xl3 border border-border text-text-2 px-6 py-4 transition-all duration-200 ease-in-out hover:border-accent hover:text-text focus-ring'
                 }
               >
                 {link.label}

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -51,16 +51,16 @@ export default function ToolsPage() {
             <Link
               href={tool.href}
               key={tool.name}
-              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-shadow transition-transform duration-200 hover:shadow-xl hover:scale-[1.02] focus-ring"
+              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-all duration-200 ease-in-out hover:shadow-xl hover:scale-[1.02] focus-ring"
             >
               <div className="flex items-start">
                 <div className="mr-6 flex-shrink-0 text-accent">{tool.icon}</div>
                 <div>
                   <h2 className="text-xl font-semibold">{tool.name}</h2>
-                  <p className="mt-1 text-text-2">{tool.description}</p>
+                  <p className="mt-4 text-text-2">{tool.description}</p>
                 </div>
                 <div className="ml-auto pl-4 flex-shrink-0">
-                  <ArrowRight size={24} className="text-text-3 transition-transform duration-200 group-hover:translate-x-1 group-hover:text-accent" />
+                  <ArrowRight size={24} className="text-text-3 transition-all duration-200 ease-in-out group-hover:translate-x-1 group-hover:text-accent" />
                 </div>
               </div>
             </Link>

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -33,16 +33,16 @@ export default function TripsPage() {
             <Link
               href={trip.href}
               key={trip.name}
-              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-shadow transition-transform duration-200 hover:shadow-xl hover:scale-[1.02] focus-ring"
+              className="group block rounded-xl border border-border bg-surface-1 p-6 shadow-md transition-all duration-200 ease-in-out hover:shadow-xl hover:scale-[1.02] focus-ring"
             >
               <div className="flex items-start">
                 <div className="mr-6 flex-shrink-0 text-accent">{trip.icon}</div>
                 <div>
                   <h2 className="text-xl font-semibold">{trip.name}</h2>
-                  <p className="mt-1 text-text-2">{trip.description}</p>
+                  <p className="mt-4 text-text-2">{trip.description}</p>
                 </div>
                 <div className="ml-auto pl-4 flex-shrink-0">
-                  <ArrowRight size={24} className="text-text-3 transition-transform duration-200 group-hover:translate-x-1 group-hover:text-accent" />
+                  <ArrowRight size={24} className="text-text-3 transition-all duration-200 ease-in-out group-hover:translate-x-1 group-hover:text-accent" />
                 </div>
               </div>
             </Link>

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -6,7 +6,7 @@ import { Loader2 } from 'lucide-react';
 /* CONFIGURATION: button variant and size classes               */
 /* ------------------------------------------------------------ */
 const buttonVariants = cva(
-  'inline-flex items-center justify-center font-medium rounded-lg transition focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
+  'inline-flex items-center justify-center font-medium rounded-lg transition-all duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
   {
     variants: {
       variant: {
@@ -17,9 +17,9 @@ const buttonVariants = cva(
         ghost: 'bg-transparent text-text hover:bg-surface-2',
       },
       size: {
-        sm: 'px-3 py-1.5 text-sm',
-        md: 'px-4 py-2',
-        lg: 'px-6 py-3 rounded-xl text-lg',
+        sm: 'px-4 py-4 text-sm',
+        md: 'px-6 py-6',
+        lg: 'px-8 py-8 rounded-xl text-lg',
       },
     },
     defaultVariants: {
@@ -45,7 +45,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         {loading && (
-          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+          <Loader2 className="mr-4 h-4 w-4 animate-spin" aria-hidden="true" />
         )}
         {children}
       </button>

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -16,7 +16,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const autoId = React.useId();
     const inputId = id ?? autoId;
 
-    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-3 py-2 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2`;
+    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-4 py-4 transition-all duration-200 ease-in-out hover:border-accent focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2`;
 
     const inputElement = (
       <input
@@ -34,12 +34,12 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className={wrapperClassName ? wrapperClassName : 'flex flex-col'}>
         {label && (
-          <label htmlFor={inputId} className="text-text-2 text-sm font-medium mb-1">
+          <label htmlFor={inputId} className="text-text-2 text-sm font-medium mb-4">
             {label}
           </label>
         )}
         {inputElement}
-        {error && <p className="text-error text-sm mt-1">{error}</p>}
+        {error && <p className="text-error text-sm mt-4">{error}</p>}
       </div>
     );
   }

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -14,18 +14,18 @@ const navLinks = [
   { label: 'Trips', href: '/trips' },
 ];
 
-const linkBaseClass = 'transition hover:text-text focus-ring';
+const linkBaseClass = 'transition-all duration-200 ease-in-out hover:text-text focus-ring';
 const activeLinkClass = 'text-text font-medium';
 const inactiveLinkClass = 'text-text-2';
 const mobileMenuTransition =
-  'transition-all duration-300 ease-in-out origin-top transform';
+  'transition-all duration-200 ease-in-out origin-top transform';
 
 export default function Nav() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   return (
     <header className="sticky top-0 z-50 backdrop-blur-md bg-surface-2/80 border-b border-border shadow-sm">
-      <nav className="container-tight flex items-center justify-between py-3">
+      <nav className="container-tight flex items-center justify-between py-4">
         <Link href="/" className={`text-lg font-semibold ${linkBaseClass}`}>
           JB
         </Link>
@@ -34,7 +34,7 @@ export default function Nav() {
           aria-expanded={open}
           variant="ghost"
           size="sm"
-          className="md:hidden p-2 border border-border hover:border-accent"
+          className="md:hidden p-4 border border-border hover:border-accent"
           onClick={() => setOpen(!open)}
         >
           {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -62,13 +62,13 @@ export default function Nav() {
             : 'scale-y-0 opacity-0 pointer-events-none'
         }`}
       >
-        <ul className="px-4 py-2 space-y-2">
+        <ul className="px-4 py-4 space-y-4">
           {navLinks.map((link) => {
             const isActive = pathname === link.href;
             return (
               <li key={link.href}>
                 <Link
-                  className={`block py-2 ${linkBaseClass} ${isActive ? activeLinkClass : inactiveLinkClass}`}
+                  className={`block py-4 ${linkBaseClass} ${isActive ? activeLinkClass : inactiveLinkClass}`}
                   href={link.href}
                   onClick={() => setOpen(false)}
                 >

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -7,19 +7,19 @@ type Props = { title: string; description: string; tags?: string[]; href?: strin
 
 export default function ProjectCard({ title, description, tags = [], href = defaultHref, imageUrl }: Props) {
   return (
-    <a href={href} className="group block rounded-xl3 overflow-hidden border border-border bg-surface-1 shadow-1 transition duration-200 ease-linear hover:shadow-2 hover:shadow-glow focus-ring">
+    <a href={href} className="group block rounded-xl3 overflow-hidden border border-border bg-surface-1 shadow-1 transition-all duration-200 ease-in-out hover:shadow-2 hover:shadow-glow focus-ring">
       {imageUrl && (
         <div className="aspect-[16/9] overflow-hidden">
           <img src={imageUrl} alt="" className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]" />
         </div>
       )}
-      <div className="p-5">
-        <h3 className="text-2xl font-semibold mb-1">{title}</h3>
+      <div className="p-6">
+        <h3 className="text-2xl font-semibold mb-4">{title}</h3>
         <p className="text-text-2">{description}</p>
         {tags.length > 0 && (
-          <div className="mt-4 flex flex-wrap gap-2">
+          <div className="mt-4 flex flex-wrap gap-4">
             {tags.map((tag) => (
-              <span key={tag} className="inline-flex items-center rounded-full border border-border px-2.5 py-1 text-[12px] text-text-2 group-hover:border-accent">
+              <span key={tag} className="inline-flex items-center rounded-full border border-border px-4 py-4 text-[12px] text-text-2 group-hover:border-accent">
                 {tag}
               </span>
             ))}

--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -16,7 +16,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     const autoId = React.useId();
     const selectId = id ?? autoId;
 
-    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-3 py-2 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2`;
+    const baseClasses = `bg-surface-1 border ${error ? 'border-error' : 'border-border'} text-text placeholder:text-text-3 rounded-lg px-4 py-4 transition-all duration-200 ease-in-out hover:border-accent focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2`;
 
     const selectElement = (
       <select
@@ -36,12 +36,12 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <div className={wrapperClassName ? wrapperClassName : 'flex flex-col'}>
         {label && (
-          <label htmlFor={selectId} className="text-text-2 text-sm font-medium mb-1">
+          <label htmlFor={selectId} className="text-text-2 text-sm font-medium mb-4">
             {label}
           </label>
         )}
         {selectElement}
-        {error && <p className="text-error text-sm mt-1">{error}</p>}
+        {error && <p className="text-error text-sm mt-4">{error}</p>}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- apply Poppins font globally and refine spacing scale
- add hover/focus/animation states to interactive elements
- unify page and component spacing for mobile responsiveness

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689bcd4bd9248320b9a86b44495cebb1