### PR TITLE
refactor: modernize calorie tracker styling

### DIFF
--- a/public/shared-styles.css
+++ b/public/shared-styles.css
@@ -140,6 +140,7 @@ body {
 .kpi .kpi-value { font-weight:700; font-size:1.5rem; color:hsl(var(--text)); }
 .kpi .kpi-delta.positive { color:hsl(var(--success)); }
 .kpi .kpi-delta.negative { color:hsl(var(--error)); }
+.kpi .kpi-delta.neutral  { color:hsl(var(--text-3)); }
 /* ---------- Semantic text ---------- */
 .text-primary  { color: hsl(var(--text)); }
 .text-secondary{ color: hsl(var(--text-2)); }
@@ -174,6 +175,10 @@ body {
 .btn-danger:hover { filter: brightness(.95); }
 .btn-success  { background: hsl(var(--success)); color: #fff; }
 .btn-warning  { background: hsl(var(--warning)); color: #000; }
+.btn-secondary{ background: hsl(var(--surface-2)); color: hsl(var(--text)); border-color: hsl(var(--border)); }
+.btn-secondary:hover { filter: brightness(.95); }
+.btn-muted   { background: hsl(var(--surface-2)); color: hsl(var(--text-3)); border-color: hsl(var(--border)); }
+.btn-muted:hover { filter: brightness(.95); }
 .btn-ghost    { background: transparent; color: hsl(var(--text)); border-color: hsl(var(--border)); }
 .icon-btn     { width: 2.25rem; height: 2.25rem; padding: 0; }
 
@@ -187,14 +192,7 @@ body {
 .badge-warn { background: color-mix(in hsl, hsl(var(--warning)) 15%, hsl(var(--surface-1))); color: hsl(var(--warning)); border-color: color-mix(in hsl, hsl(var(--warning)) 30%, hsl(var(--surface-1))); }
 .badge-bad  { background: color-mix(in hsl, hsl(var(--error)) 15%, hsl(var(--surface-1))); color: hsl(var(--error)); border-color: color-mix(in hsl, hsl(var(--error)) 30%, hsl(var(--surface-1))); }
 
-/* ---------- KPI tile & progress ---------- */
-.kpi { padding: 1rem; }
-.kpi-title { color: hsl(var(--text-2)); font-weight: 600; }
-.kpi-value { color: hsl(var(--text)); font-weight: 800; font-size: 1.4rem; }
-.kpi-diff.negative { color: hsl(var(--error)); }
-.kpi-diff.positive { color: hsl(var(--success)); }
-.kpi-diff.neutral  { color: hsl(var(--text-3)); }
-
+/* ---------- Progress Bars ---------- */
 .progress { height: .5rem; background: hsl(var(--surface-3)); border-radius: .5rem; overflow: hidden; }
 .progress > .fill { height: 100%; }
 .fill.good { background: hsl(var(--success)); }

--- a/public/tools/CalorieTracker/food/manager.js
+++ b/public/tools/CalorieTracker/food/manager.js
@@ -86,16 +86,16 @@ export function openFoodManager() {
   const list = Array.from(state.savedFoodItems.entries()).sort(([, a], [, b]) => (a.name || '').localeCompare(b.name || ''));
 
   container.innerHTML = list.map(([id, f]) => `
-    <div class="flex justify-between items-center p-3 border-b border-gray-200">
+    <div class="flex justify-between items-center p-3 border-b border-default">
       <div>
         <div class="font-medium">${f.name}</div>
-        <div class="text-sm text-gray-500">Cal: ${f.calories || 0} | P: ${f.protein || 0} / C: ${f.carbs || 0} / F: ${f.fat || 0}</div>
+        <div class="text-sm text-muted">Cal: ${f.calories || 0} | P: ${f.protein || 0} / C: ${f.carbs || 0} / F: ${f.fat || 0}</div>
       </div>
       <div class="flex gap-2">
-        <button onclick="editFoodItem('${id}')" class="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700">Edit</button>
-        <button onclick="deleteFoodItemFromManager('${id}')" class="px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Delete</button>
+        <button onclick="editFoodItem('${id}')" class="btn btn-primary text-sm">Edit</button>
+        <button onclick="deleteFoodItemFromManager('${id}')" class="btn btn-danger text-sm">Delete</button>
       </div>
-    </div>`).join('') || '<p class="text-gray-500 text-center p-4">No saved food items.</p>';
+    </div>`).join('') || '<p class="text-muted text-center p-4">No saved food items.</p>';
 
   modal.classList.remove('hidden');
 }

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -18,26 +18,6 @@
     /* CONFIGURATION: Dark theme colors matching main site          */
     /* ------------------------------------------------------------ */
     :root {
-      --bg: 220 43% 8%;
-      --surface-1: 222 47% 13%;
-      --surface-2: 220 28% 12%;
-      --surface-3: 215 28% 17%;
-      --border: 214 30% 20%;
-
-      --text: 210 20% 92%;
-      --text-2: 215 14% 63%;
-      --text-3: 220 9% 46%;
-
-      --accent: 186 100% 50%;
-      --accent-600: 186 100% 42%;
-      --magenta: 334 100% 55%;
-      --purple: 278 100% 57%;
-
-      --success: 142 72% 45%;
-      --warning: 42 96% 50%;
-      --error: 0 84% 60%;
-      --info: 199 92% 60%;
-
       --shadow-1: 0 1px 2px 0 rgb(0 0 0 / 0.30);
       --shadow-2: 0 6px 24px rgb(0 0 0 / 0.50);
       --shadow-glow: 0 0 0 2px hsl(var(--accent) / 0.35), 0 0 24px 4px hsl(var(--accent) / 0.35);
@@ -106,7 +86,6 @@
 
     .border { border: 1px solid hsl(var(--border)); }
     .border-b { border-bottom: 1px solid hsl(var(--border)); }
-    .border-border { border-color: hsl(var(--border)); }
 
     .flex { display: flex; }
     .flex-col { flex-direction: column; }
@@ -234,51 +213,6 @@
       box-shadow: 0 0 0 3px hsl(var(--accent) / 0.1);
     }
 
-    /* Button styling matching main site */
-    .btn-primary {
-      background: hsl(var(--accent));
-      color: black;
-      font-weight: 600;
-      padding: 0.75rem 1.5rem;
-      border-radius: 1rem;
-      transition: all 0.2s;
-      box-shadow: var(--shadow-glow);
-      border: none;
-      cursor: pointer;
-    }
-    .btn-primary:hover { transform: translateY(-2px); filter: brightness(1.1); }
-
-    .btn-secondary {
-      background: hsl(var(--surface-2));
-      color: hsl(var(--text));
-      border: 1px solid hsl(var(--border));
-      padding: 0.75rem 1.5rem;
-      border-radius: 1rem;
-      transition: all 0.2s;
-      cursor: pointer;
-    }
-    .btn-secondary:hover { border-color: hsl(var(--accent)); color: hsl(var(--accent)); }
-
-    .btn-danger {
-      background: hsl(var(--error));
-      color: white;
-      border: none;
-      padding: 0.75rem 1.5rem;
-      border-radius: 1rem;
-      cursor: pointer;
-      transition: filter .2s;
-    }
-    .btn-danger:hover { filter: brightness(1.05); }
-
-    .btn-muted {
-      background: hsl(var(--surface-3));
-      color: hsl(var(--text-2));
-      border: 1px solid hsl(var(--border));
-      padding: .5rem .75rem;
-      border-radius: .625rem;
-      cursor: pointer;
-    }
-
     /* Modal styling */
     .modal-backdrop {
       background: rgba(0, 0, 0, 0.8);
@@ -315,16 +249,6 @@
       border-radius: 0.5rem;
     }
 
-    /* Status colors */
-    .text-success { color: hsl(var(--success)); }
-    .text-error { color: hsl(var(--error)); }
-    .text-warning { color: hsl(var(--warning)); }
-    .text-info { color: hsl(var(--info)); }
-    .text-accent { color: hsl(var(--accent)); }
-    .text-text-2 { color: hsl(var(--text-2)); }
-    .text-text-3 { color: hsl(var(--text-3)); }
-
-    /* Message box */
     #message-box {
       background: hsl(var(--surface-1));
       border: 1px solid hsl(var(--accent));
@@ -343,7 +267,7 @@
 </head>
 
 <body>
-  <nav class="p-4 border-b border-border">
+  <nav class="surface-1 text-primary p-4 border-b border-default">
     <a href="/" class="text-accent" style="text-decoration:none;">
       ← Back to Hub
     </a>
@@ -354,32 +278,32 @@
     <i class="fas fa-spinner fa-spin fa-3x text-accent"></i>
   </div>
 
-  <div id="main-content" class="hidden">
-    <header class="section-card p-6 mb-8 flex justify-between items-center">
+  <div id="main-content" class="hidden surface-1 text-primary">
+    <header class="section-card surface-1 text-primary p-6 mb-8 flex justify-between items-center">
       <div class="flex items-center">
         <i class="fas fa-chart-pie text-3xl text-accent" style="margin-right:.75rem;"></i>
         <h1 class="text-2xl font-bold">3-Day Rolling Nutrition Tracker</h1>
       </div>
       <div class="flex items-center space-x-4">
-        <span id="user-status" class="text-text-2 text-sm hidden"></span>
-        <button id="open-login-btn" class="btn-primary">Login / Sign Up</button>
-        <button id="logout-btn" class="hidden btn-secondary">Logout</button>
-        <button id="open-settings-btn" class="btn-secondary" title="Settings"><i class="fas fa-cog"></i></button>
+        <span id="user-status" class="text-primary text-sm hidden"></span>
+        <button id="open-login-btn" class="btn btn-primary">Login / Sign Up</button>
+        <button id="logout-btn" class="hidden btn btn-secondary">Logout</button>
+        <button id="open-settings-btn" class="btn btn-secondary" title="Settings"><i class="fas fa-cog"></i></button>
       </div>
     </header>
 
-    <main class="p-4 grid grid-cols-1 lg:grid-cols-3 gap-8">
+    <main class="p-4 grid grid-cols-1 lg:grid-cols-3 gap-8 text-primary">
       <!-- LEFT COLUMN -->
-      <div class="lg:col-span-1 section-card h-fit">
-        <h2 class="text-2xl font-bold mb-4 text-accent">Daily Log</h2>
+      <div class="lg:col-span-1 section-card surface-1 text-primary h-fit">
+        <h2 class="text-2xl font-bold mb-4 text-secondary">Daily Log</h2>
 
         <div class="mb-4">
-          <label for="date-input" class="block text-sm font-medium text-text-2 mb-1">Date</label>
+          <label for="date-input" class="block text-sm font-medium text-primary mb-1">Date</label>
           <input type="date" id="date-input">
         </div>
 
         <div class="mb-4">
-          <label for="training-bump" class="block text-sm font-medium text-text-2 mb-1">Training Bump</label>
+          <label for="training-bump" class="block text-sm font-medium text-primary mb-1">Training Bump</label>
           <select id="training-bump">
             <option value="0">Rest Day (0 kcal)</option>
             <option value="100">Light Lift ≤45min (+100 kcal)</option>
@@ -389,32 +313,32 @@
         </div>
 
         <div class="mb-4">
-          <label for="paste-area" class="block text-sm font-medium text-text-2 mb-1">Paste Log to Stage</label>
+          <label for="paste-area" class="block text-sm font-medium text-primary mb-1">Paste Log to Stage</label>
           <textarea id="paste-area" rows="4" placeholder="Paste your log here..."></textarea>
-          <button type="button" id="parse-btn" class="w-full mt-2 btn-primary">
+          <button type="button" id="parse-btn" class="w-full mt-2 btn btn-primary">
             <i class="fas fa-arrow-down" style="margin-right:.5rem;"></i>Parse to Staging Area
           </button>
         </div>
 
-        <hr class="my-4 border-border">
-        <h3 class="text-xl font-semibold mb-2 text-accent">Staging Area</h3>
+        <hr class="my-4 border-default">
+        <h3 class="text-xl font-semibold mb-2 text-secondary">Staging Area</h3>
 
         <div class="flex justify-between items-center mb-4">
           <div class="flex gap-2">
-            <button type="button" id="replace-day-btn" class="btn-secondary text-sm" title="Replace today's entire log with staged values">Replace Day</button>
-            <button type="button" id="stage-to-targets-btn" class="btn-secondary text-sm" title="Update your baseline targets with staged values">Update Targets</button>
+            <button type="button" id="replace-day-btn" class="btn btn-primary text-sm" title="Replace today's entire log with staged values">Replace Day</button>
+            <button type="button" id="stage-to-targets-btn" class="btn btn-primary text-sm" title="Update your baseline targets with staged values">Update Targets</button>
           </div>
         </div>
 
         <!-- Food Database -->
         <div class="mb-4 p-3 staging-section">
           <div class="flex justify-between items-center mb-3">
-            <label class="block text-sm font-medium text-text-2">Food Item Database</label>
+            <label class="block text-sm font-medium text-primary">Food Item Database</label>
             <div class="flex gap-2">
-              <button type="button" id="save-food-item-btn" class="btn-secondary text-sm">
+              <button type="button" id="save-food-item-btn" class="btn btn-secondary text-sm">
                 <i class="fas fa-save" style="margin-right:.375rem;"></i>Save Food
               </button>
-              <button type="button" id="open-food-manager-btn" class="btn-secondary text-sm">
+              <button type="button" id="open-food-manager-btn" class="btn btn-ghost text-sm">
                 <i class="fas fa-list" style="margin-right:.375rem;"></i>Manage Foods
               </button>
             </div>
@@ -427,193 +351,193 @@
                 <div id="food-dropdown" class="food-dropdown-list hidden"></div>
               </div>
             </div>
-            <button type="button" id="add-day-btn" class="w-10 h-10 btn-primary rounded-lg flex items-center justify-center" title="Add staged nutrients to today's log">
+            <button type="button" id="add-day-btn" class="btn btn-success icon-btn" title="Add" aria-label="Add">
               <i class="fas fa-plus"></i>
             </button>
-            <button type="button" id="subtract-day-btn" class="w-10 h-10 btn-secondary rounded-lg flex items-center justify-center" title="Subtract staged nutrients from today's log">
+            <button type="button" id="subtract-day-btn" class="btn btn-warning icon-btn" title="Subtract" aria-label="Subtract">
               <i class="fas fa-minus"></i>
             </button>
           </div>
 
           <div class="mt-3">
-            <h4 class="text-sm font-semibold text-text-2 mb-2">Today's Food Items:</h4>
+            <h4 class="text-sm font-semibold text-secondary mb-2">Today's Food Items:</h4>
             <div id="food-items-list" class="food-items-container space-y-2 overflow-y-auto p-2"></div>
           </div>
         </div>
 
         <!-- Staging inputs -->
         <div class="space-y-3 max-h-[45vh] overflow-y-auto pr-2">
-          <h4 class="text-lg font-semibold text-accent pt-2 sticky top-0" style="background: hsl(var(--surface-1));">Macros</h4>
-          <div><label for="actual-calories" class="block text-sm font-medium text-text-2">Calories</label><input type="number" step="any" id="actual-calories"></div>
-          <div><label for="actual-protein" class="block text-sm font-medium text-text-2">Protein (g)</label><input type="number" step="any" id="actual-protein"></div>
-          <div><label for="actual-carbs" class="block text-sm font-medium text-text-2">Carbs (g)</label><input type="number" step="any" id="actual-carbs"></div>
-          <div><label for="actual-fat" class="block text-sm font-medium text-text-2">Fat (g)</label><input type="number" step="any" id="actual-fat"></div>
+          <h4 class="text-lg font-semibold text-secondary pt-2 sticky top-0" style="background: hsl(var(--surface-1));">Macros</h4>
+          <div><label for="actual-calories" class="block text-sm font-medium text-primary">Calories</label><input type="number" step="any" id="actual-calories"></div>
+          <div><label for="actual-protein" class="block text-sm font-medium text-primary">Protein (g)</label><input type="number" step="any" id="actual-protein"></div>
+          <div><label for="actual-carbs" class="block text-sm font-medium text-primary">Carbs (g)</label><input type="number" step="any" id="actual-carbs"></div>
+          <div><label for="actual-fat" class="block text-sm font-medium text-primary">Fat (g)</label><input type="number" step="any" id="actual-fat"></div>
 
-          <h4 class="text-lg font-semibold text-accent pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Daily Vitamins</h4>
-          <div><label for="actual-vitaminB12" class="block text-sm font-medium text-text-2">Vitamin B12 (mcg)</label><input type="number" step="any" id="actual-vitaminB12"></div>
-          <div><label for="actual-folate" class="block text-sm font-medium text-text-2">Folate (mcg)</label><input type="number" step="any" id="actual-folate"></div>
-          <div><label for="actual-vitaminC" class="block text-sm font-medium text-text-2">Vitamin C (mg)</label><input type="number" step="any" id="actual-vitaminC"></div>
-          <div><label for="actual-vitaminB6" class="block text-sm font-medium text-text-2">Vitamin B6 (mg)</label><input type="number" step="any" id="actual-vitaminB6"></div>
+          <h4 class="text-lg font-semibold text-secondary pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Daily Vitamins</h4>
+          <div><label for="actual-vitaminB12" class="block text-sm font-medium text-primary">Vitamin B12 (mcg)</label><input type="number" step="any" id="actual-vitaminB12"></div>
+          <div><label for="actual-folate" class="block text-sm font-medium text-primary">Folate (mcg)</label><input type="number" step="any" id="actual-folate"></div>
+          <div><label for="actual-vitaminC" class="block text-sm font-medium text-primary">Vitamin C (mg)</label><input type="number" step="any" id="actual-vitaminC"></div>
+          <div><label for="actual-vitaminB6" class="block text-sm font-medium text-primary">Vitamin B6 (mg)</label><input type="number" step="any" id="actual-vitaminB6"></div>
 
-          <h4 class="text-lg font-semibold text-accent pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Averaged Vitamins</h4>
-          <div><label for="actual-vitaminA" class="block text-sm font-medium text-text-2">Vitamin A (mcg)</label><input type="number" step="any" id="actual-vitaminA"></div>
-          <div><label for="actual-vitaminD" class="block text-sm font-medium text-text-2">Vitamin D (mcg)</label><input type="number" step="any" id="actual-vitaminD"></div>
-          <div><label for="actual-vitaminE" class="block text-sm font-medium text-text-2">Vitamin E (mg)</label><input type="number" step="any" id="actual-vitaminE"></div>
-          <div><label for="actual-vitaminK" class="block text-sm font-medium text-text-2">Vitamin K (mcg)</label><input type="number" step="any" id="actual-vitaminK"></div>
+          <h4 class="text-lg font-semibold text-secondary pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Averaged Vitamins</h4>
+          <div><label for="actual-vitaminA" class="block text-sm font-medium text-primary">Vitamin A (mcg)</label><input type="number" step="any" id="actual-vitaminA"></div>
+          <div><label for="actual-vitaminD" class="block text-sm font-medium text-primary">Vitamin D (mcg)</label><input type="number" step="any" id="actual-vitaminD"></div>
+          <div><label for="actual-vitaminE" class="block text-sm font-medium text-primary">Vitamin E (mg)</label><input type="number" step="any" id="actual-vitaminE"></div>
+          <div><label for="actual-vitaminK" class="block text-sm font-medium text-primary">Vitamin K (mcg)</label><input type="number" step="any" id="actual-vitaminK"></div>
 
-          <h4 class="text-lg font-semibold text-accent pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Daily Minerals</h4>
-          <div><label for="actual-iron" class="block text-sm font-medium text-text-2">Iron (mg)</label><input type="number" step="any" id="actual-iron"></div>
-          <div><label for="actual-calcium" class="block text-sm font-medium text-text-2">Calcium (mg)</label><input type="number" step="any" id="actual-calcium"></div>
-          <div><label for="actual-magnesium" class="block text-sm font-medium text-text-2">Magnesium (mg)</label><input type="number" step="any" id="actual-magnesium"></div>
-          <div><label for="actual-zinc" class="block text-sm font-medium text-text-2">Zinc (mg)</label><input type="number" step="any" id="actual-zinc"></div>
-          <div><label for="actual-potassium" class="block text-sm font-medium text-text-2">Potassium (mg)</label><input type="number" step="any" id="actual-potassium"></div>
-          <div><label for="actual-sodium" class="block text-sm font-medium text-text-2">Sodium (mg)</label><input type="number" step="any" id="actual-sodium"></div>
+          <h4 class="text-lg font-semibold text-secondary pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Daily Minerals</h4>
+          <div><label for="actual-iron" class="block text-sm font-medium text-primary">Iron (mg)</label><input type="number" step="any" id="actual-iron"></div>
+          <div><label for="actual-calcium" class="block text-sm font-medium text-primary">Calcium (mg)</label><input type="number" step="any" id="actual-calcium"></div>
+          <div><label for="actual-magnesium" class="block text-sm font-medium text-primary">Magnesium (mg)</label><input type="number" step="any" id="actual-magnesium"></div>
+          <div><label for="actual-zinc" class="block text-sm font-medium text-primary">Zinc (mg)</label><input type="number" step="any" id="actual-zinc"></div>
+          <div><label for="actual-potassium" class="block text-sm font-medium text-primary">Potassium (mg)</label><input type="number" step="any" id="actual-potassium"></div>
+          <div><label for="actual-sodium" class="block text-sm font-medium text-primary">Sodium (mg)</label><input type="number" step="any" id="actual-sodium"></div>
 
-          <h4 class="text-lg font-semibold text-accent pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Averaged Minerals</h4>
-          <div><label for="actual-selenium" class="block text-sm font-medium text-text-2">Selenium (mcg)</label><input type="number" step="any" id="actual-selenium"></div>
-          <div><label for="actual-iodine" class="block text-sm font-medium text-text-2">Iodine (mcg)</label><input type="number" step="any" id="actual-iodine"></div>
-          <div><label for="actual-phosphorus" class="block text-sm font-medium text-text-2">Phosphorus (mg)</label><input type="number" step="any" id="actual-phosphorus"></div>
+          <h4 class="text-lg font-semibold text-secondary pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Averaged Minerals</h4>
+          <div><label for="actual-selenium" class="block text-sm font-medium text-primary">Selenium (mcg)</label><input type="number" step="any" id="actual-selenium"></div>
+          <div><label for="actual-iodine" class="block text-sm font-medium text-primary">Iodine (mcg)</label><input type="number" step="any" id="actual-iodine"></div>
+          <div><label for="actual-phosphorus" class="block text-sm font-medium text-primary">Phosphorus (mg)</label><input type="number" step="any" id="actual-phosphorus"></div>
 
-          <h4 class="text-lg font-semibold text-accent pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Optional</h4>
-          <div><label for="actual-omega3" class="block text-sm font-medium text-text-2">Omega-3 (g)</label><input type="number" step="any" id="actual-omega3"></div>
-          <div><label for="actual-fiber" class="block text-sm font-medium text-text-2">Fiber (g)</label><input type="number" step="any" id="actual-fiber"></div>
-          <div><label for="actual-choline" class="block text-sm font-medium text-text-2">Choline (mg)</label><input type="number" step="any" id="actual-choline"></div>
+          <h4 class="text-lg font-semibold text-secondary pt-4 sticky top-0" style="background: hsl(var(--surface-1));">Optional</h4>
+          <div><label for="actual-omega3" class="block text-sm font-medium text-primary">Omega-3 (g)</label><input type="number" step="any" id="actual-omega3"></div>
+          <div><label for="actual-fiber" class="block text-sm font-medium text-primary">Fiber (g)</label><input type="number" step="any" id="actual-fiber"></div>
+          <div><label for="actual-choline" class="block text-sm font-medium text-primary">Choline (mg)</label><input type="number" step="any" id="actual-choline"></div>
         </div>
       </div>
 
       <!-- RIGHT COLUMN -->
       <div class="lg:col-span-2">
-        <div id="dashboard"></div>
+        <div id="dashboard" class="surface-1 text-primary"></div>
       </div>
     </main>
   </div>
 
   <!-- Login Modal -->
   <div id="login-modal" class="hidden fixed inset-0 modal-backdrop flex justify-center items-center p-4 z-50">
-    <div class="modal-content rounded-xl p-8 w-full max-w-sm relative">
+    <div class="modal-content surface-1 text-primary rounded-xl p-8 w-full max-w-sm relative">
       <button id="close-login-btn" class="absolute top-2 right-4 btn btn-ghost icon-btn" title="Close" aria-label="Close">&times;</button>
-      <h2 class="text-2xl font-bold mb-6 text-center text-accent">Account Access</h2>
+      <h2 class="text-2xl font-bold mb-6 text-center text-secondary">Account Access</h2>
 
       <form id="auth-form" class="space-y-4">
         <div>
-          <label for="email-input" class="block text-sm font-medium text-text-2">Email</label>
+          <label for="email-input" class="block text-sm font-medium text-primary">Email</label>
           <input type="email" id="email-input" required>
         </div>
         <div>
-          <label for="password-input" class="block text-sm font-medium text-text-2">Password</label>
+          <label for="password-input" class="block text-sm font-medium text-primary">Password</label>
           <input type="password" id="password-input" required>
         </div>
         <div class="flex space-x-2 pt-2">
-          <button type="button" id="login-btn" class="w-full btn-secondary">Login</button>
-          <button type="button" id="signup-btn" class="w-full btn-primary">Sign Up</button>
+          <button type="button" id="login-btn" class="w-full btn btn-secondary">Login</button>
+          <button type="button" id="signup-btn" class="w-full btn btn-primary">Sign Up</button>
         </div>
       </form>
 
       <div class="my-4 flex items-center">
-        <hr class="flex-grow border-b border-border">
-        <span class="mx-2 text-text-3 text-sm">OR</span>
-        <hr class="flex-grow border-b border-border">
+        <hr class="flex-grow border-b border-default">
+        <span class="mx-2 text-muted text-sm">OR</span>
+        <hr class="flex-grow border-b border-default">
       </div>
-      <button id="guest-btn" class="w-full btn-muted">Continue as Guest</button>
+      <button id="guest-btn" class="w-full btn btn-muted">Continue as Guest</button>
     </div>
   </div>
 
   <!-- Settings Modal -->
   <div id="settings-modal" class="hidden fixed inset-0 modal-backdrop flex justify-center items-center p-4 z-50">
-    <div class="modal-content rounded-xl p-8 w-full max-w-4xl max-h-[90vh] relative">
+    <div class="modal-content surface-1 text-primary rounded-xl p-8 w-full max-w-4xl max-h-[90vh] relative">
       <button id="close-settings-btn" class="absolute top-4 right-4 btn btn-ghost icon-btn" title="Close" aria-label="Close">&times;</button>
-      <h2 class="text-2xl font-bold mb-6 text-accent">Set Baseline Targets & Configuration</h2>
+      <h2 class="text-2xl font-bold mb-6 text-secondary">Set Baseline Targets & Configuration</h2>
 
       <form id="settings-form" class="overflow-y-auto max-h-[70vh] pr-4">
         <div class="grid grid-cols-1 gap-4">
           <!-- Macros -->
-          <div class="section-card">
-            <h3 class="text-lg font-semibold text-text-2 mb-2">Macros</h3>
+          <div class="section-card surface-1 text-primary">
+            <h3 class="text-lg font-semibold text-secondary mb-2">Macros</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-calories" class="block text-sm font-medium text-text-2">Calories</label><input type="number" step="any" id="target-calories"></div>
-              <div><label for="target-protein" class="block text-sm font-medium text-text-2">Protein (g)</label><input type="number" step="any" id="target-protein"></div>
-              <div><label for="target-carbs" class="block text-sm font-medium text-text-2">Carbs (g)</label><input type="number" step="any" id="target-carbs"></div>
-              <div><label for="target-fat" class="block text-sm font-medium text-text-2">Fat (g)</label><input type="number" step="any" id="target-fat"></div>
+              <div><label for="target-calories" class="block text-sm font-medium text-primary">Calories</label><input type="number" step="any" id="target-calories"></div>
+              <div><label for="target-protein" class="block text-sm font-medium text-primary">Protein (g)</label><input type="number" step="any" id="target-protein"></div>
+              <div><label for="target-carbs" class="block text-sm font-medium text-primary">Carbs (g)</label><input type="number" step="any" id="target-carbs"></div>
+              <div><label for="target-fat" class="block text-sm font-medium text-primary">Fat (g)</label><input type="number" step="any" id="target-fat"></div>
             </div>
           </div>
 
           <!-- Banking Config -->
-          <div class="section-card">
-            <h3 class="text-lg font-semibold text-text-2 mb-2">Banking System Configuration</h3>
+          <div class="section-card surface-1 text-primary">
+            <h3 class="text-lg font-semibold text-secondary mb-2">Banking System Configuration</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-fatMinimum" class="block text-sm font-medium text-text-2">Minimum Fat (g)</label><input type="number" step="any" id="target-fatMinimum"></div>
-              <div><label for="target-correctionDivisor" class="block text-sm font-medium text-text-2">Correction Divisor</label><input type="number" step="0.1" id="target-correctionDivisor" title="Bank divided by this number equals raw correction (default: 3)"></div>
-              <div><label for="target-decayHalfLife" class="block text-sm font-medium text-text-2">Decay Half-Life (days)</label><input type="number" step="0.1" id="target-decayHalfLife" title="How quickly past days lose influence (default: 3.5)"></div>
+              <div><label for="target-fatMinimum" class="block text-sm font-medium text-primary">Minimum Fat (g)</label><input type="number" step="any" id="target-fatMinimum"></div>
+              <div><label for="target-correctionDivisor" class="block text-sm font-medium text-primary">Correction Divisor</label><input type="number" step="0.1" id="target-correctionDivisor" title="Bank divided by this number equals raw correction (default: 3)"></div>
+              <div><label for="target-decayHalfLife" class="block text-sm font-medium text-primary">Decay Half-Life (days)</label><input type="number" step="0.1" id="target-decayHalfLife" title="How quickly past days lose influence (default: 3.5)"></div>
               <div class="grid grid-cols-1 gap-4">
-                <h4 class="text-md font-medium text-text-2">Safety Caps (% of base calories)</h4>
-                <div><label for="target-smallBankCap" class="block text-sm font-medium text-text-2">Small Bank Cap (%)</label><input type="number" step="1" id="target-smallBankCap" title="Max adjustment when |bank| less than base calories (default: 15%)"></div>
-                <div><label for="target-mediumBankCap" class="block text-sm font-medium text-text-2">Medium Bank Cap (%)</label><input type="number" step="1" id="target-mediumBankCap" title="Max adjustment when |bank| at least base calories (default: 30%)"></div>
-                <div><label for="target-largeBankCap" class="block text-sm font-medium text-text-2">Large Bank Cap (%)</label><input type="number" step="1" id="target-largeBankCap" title="Max adjustment when |bank| at least two times base calories (default: 40%)"></div>
+                <h4 class="text-md font-medium text-secondary">Safety Caps (% of base calories)</h4>
+                <div><label for="target-smallBankCap" class="block text-sm font-medium text-primary">Small Bank Cap (%)</label><input type="number" step="1" id="target-smallBankCap" title="Max adjustment when |bank| less than base calories (default: 15%)"></div>
+                <div><label for="target-mediumBankCap" class="block text-sm font-medium text-primary">Medium Bank Cap (%)</label><input type="number" step="1" id="target-mediumBankCap" title="Max adjustment when |bank| at least base calories (default: 30%)"></div>
+                <div><label for="target-largeBankCap" class="block text-sm font-medium text-primary">Large Bank Cap (%)</label><input type="number" step="1" id="target-largeBankCap" title="Max adjustment when |bank| at least two times base calories (default: 40%)"></div>
               </div>
             </div>
           </div>
 
           <!-- Daily Vitamins -->
-          <div class="section-card">
-            <h3 class="text-lg font-semibold text-text-2 mb-2">Daily Vitamins (Water-Soluble)</h3>
+          <div class="section-card surface-1 text-primary">
+            <h3 class="text-lg font-semibold text-secondary mb-2">Daily Vitamins (Water-Soluble)</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-vitaminB12" class="block text-sm font-medium text-text-2">Vitamin B12 (mcg)</label><input type="number" step="any" id="target-vitaminB12"></div>
-              <div><label for="target-folate" class="block text-sm font-medium text-text-2">Folate (mcg)</label><input type="number" step="any" id="target-folate"></div>
-              <div><label for="target-vitaminC" class="block text-sm font-medium text-text-2">Vitamin C (mg)</label><input type="number" step="any" id="target-vitaminC"></div>
-              <div><label for="target-vitaminB6" class="block text-sm font-medium text-text-2">Vitamin B6 (mg)</label><input type="number" step="any" id="target-vitaminB6"></div>
+              <div><label for="target-vitaminB12" class="block text-sm font-medium text-primary">Vitamin B12 (mcg)</label><input type="number" step="any" id="target-vitaminB12"></div>
+              <div><label for="target-folate" class="block text-sm font-medium text-primary">Folate (mcg)</label><input type="number" step="any" id="target-folate"></div>
+              <div><label for="target-vitaminC" class="block text-sm font-medium text-primary">Vitamin C (mg)</label><input type="number" step="any" id="target-vitaminC"></div>
+              <div><label for="target-vitaminB6" class="block text-sm font-medium text-primary">Vitamin B6 (mg)</label><input type="number" step="any" id="target-vitaminB6"></div>
             </div>
           </div>
 
           <!-- Averaged Vitamins -->
-          <div class="section-card">
-            <h3 class="text-lg font-semibold text-text-2 mb-2">Averaged Vitamins (Fat-Soluble)</h3>
+          <div class="section-card surface-1 text-primary">
+            <h3 class="text-lg font-semibold text-secondary mb-2">Averaged Vitamins (Fat-Soluble)</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-vitaminA" class="block text-sm font-medium text-text-2">Vitamin A (mcg)</label><input type="number" step="any" id="target-vitaminA"></div>
-              <div><label for="target-vitaminD" class="block text-sm font-medium text-text-2">Vitamin D (mcg)</label><input type="number" step="any" id="target-vitaminD"></div>
-              <div><label for="target-vitaminE" class="block text-sm font-medium text-text-2">Vitamin E (mg)</label><input type="number" step="any" id="target-vitaminE"></div>
-              <div><label for="target-vitaminK" class="block text-sm font-medium text-text-2">Vitamin K (mcg)</label><input type="number" step="any" id="target-vitaminK"></div>
+              <div><label for="target-vitaminA" class="block text-sm font-medium text-primary">Vitamin A (mcg)</label><input type="number" step="any" id="target-vitaminA"></div>
+              <div><label for="target-vitaminD" class="block text-sm font-medium text-primary">Vitamin D (mcg)</label><input type="number" step="any" id="target-vitaminD"></div>
+              <div><label for="target-vitaminE" class="block text-sm font-medium text-primary">Vitamin E (mg)</label><input type="number" step="any" id="target-vitaminE"></div>
+              <div><label for="target-vitaminK" class="block text-sm font-medium text-primary">Vitamin K (mcg)</label><input type="number" step="any" id="target-vitaminK"></div>
             </div>
           </div>
 
           <!-- Daily Minerals -->
-          <div class="section-card">
-            <h3 class="text-lg font-semibold text-text-2 mb-2">Daily Minerals</h3>
+          <div class="section-card surface-1 text-primary">
+            <h3 class="text-lg font-semibold text-secondary mb-2">Daily Minerals</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-iron" class="block text-sm font-medium text-text-2">Iron (mg)</label><input type="number" step="any" id="target-iron"></div>
-              <div><label for="target-calcium" class="block text-sm font-medium text-text-2">Calcium (mg)</label><input type="number" step="any" id="target-calcium"></div>
-              <div><label for="target-magnesium" class="block text-sm font-medium text-text-2">Magnesium (mg)</label><input type="number" step="any" id="target-magnesium"></div>
-              <div><label for="target-zinc" class="block text-sm font-medium text-text-2">Zinc (mg)</label><input type="number" step="any" id="target-zinc"></div>
-              <div><label for="target-potassium" class="block text-sm font-medium text-text-2">Potassium (mg)</label><input type="number" step="any" id="target-potassium"></div>
-              <div><label for="target-sodium" class="block text-sm font-medium text-text-2">Sodium (mg)</label><input type="number" step="any" id="target-sodium"></div>
+              <div><label for="target-iron" class="block text-sm font-medium text-primary">Iron (mg)</label><input type="number" step="any" id="target-iron"></div>
+              <div><label for="target-calcium" class="block text-sm font-medium text-primary">Calcium (mg)</label><input type="number" step="any" id="target-calcium"></div>
+              <div><label for="target-magnesium" class="block text-sm font-medium text-primary">Magnesium (mg)</label><input type="number" step="any" id="target-magnesium"></div>
+              <div><label for="target-zinc" class="block text-sm font-medium text-primary">Zinc (mg)</label><input type="number" step="any" id="target-zinc"></div>
+              <div><label for="target-potassium" class="block text-sm font-medium text-primary">Potassium (mg)</label><input type="number" step="any" id="target-potassium"></div>
+              <div><label for="target-sodium" class="block text-sm font-medium text-primary">Sodium (mg)</label><input type="number" step="any" id="target-sodium"></div>
             </div>
           </div>
 
           <!-- Averaged Minerals -->
-          <div class="section-card">
-            <h3 class="text-lg font-semibold text-text-2 mb-2">Averaged Minerals</h3>
+          <div class="section-card surface-1 text-primary">
+            <h3 class="text-lg font-semibold text-secondary mb-2">Averaged Minerals</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-selenium" class="block text-sm font-medium text-text-2">Selenium (mcg)</label><input type="number" step="any" id="target-selenium"></div>
-              <div><label for="target-iodine" class="block text-sm font-medium text-text-2">Iodine (mcg)</label><input type="number" step="any" id="target-iodine"></div>
-              <div><label for="target-phosphorus" class="block text-sm font-medium text-text-2">Phosphorus (mg)</label><input type="number" step="any" id="target-phosphorus"></div>
+              <div><label for="target-selenium" class="block text-sm font-medium text-primary">Selenium (mcg)</label><input type="number" step="any" id="target-selenium"></div>
+              <div><label for="target-iodine" class="block text-sm font-medium text-primary">Iodine (mcg)</label><input type="number" step="any" id="target-iodine"></div>
+              <div><label for="target-phosphorus" class="block text-sm font-medium text-primary">Phosphorus (mg)</label><input type="number" step="any" id="target-phosphorus"></div>
             </div>
           </div>
 
           <!-- Optional Nutrients -->
-          <div class="section-card">
-            <h3 class="text-lg font-semibold text-text-2 mb-2">Optional Nutrients</h3>
+          <div class="section-card surface-1 text-primary">
+            <h3 class="text-lg font-semibold text-secondary mb-2">Optional Nutrients</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-omega3" class="block text-sm font-medium text-text-2">Omega-3 (g)</label><input type="number" step="any" id="target-omega3"></div>
-              <div><label for="target-fiber" class="block text-sm font-medium text-text-2">Fiber (g)</label><input type="number" step="any" id="target-fiber"></div>
-              <div><label for="target-choline" class="block text-sm font-medium text-text-2">Choline (mg)</label><input type="number" step="any" id="target-choline"></div>
+              <div><label for="target-omega3" class="block text-sm font-medium text-primary">Omega-3 (g)</label><input type="number" step="any" id="target-omega3"></div>
+              <div><label for="target-fiber" class="block text-sm font-medium text-primary">Fiber (g)</label><input type="number" step="any" id="target-fiber"></div>
+              <div><label for="target-choline" class="block text-sm font-medium text-primary">Choline (mg)</label><input type="number" step="any" id="target-choline"></div>
             </div>
           </div>
 
           <!-- Actions -->
           <div class="flex justify-between items-center">
-            <button type="button" id="export-targets-json-btn" class="btn-secondary text-sm">Export Targets (JSON)</button>
-            <button type="button" id="export-saved-foods-csv-btn" class="btn-secondary text-sm">Export Saved Foods (CSV)</button>
-            <button type="button" id="export-all-data-btn" class="btn-secondary text-sm">Export Daily Log (CSV)</button>
-            <button type="submit" class="btn-primary">Save Targets</button>
+            <button type="button" id="export-targets-json-btn" class="btn btn-secondary text-sm">Export Targets (JSON)</button>
+            <button type="button" id="export-saved-foods-csv-btn" class="btn btn-secondary text-sm">Export Saved Foods (CSV)</button>
+            <button type="button" id="export-all-data-btn" class="btn btn-secondary text-sm">Export Daily Log (CSV)</button>
+            <button type="submit" class="btn btn-primary">Save Targets</button>
           </div>
         </div>
       </form>
@@ -622,9 +546,9 @@
 
   <!-- Food Manager Modal -->
   <div id="food-manager-modal" class="hidden fixed inset-0 modal-backdrop flex justify-center items-center p-4 z-50">
-    <div class="modal-content rounded-xl p-8 w-full max-w-4xl max-h-[90vh] relative">
+    <div class="modal-content surface-1 text-primary rounded-xl p-8 w-full max-w-4xl max-h-[90vh] relative">
       <button onclick="closeFoodManager()" class="absolute top-4 right-4 btn btn-ghost icon-btn" title="Close" aria-label="Close">&times;</button>
-      <h2 class="text-2xl font-bold mb-6 text-accent">Manage Saved Foods</h2>
+      <h2 class="text-2xl font-bold mb-6 text-secondary">Manage Saved Foods</h2>
       <div class="overflow-y-auto max-h-[70vh] pr-4">
         <div id="food-manager-list"></div>
       </div>
@@ -633,30 +557,30 @@
 
   <!-- Duplicate Food Modal -->
   <div id="duplicate-food-modal" class="hidden fixed inset-0 modal-backdrop flex justify-center items-center p-4 z-50">
-    <div class="modal-content rounded-xl p-8 w-full max-w-3xl max-h-[90vh] relative">
-      <h2 class="text-xl font-bold mb-4 text-accent">Duplicate Food Detected</h2>
+    <div class="modal-content surface-1 text-primary rounded-xl p-8 w-full max-w-3xl max-h-[90vh] relative">
+      <h2 class="text-xl font-bold mb-4 text-secondary">Duplicate Food Detected</h2>
       <div id="duplicate-comparison" class="overflow-y-auto max-h-[70vh]"></div>
     </div>
   </div>
 
   <!-- Blank Food Name Modal -->
   <div id="blank-food-name-modal" class="hidden fixed inset-0 modal-backdrop flex justify-center items-center p-4 z-50">
-    <div class="modal-content rounded-xl p-8 w-full max-w-sm relative">
+    <div class="modal-content surface-1 text-primary rounded-xl p-8 w-full max-w-sm relative">
       <button onclick="closeBlankFoodNameModal()" class="absolute top-2 right-4 btn btn-ghost icon-btn" title="Close" aria-label="Close">&times;</button>
-      <h2 class="text-2xl font-bold mb-6 text-center text-accent">Food Name Required</h2>
+      <h2 class="text-2xl font-bold mb-6 text-center text-secondary">Food Name Required</h2>
       <div id="blank-food-name-prompt" class="text-center">
         <p class="mb-4">The food name is blank. Would you like to save it as "(blank)" or enter a name?</p>
         <div class="flex justify-center gap-4">
-          <button id="confirm-blank-name-btn" class="btn-secondary">Save as (blank)</button>
-          <button id="enter-name-btn" class="btn-primary">Enter Name</button>
+          <button id="confirm-blank-name-btn" class="btn btn-secondary">Save as (blank)</button>
+          <button id="enter-name-btn" class="btn btn-primary">Enter Name</button>
         </div>
       </div>
       <div id="blank-food-name-input-container" class="hidden mt-4">
-        <label for="blank-food-name-input" class="block text-sm font-medium text-text-2 mb-1">Enter New Food Name</label>
+        <label for="blank-food-name-input" class="block text-sm font-medium text-primary mb-1">Enter New Food Name</label>
         <input type="text" id="blank-food-name-input" placeholder="e.g., Unlabeled Snack">
         <div class="flex justify-end gap-4 mt-4">
-          <button id="cancel-blank-name-btn" class="btn-secondary">Cancel</button>
-          <button id="submit-new-food-name-btn" class="btn-primary">Submit</button>
+          <button id="cancel-blank-name-btn" class="btn btn-secondary">Cancel</button>
+          <button id="submit-new-food-name-btn" class="btn btn-primary">Submit</button>
         </div>
       </div>
     </div>
@@ -664,24 +588,24 @@
 
   <!-- Confirmation Modal -->
   <div id="confirmation-modal" class="hidden fixed inset-0 modal-backdrop flex justify-center items-center p-4 z-50">
-    <div class="modal-content rounded-xl p-8 w-full max-w-sm relative">
-      <h2 class="text-xl font-bold mb-4 text-center text-accent">Confirm Action</h2>
-      <p id="confirmation-message" class="text-text-2 text-center mb-6"></p>
+    <div class="modal-content surface-1 text-primary rounded-xl p-8 w-full max-w-sm relative">
+      <h2 class="text-xl font-bold mb-4 text-center text-secondary">Confirm Action</h2>
+      <p id="confirmation-message" class="text-primary text-center mb-6"></p>
 
       <div id="prompt-input-container" class="mt-4 hidden">
-        <label for="prompt-input" class="block text-sm font-medium text-text-2 mb-1">Enter Value:</label>
+        <label for="prompt-input" class="block text-sm font-medium text-primary mb-1">Enter Value:</label>
         <input type="text" id="prompt-input" />
       </div>
 
       <div class="flex justify-center gap-4 mt-6">
-        <button id="confirm-action-btn" class="btn-primary">Confirm</button>
-        <button id="cancel-action-btn" class="btn-secondary">Cancel</button>
+        <button id="confirm-action-btn" class="btn btn-primary">Confirm</button>
+        <button id="cancel-action-btn" class="btn btn-secondary">Cancel</button>
       </div>
     </div>
   </div>
 
   <!-- Toast / Message box -->
-  <div id="message-box" class="hidden fixed bottom-5 right-5 text-text px-6 py-3 rounded-xl shadow-glow z-50">
+  <div id="message-box" class="hidden fixed bottom-5 right-5 text-primary px-6 py-3 rounded-xl shadow-glow z-50">
     <p id="message-text"></p>
   </div>
 

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -186,7 +186,7 @@ function renderFoodItemsContent(container) {
           </div>
           <div class="text-xs text-secondary">${details}</div>
         </div>
-        <button onclick="removeFoodItem(${index})" class="ml-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200 btn btn-danger icon-btn" title="Remove Item" aria-label="Remove Item">
+        <button onclick="removeFoodItem(${index})" class="ml-3 btn btn-danger icon-btn" title="Delete" aria-label="Delete">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>`;

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -481,7 +481,7 @@ export function updateDashboard() {
       dashboard.innerHTML = `
         <div id="dashboard-errors"></div>
         <div class="text-center p-8 surface-1 rounded-lg shadow-md">
-          <h3 class="text-xl font-semibold text-primary">Welcome to Adaptive Nutrition Tracker!</h3>
+          <h3 class="text-xl font-semibold text-secondary">Welcome to Adaptive Nutrition Tracker!</h3>
           <p class="mt-2 text-muted">Please log in and set your baseline targets to get started.</p>
           <button onclick="document.getElementById('open-settings-btn').click()"
             class="mt-4 px-6 py-2 btn btn-primary">Set Targets</button>
@@ -573,8 +573,8 @@ function setupCollapsibleHandlers() {
 function renderInfoBox() {
   return `
     <div class="mb-6 p-4 surface-2 rounded-lg border">
-      <h3 class="font-semibold text-accent mb-2"><i class="fas fa-info-circle mr-2"></i>How This Works</h3>
-      <div class="text-sm text-secondary space-y-1">
+      <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How This Works</h3>
+      <div class="text-sm text-muted space-y-1">
         <p><strong>Smart Banking:</strong> Your "bank" tracks when you eat more (+) or less (-) than planned. Recent days matter most.</p>
         <p><strong>Auto-Adjust:</strong> Tomorrow's calories adjust to balance your bank, with safety limits (15-40% max change).</p>
         <p><strong>Training Days:</strong> Select your workout type above - this adds calories and scales electrolytes appropriately.</p>
@@ -614,7 +614,7 @@ function renderBankingPanel(bankingData) {
   return `
     <div class="section-card p-4">
       <div class="flex items-center justify-between mb-4">
-        <h3 class="text-xl font-bold">🏦 Your Calorie Bank</h3>
+        <h3 class="text-xl font-bold text-secondary">🏦 Your Calorie Bank</h3>
         <button id="recent-days-toggle" class="text-accent hover:text-accent-600 text-sm font-medium flex items-center gap-2">
             <i class="fas fa-chevron-down"></i>
             <span class="toggle-text">Show Recent Days Breakdown</span>
@@ -626,7 +626,7 @@ function renderBankingPanel(bankingData) {
           <div class="text-2xl font-bold ${bankToday > 0 ? 'text-negative' : bankToday < 0 ? 'text-positive' : 'text-muted'}">
             ${bankToday > 0 ? '+' : ''}${bankToday} kcal
           </div>
-          <p class="text-sm text-secondary mt-1">${bankExplanation}</p>
+          <p class="text-sm text-muted mt-1">${bankExplanation}</p>
           ${!debug.mathIsConsistent && DASHBOARD_CONFIG.SHOW_MATH_VERIFICATION ? `
             <div class="mt-2 p-2 border surface-2 text-xs text-warning rounded">
               ⚠️ Math verification: Expected ${bankToday}, calculated ${debug.calculatedTotal} (difference: ${debug.calculatedTotal - bankToday})
@@ -649,8 +649,8 @@ function renderBankingPanel(bankingData) {
             <tbody>
               ${contributionRows}
               <tr class="border-t-2 border">
-                <td colspan="3" class="px-3 py-2 text-sm font-medium text-secondary italic">Days 6+ ago contribution</td>
-                <td class="px-3 py-2 text-sm text-center font-medium text-secondary italic">
+                <td colspan="3" class="px-3 py-2 text-sm font-medium text-primary italic">Days 6+ ago contribution</td>
+                <td class="px-3 py-2 text-sm text-center font-medium text-primary italic">
                   ${olderContributions > 0 ? '+' : ''}${Math.round(olderContributions)}
                 </td>
               </tr>
@@ -664,7 +664,7 @@ function renderBankingPanel(bankingData) {
           </table>
         </div>
 
-        <p class="mt-3 text-xs text-secondary">
+        <p class="mt-3 text-xs text-muted">
           <strong>How it works:</strong> Recent days have more impact (yesterday = 82%, 2 days = 67%, etc.).
           After 7-10 days, the impact is nearly zero (≤25%).
         </p>
@@ -714,7 +714,7 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
   
   return `
     <div class="mb-6 card p-6 shadow-lg">
-      <h3 class="text-xl font-bold mb-4">🍽️ Today's Nutrition Plan</h3>
+      <h3 class="text-xl font-bold text-secondary mb-4">🍽️ Today's Nutrition Plan</h3>
 
       <!-- Summary Section -->
       <div class="mb-4 p-4 surface-2 rounded-lg border">
@@ -723,7 +723,7 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
           <span class="text-accent">${todayKcalTarget} kcal</span>
         </div>
         <div class="flex justify-between items-center text-sm mt-1">
-          <span class="text-secondary">Remaining:</span>
+          <span class="text-primary">Remaining:</span>
           <span class="font-medium ${remainingCaloriesColor}">${remainingCalories.toFixed(0)} kcal</span>
         </div>
 
@@ -745,7 +745,7 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
               <span class="font-medium">${todaysTrainingBump > 0 ? '+' : ''}${todaysTrainingBump} kcal</span>
             </div>
             ${todaysTrainingBump > 0 ? `
-              <p class="text-xs text-accent px-2 italic">${TRAINING_EXPLANATIONS[trainingIntensity]}</p>
+              <p class="text-xs text-muted px-2 italic">${TRAINING_EXPLANATIONS[trainingIntensity]}</p>
             ` : ''}
             <div class="flex justify-between items-center p-2 rounded border ${bankToday !== 0 ? 'surface-2' : 'surface-1'}">
               <span>Bank balance adjustment:</span>
@@ -768,41 +768,32 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <!-- Macro Breakdown -->
         <div class="md:col-span-3">
-          <h4 class="font-semibold mb-3">Your Macro Targets</h4>
+          <h4 class="font-semibold text-secondary mb-3">Your Macro Targets</h4>
           <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <div class="kpi card">
-              <div class="flex justify-between items-center">
-                <span class="kpi-title">Protein</span>
+            <div class="kpi">
+              <div class="flex justify-between items-center mb-1">
+                <span class="kpi-label">Protein</span>
                 <span class="kpi-value">${proteinG}g</span>
               </div>
-              <div class="flex justify-between items-center text-xs ${remainingProteinColor} mb-1">
-                <span>Remaining:</span>
-                <span class="font-bold">${remainingProtein.toFixed(0)}g</span>
-              </div>
+              <div class="kpi-delta ${remainingProtein >= 0 ? 'positive' : 'negative'}">Remaining: ${remainingProtein.toFixed(0)}g</div>
               <div class="text-xs text-muted">${proteinG * 4} kcal • ${trainingIntensity !== 'rest' && proteinG > BANKING_CONFIG.PROTEIN_G ? 'Training boost applied' : 'Standard target'}</div>
             </div>
 
-            <div class="kpi card">
-              <div class="flex justify-between items-center">
-                <span class="kpi-title">Fat (minimum)</span>
+            <div class="kpi">
+              <div class="flex justify-between items-center mb-1">
+                <span class="kpi-label">Fat (minimum)</span>
                 <span class="kpi-value">${fatG}g</span>
               </div>
-              <div class="flex justify-between items-center text-xs ${remainingFatColor} mb-1">
-                <span>Remaining:</span>
-                <span class="font-bold">${remainingFat.toFixed(0)}g</span>
-              </div>
+              <div class="kpi-delta ${remainingFat >= 0 ? 'positive' : 'negative'}">Remaining: ${remainingFat.toFixed(0)}g</div>
               <div class="text-xs text-muted">${fatG * 9} kcal • Essential for hormone production</div>
             </div>
 
-            <div class="kpi card">
-              <div class="flex justify-between items-center">
-                <span class="kpi-title">Carbs (flexible)</span>
+            <div class="kpi">
+              <div class="flex justify-between items-center mb-1">
+                <span class="kpi-label">Carbs (flexible)</span>
                 <span class="kpi-value">${carbsG}g</span>
               </div>
-              <div class="flex justify-between items-center text-xs ${remainingCarbsColor} mb-1">
-                <span>Remaining:</span>
-                <span class="font-bold">${remainingCarbs.toFixed(0)}g</span>
-              </div>
+              <div class="kpi-delta ${remainingCarbs >= 0 ? 'positive' : 'negative'}">Remaining: ${remainingCarbs.toFixed(0)}g</div>
               <div class="text-xs text-muted">${carbsG * 4} kcal • Fills remaining calories</div>
             </div>
           </div>
@@ -818,7 +809,7 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
 function renderChartSection() {
   return `
     <div class="mb-8 card p-6 shadow-lg">
-      <h3 class="text-2xl font-bold text-primary mb-4">📊 Nutrition Progress Chart</h3>
+      <h3 class="text-2xl font-bold text-secondary mb-4">📊 Nutrition Progress Chart</h3>
       <div class="mb-4 grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
           <label for="chart-nutrients" class="block text-sm font-medium text-primary mb-1">Select Nutrients</label>
@@ -837,11 +828,11 @@ function renderChartSection() {
           <div class="space-y-2 mt-2">
             <div class="flex items-center">
               <input type="checkbox" id="show-3day-avg" class="mr-2 h-4 w-4 text-accent border rounded focus:ring-accent-600">
-              <label for="show-3day-avg" class="text-sm text-secondary">3-day average</label>
+              <label for="show-3day-avg" class="text-sm text-primary">3-day average</label>
             </div>
             <div class="flex items-center">
               <input type="checkbox" id="show-7day-avg" class="mr-2 h-4 w-4 text-accent border rounded focus:ring-accent-600">
-              <label for="show-7day-avg" class="text-sm text-secondary">7-day average</label>
+              <label for="show-7day-avg" class="text-sm text-primary">7-day average</label>
             </div>
           </div>
         </div>
@@ -909,7 +900,7 @@ function renderMicronutrientSections(metrics) {
             <div class="w-full surface-3 rounded-full h-2">
               <div class="h-2 rounded-full ${statusColors[status]}" style="width: ${Math.min(100, percentage)}%"></div>
             </div>
-            <p class="text-xs text-secondary mt-1">${percentage.toFixed(0)}% of target</p>
+            <p class="text-xs text-muted mt-1">${percentage.toFixed(0)}% of target</p>
           </div>
         ` : ''}
       </div>
@@ -927,8 +918,8 @@ function renderMicronutrientSections(metrics) {
     return `
       <div class="mb-8">
         <div class="mb-4">
-          <h3 class="text-2xl font-bold text-primary">${title}</h3>
-          <p class="text-sm text-secondary">${description}</p>
+          <h3 class="text-2xl font-bold text-secondary">${title}</h3>
+          <p class="text-sm text-muted">${description}</p>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
           ${cards}


### PR DESCRIPTION
## Summary
- standardize color tokens and button variants for Calorie Tracker
- redesign macro KPI tiles and improve accessibility for delete buttons
- route negative/positive/neutral text through shared danger/success tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

## Docs
- n/a

------
https://chatgpt.com/codex/tasks/task_b_689fa2d22e108320bdea46c9e216fbbf