### PR TITLE
fix: standardize delete buttons in CalorieTracker

### DIFF
--- a/public/tools/CalorieTracker/food/manager.js
+++ b/public/tools/CalorieTracker/food/manager.js
@@ -93,7 +93,7 @@ export function openFoodManager() {
       </div>
       <div class="flex gap-2">
         <button onclick="editFoodItem('${id}')" class="btn btn-primary text-sm">Edit</button>
-        <button onclick="deleteFoodItemFromManager('${id}')" class="btn btn-danger text-sm">Delete</button>
+        <button onclick="deleteFoodItemFromManager('${id}')" class="btn btn-danger icon-btn" aria-label="Delete" title="Delete">&times;</button>
       </div>
     </div>`).join('') || '<p class="text-muted text-center p-4">No saved food items.</p>';
 

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -186,9 +186,7 @@ function renderFoodItemsContent(container) {
           </div>
           <div class="text-xs text-secondary">${details}</div>
         </div>
-        <button onclick="removeFoodItem(${index})" class="ml-3 btn btn-danger icon-btn" title="Delete" aria-label="Delete">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <button onclick="removeFoodItem(${index})" class="btn btn-danger icon-btn" aria-label="Delete" title="Delete">&times;</button>
       </div>`;
   }).join('');
 


### PR DESCRIPTION
## Summary
- standardize delete button markup for food manager entries
- streamline dashboard delete buttons for consistency

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689fa804248483208eca57d713a3cbe1