### PR TITLE
refactor: align Calorie Tracker tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Welcome to my personal website project! This repository is a monorepo containing
 
 This stack means the site is primarily a static front-end (deployed on Cloudflare Pages) with some dynamic client-side features. Firebase is used as a backend for data-heavy features (e.g. saving user data for certain tools like the Trip Cost calculator or Calorie Tracker).
 
+### Shared UI tokens
+
+Static tools under `/public` share utility classes and color tokens defined in `public/shared-styles.css`:
+
+- `.hbar` with `.hbar-fill` and `.hbar-marker` draws horizontal KPI bars on a 0–150% scale with a 100% marker.
+- `.kpi-row` standardizes KPI label/value layouts.
+- `--chart-1-hex` … `--chart-8-hex` variables supply chart colors consumed via `CONFIG.CHART_COLORS`.
+
 ## Project Structure
 
 The project uses a flat, intuitive structure to organize content. The main directories are:

--- a/public/shared-styles.css
+++ b/public/shared-styles.css
@@ -244,3 +244,7 @@ body {
 .kpi-row .meta .target  { color:hsl(var(--text-2)); }
 .kpi-row .meta .remain  { color:hsl(var(--text-3)); }
 .kpi-row .meta .over    { font-size:.75rem; color:hsl(var(--error)); }
+
+/* Table helpers */
+.divide-y > * + * { border-top:1px solid hsl(var(--border)); }
+.hover-surface-2:hover { background-color:hsl(var(--surface-2)); }

--- a/public/tools/CalorieTracker/config.js
+++ b/public/tools/CalorieTracker/config.js
@@ -22,17 +22,8 @@ export const CONFIG = {
   // Default minimum grams of fat for macro calculations if not set by the user.
   DEFAULT_FAT_MINIMUM: 50,
 
-  // Array of hex color codes for the chart datasets.
-  CHART_COLORS: [
-    chartFromCss(1) || '#3B82F6',
-    chartFromCss(2) || '#EF4444',
-    chartFromCss(3) || '#10B981',
-    chartFromCss(4) || '#F59E0B',
-    chartFromCss(5) || '#8B5CF6',
-    chartFromCss(6) || '#EC4899',
-    chartFromCss(7) || '#06B6D4',
-    chartFromCss(8) || '#84CC16',
-  ],
+  // Array of chart colors pulled directly from CSS tokens.
+  CHART_COLORS: Array.from({ length: 8 }, (_, i) => chartFromCss(i + 1)),
 
   // Number of previous days to look back for calculating rolling averages in the chart.
   CHART_AVERAGE_LOOKBACK: 3,

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -193,8 +193,8 @@ function renderFoodItemsContent(container) {
   // Summary section
   const summaryHtml = `
     <div class="kpi card mb-3">
-      <div class="flex justify-between items-center">
-        <span class="kpi-title">Today's Totals (${state.dailyFoodItems.length} items):</span>
+      <div class="kpi-row">
+        <span class="kpi-label">Today's Totals (${state.dailyFoodItems.length} items)</span>
         <span class="kpi-value">${Math.round(totals.calories)} cal | ${Math.round(totals.protein)}p / ${Math.round(totals.carbs)}c / ${Math.round(totals.fat)}f</span>
       </div>
     </div>

--- a/public/tools/CalorieTracker/ui/chart.js
+++ b/public/tools/CalorieTracker/ui/chart.js
@@ -40,6 +40,10 @@ const CHART_CONFIG = {
   ENABLE_DEBUG_LOGGING: true
 };
 
+// Pull border color token for target line
+const css = getComputedStyle(document.documentElement);
+const borderColor = `hsl(${css.getPropertyValue('--border').trim()})`;
+
 // Chart colors are provided by CONFIG.CHART_COLORS
 
 // =========================
@@ -67,9 +71,9 @@ function handleChartError(operation, error) {
   const errorDiv = document.getElementById('chart-error-display');
   if (errorDiv) {
     errorDiv.innerHTML = `
-      <div class="p-4 bg-red-50 border border-red-200 rounded-lg">
-        <p class="text-red-800 font-medium">Chart Error in ${operation}</p>
-        <p class="text-red-600 text-sm">${error.message}</p>
+      <div class="p-4 border surface-1 rounded-lg">
+        <p class="text-negative font-medium">Chart Error in ${operation}</p>
+        <p class="text-negative text-sm">${error.message}</p>
       </div>
     `;
   }
@@ -417,7 +421,7 @@ export function updateChart() {
             label: 'Target (100%)',
             data: new Array(labels.length).fill(100),
             type: 'line',
-            borderColor: '#6B7280',
+            borderColor: borderColor,
             borderDash: [5, 5],
             borderWidth: 2,
             fill: false,
@@ -586,34 +590,34 @@ function updateChartTable(tableData, nutrientKeys, labels) {
     }
 
     if (!Object.keys(tableData).length || !nutrientKeys.length) {
-      tableContainer.innerHTML = '<p class="text-gray-500 text-center py-4">No data available for selected nutrients and timeframe</p>';
+      tableContainer.innerHTML = '<p class="text-muted text-center py-4">No data available for selected nutrients and timeframe</p>';
       return;
     }
 
     let html = `
-      <div class="overflow-x-auto bg-white rounded-lg border border-gray-200">
+      <div class="overflow-x-auto surface-1 rounded-lg border">
         <table class="min-w-full">
-          <thead class="bg-gray-50">
+          <thead class="surface-2">
             <tr>
-              <th class="px-4 py-3 text-left text-sm font-semibold text-gray-700">Nutrient</th>`;
+              <th class="px-4 py-3 text-left text-sm font-semibold text-secondary">Nutrient</th>`;
     
     labels.forEach(dateStr => {
       const date = new Date(`${dateStr}T00:00:00`);
       const shortDate = date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
-      html += `<th class="px-3 py-3 text-center text-sm font-semibold text-gray-700">${shortDate}</th>`;
+      html += `<th class="px-3 py-3 text-center text-sm font-semibold text-secondary">${shortDate}</th>`;
     });
-    
-    html += `</tr></thead><tbody class="divide-y divide-gray-200">`;
+
+    html += `</tr></thead><tbody class="divide-y">`;
 
     nutrientKeys.forEach(nutrient => {
-      html += `<tr class="hover:bg-gray-50">
-        <td class="px-4 py-3 text-sm font-medium text-gray-900">${formatNutrientName(nutrient)}</td>`;
+      html += `<tr class="hover-surface-2">
+        <td class="px-4 py-3 text-sm font-medium text-primary">${formatNutrientName(nutrient)}</td>`;
       
       labels.forEach(dateStr => {
         const data = tableData[dateStr][nutrient];
         if (data) {
-          const colorClass = data.percentage >= 90 && data.percentage <= 110 ? 'text-green-600' :
-                            data.percentage >= 70 ? 'text-yellow-600' : 'text-red-600';
+          const colorClass = data.percentage >= 90 && data.percentage <= 110 ? 'text-positive' :
+                            data.percentage >= 70 ? 'text-warning' : 'text-negative';
           
           html += `
             <td class="px-3 py-3 text-center text-sm">
@@ -621,7 +625,7 @@ function updateChartTable(tableData, nutrientKeys, labels) {
               <div class="${colorClass} text-xs">${data.percentage.toFixed(0)}%</div>
             </td>`;
         } else {
-          html += `<td class="px-3 py-3 text-center text-sm text-gray-400">—</td>`;
+          html += `<td class="px-3 py-3 text-center text-sm text-muted">—</td>`;
         }
       });
       

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -148,6 +148,7 @@ function getScaledNutrientTarget(nutrient, baseTarget, trainingBump) {
 const clampPct150 = (v, tgt) => Math.max(0, Math.min(150, (v / Math.max(1, tgt)) * 100));
 const pctWidth = (v, tgt) => clampPct150(v, tgt) + "%";
 const markerLeft = "66.6667%";
+const remainClass = v => v > 0 ? 'text-positive' : v < 0 ? 'text-negative' : 'text-muted';
 
 // =========================
 // MAIN BANKING CALCULATION
@@ -784,8 +785,8 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
                 <div class="meta">
                   <span class="current">${Math.round(todaysProtein)}g</span>
                   <span class="target">target ${Math.round(proteinG)}g</span>
-                  <span class="remain ${remainingProtein >= 0 ? 'text-positive' : 'text-negative'}">
-                    ${remainingProtein >= 0 ? `${Math.round(remainingProtein)}g left` : `${Math.abs(Math.round(remainingProtein))}g over`}
+                  <span class="remain ${remainClass(remainingProtein)}">
+                    ${remainingProtein > 0 ? `${Math.round(remainingProtein)}g left` : remainingProtein < 0 ? `${Math.abs(Math.round(remainingProtein))}g over` : '0g left'}
                   </span>
                   ${proteinPct > 150 ? `<span class="over">${Math.round((todaysProtein/proteinG)*100)}% of goal</span>` : ''}
                 </div>
@@ -806,8 +807,8 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
                 <div class="meta">
                   <span class="current">${Math.round(todaysFat)}g</span>
                   <span class="target">target ${Math.round(fatG)}g</span>
-                  <span class="remain ${remainingFat >= 0 ? 'text-positive' : 'text-negative'}">
-                    ${remainingFat >= 0 ? `${Math.round(remainingFat)}g left` : `${Math.abs(Math.round(remainingFat))}g over`}
+                  <span class="remain ${remainClass(remainingFat)}">
+                    ${remainingFat > 0 ? `${Math.round(remainingFat)}g left` : remainingFat < 0 ? `${Math.abs(Math.round(remainingFat))}g over` : '0g left'}
                   </span>
                   ${fatPct > 150 ? `<span class="over">${Math.round((todaysFat/fatG)*100)}% of goal</span>` : ''}
                 </div>
@@ -828,8 +829,8 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
                 <div class="meta">
                   <span class="current">${Math.round(todaysCarbs)}g</span>
                   <span class="target">target ${Math.round(carbsG)}g</span>
-                  <span class="remain ${remainingCarbs >= 0 ? 'text-positive' : 'text-negative'}">
-                    ${remainingCarbs >= 0 ? `${Math.round(remainingCarbs)}g left` : `${Math.abs(Math.round(remainingCarbs))}g over`}
+                  <span class="remain ${remainClass(remainingCarbs)}">
+                    ${remainingCarbs > 0 ? `${Math.round(remainingCarbs)}g left` : remainingCarbs < 0 ? `${Math.abs(Math.round(remainingCarbs))}g over` : '0g left'}
                   </span>
                   ${carbsPct > 150 ? `<span class="over">${Math.round((todaysCarbs/carbsG)*100)}% of goal</span>` : ''}
                 </div>
@@ -914,7 +915,7 @@ function renderMicronutrientSections(metrics) {
           <div class="meta">
             <span class="current">${displayValue.toFixed(1)}</span>
             <span class="target">target ${targetValue.toFixed(1)}</span>
-            <span class="remain ${displayValue >= targetValue ? 'text-positive' : 'text-negative'}">${Math.round(clampPct150(displayValue, targetValue))}%</span>
+            <span class="remain ${remainClass(displayValue - targetValue)}">${Math.round(clampPct150(displayValue, targetValue))}%</span>
             ${pct > 150 ? `<span class="over">${Math.round(pct)}%</span>` : ''}
           </div>
           <div class="hbar">


### PR DESCRIPTION
## Summary
- route chart palette through CSS tokens in Calorie Tracker config
- style KPI tables and chart UI with shared utilities
- document shared `hbar`, `kpi-row`, and `--chart-N-hex` tokens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

## Docs
- `README.md`


------
https://chatgpt.com/codex/tasks/task_b_689ff44cec108320bfbe2bf619a6a533