### PR TITLE
feat: streamline kpi nutrient rows

### DIFF
--- a/public/shared-styles.css
+++ b/public/shared-styles.css
@@ -249,6 +249,7 @@ body {
 /* KPI row layout */
 .kpi-row { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: .5rem .75rem; }
 .kpi-row .meta { display:flex; gap:.75rem; align-items:center; font-size:.85rem; }
+.kpi-row .meta .label { font-weight:600; min-width:6rem; }
 .kpi-row .meta .current { color:hsl(var(--text)); font-weight:600; }
 .kpi-row .meta .target  { color:hsl(var(--text-2)); }
 .kpi-row .meta .remain  { color:hsl(var(--text-3)); }


### PR DESCRIPTION
## Summary
- condense macro KPI cards into single-line rows with 0–150% progress bars
- simplify micronutrient display into table-style rows with gradient fill
- add dynamic color helper and label styling for KPI rows
- replace inline bar colors with token classes and configurable thresholds
- derive warn/good classes from bar marker to fix thresholds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68ad1d53ca108320b3eedb589ece29ba