### PR TITLE
Add batch CSV templates & upload support for Date Night; docs and style updates

### DIFF
--- a/AI_AGENTS.md
+++ b/AI_AGENTS.md
@@ -15,7 +15,7 @@ This document is the **single source of truth** for automated assistants (Claude
   - `style-guide/page.tsx` showcases UI tokens and basic components
   - `tools/trip-cost/**` Firebase-backed Trip Cost React app
   - `tools/trip-planner/**` Trip Planner scaffold (Firebase Auth + UI timeline)
-  - `tools/date-night/**` Date Night Roulette (Firebase Auth + Firestore roller + reviews; split math in `lib/{decay,stacking,roller}.ts` with Vitest tests)
+  - `tools/date-night/**` Date Night Roulette (Firebase Auth + Firestore roller + reviews + batch CSV imports; split math in `lib/{decay,stacking,roller}.ts` with Vitest tests)
 - **/components** — Reusable UI (Button via CVA, Input, Select, Nav, ProjectCard)
 - **/public** — Static HTML/CSS/JS sub-sites and assets
   - `/games/**`, `/tools/**`, `/trips/**` each with their own `index.html`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ public/
   Path: `/tools/trip-cost`
 - **Trip Planner** — React-based itinerary planner backed by Firebase Auth + Firestore with a timeline UI, idea library, and shared settings/map panels.
   Path: `/tools/trip-planner`
-- **Date Night Roulette** — Firebase-backed picker for date ideas/modifiers with veto/accept flow and photo/review history.
+- **Date Night Roulette** — Firebase-backed picker for date ideas/modifiers with veto/accept flow, batch CSV uploads for pool items, and photo/review history.
   Path: `/tools/date-night`
 - **Calorie Tracker** — A simple tool to track daily calorie intake (Static HTML).
   Path: `/tools/CalorieTracker/index.html`

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Key features:
 - **Accept/veto state machine:** spins are local-first, accepts persist `pending-review` rolls, vetoes increment source counters and reroll.
 - **Pending review workflow:** two participant review columns (1-9 labeled scoring), photo uploads with client-side compression, and completion handling.
 - **Admin participant panel:** add/edit participant UIDs + display names directly in-app.
+- **Batch list management:** downloadable CSV templates plus batch upload support for date ideas and modifiers.
 - **History & stats:** most-loved dates, veto leaderboards, dormancy ranking, weekly streak, and score histogram.
 
 Data persists under `artifacts/date-night/**` with `couples/main`, `settings/global`, `dates`, `modifiers`, and `rolls`.

--- a/app/style-guide/page.tsx
+++ b/app/style-guide/page.tsx
@@ -29,6 +29,7 @@ const colorTokens = [
 
 const buttonVariants = ['primary', 'secondary', 'danger', 'success', 'ghost'] as const;
 const spacingSizes = ['1', '2', '4', '8', '16', '24', '32'];
+const csvUploadHeaders = ['name', 'description', 'rarity', 'frequency', 'baseWeight', 'decayEnabled'];
 
 export default function StyleGuidePage() {
   const [colors, setColors] = useState<{ name: string; label: string; value: string }[]>([]);
@@ -97,6 +98,23 @@ export default function StyleGuidePage() {
           <Select label="Disabled" disabled>
             <option>Option A</option>
           </Select>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-3xl font-semibold mb-8">CSV Upload Pattern</h2>
+        <div className="rounded-xl border border-border bg-surface-2/60 p-5 space-y-3">
+          <p className="text-sm text-text-2">
+            Use this pattern when tools support downloadable template files + batch CSV uploads.
+          </p>
+          <div className="rounded-lg border border-border/70 bg-surface-1 p-3">
+            <p className="text-xs uppercase tracking-wide text-text-3 mb-2">Required columns</p>
+            <p className="font-mono text-xs text-text-2 break-all">{csvUploadHeaders.join(', ')}</p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button variant="secondary" size="sm" type="button">Download template</Button>
+            <Input label="Upload CSV" type="file" />
+          </div>
         </div>
       </section>
 
@@ -172,4 +190,3 @@ export default function StyleGuidePage() {
     </div>
   );
 }
-

--- a/app/tools/date-night/components/Manage.tsx
+++ b/app/tools/date-night/components/Manage.tsx
@@ -27,12 +27,60 @@ const FREQUENCY_LABELS: Record<DateNightFrequency, string> = {
   biannual: 'Twice a year',
   annual: 'Once a year',
 };
+const CSV_HEADERS = ['name', 'description', 'rarity', 'frequency', 'baseWeight', 'decayEnabled'] as const;
+const CSV_TEMPLATE_ROWS = [
+  ['Wine tasting night', 'Try a new local winery or tasting room', 'uncommon', 'monthly', '1.4', 'true'],
+  ['Picnic at sunset', 'Pack snacks and watch the sunset together', 'common', 'biweekly', '1.1', 'true'],
+];
+
+const splitCsvLine = (line: string) => {
+  const values: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let idx = 0; idx < line.length; idx += 1) {
+    const char = line[idx];
+
+    if (char === '"') {
+      const next = line[idx + 1];
+      if (inQuotes && next === '"') {
+        current += '"';
+        idx += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      values.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  values.push(current.trim());
+  return values.map((value) => value.replace(/^"(.*)"$/, '$1').trim());
+};
+
+const parseBoolean = (value: string, fallback = true) => {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return fallback;
+  return ['true', '1', 'yes', 'y'].includes(normalized);
+};
+
+const isRarity = (value: string): value is DateNightRarity => RARITIES.includes(value as DateNightRarity);
+const isFrequency = (value: string): value is DateNightFrequency => FREQUENCIES.includes(value as DateNightFrequency);
 
 export default function Manage() {
   const { dates, modifiers, saveItem, deleteItem } = useDateNight();
   const [kind, setKind] = useState<'date' | 'modifier'>('date');
   const [editing, setEditing] = useState<DateNightPoolItem | null>(null);
   const [sort, setSort] = useState<'recent' | 'accepted' | 'dormant'>('recent');
+  const [uploadingBatch, setUploadingBatch] = useState(false);
+  const [batchMessage, setBatchMessage] = useState('');
   const [form, setForm] = useState({
     name: '', description: '', rarity: 'common' as DateNightRarity, frequency: 'anytime' as DateNightFrequency, baseWeight: 1, decayEnabled: true,
   });
@@ -50,6 +98,118 @@ export default function Manage() {
     await saveItem(kind, form, editing?.id);
     setEditing(null);
     setForm({ name: '', description: '', rarity: 'common', frequency: 'anytime', baseWeight: 1, decayEnabled: true });
+  };
+
+  const downloadTemplate = (downloadKind: 'date' | 'modifier') => {
+    const suffix = downloadKind === 'date' ? 'idea' : 'modifier';
+    const csvRows = [
+      CSV_HEADERS.join(','),
+      ...CSV_TEMPLATE_ROWS.map((row) => row.map((value) => `"${value.replace(/"/g, '""')}"`).join(',')),
+    ];
+
+    const blob = new Blob([csvRows.join('\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `date-night-${suffix}-batch-template.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleBatchUpload = async (event: React.ChangeEvent<HTMLInputElement>, uploadKind: 'date' | 'modifier') => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    setBatchMessage('');
+    if (!file) return;
+
+    try {
+      setUploadingBatch(true);
+      const raw = await file.text();
+      const lines = raw
+        .split(/\r?\n/g)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      if (lines.length < 2) {
+        setBatchMessage('CSV must include a header row and at least one data row.');
+        return;
+      }
+
+      const [header, ...rows] = lines;
+      const parsedHeader = splitCsvLine(header).map((column) => column.trim());
+      const missingColumns = CSV_HEADERS.filter((column) => !parsedHeader.includes(column));
+      const existingItems = uploadKind === 'date' ? dates : modifiers;
+      const existingNames = new Set(
+        existingItems
+          .map((item) => item.name.trim().toLowerCase())
+          .filter(Boolean),
+      );
+
+      if (missingColumns.length > 0) {
+        setBatchMessage(`Missing required columns: ${missingColumns.join(', ')}`);
+        return;
+      }
+
+      const savedNames: string[] = [];
+      const rowErrors: string[] = [];
+
+      for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+        const values = splitCsvLine(rows[rowIndex]);
+        const rowMap = Object.fromEntries(parsedHeader.map((key, index) => [key, values[index] ?? '']));
+        const name = rowMap.name?.trim() ?? '';
+        const normalizedName = name.toLowerCase();
+        const rarity = (rowMap.rarity ?? '').trim();
+        const frequency = (rowMap.frequency ?? '').trim();
+        const baseWeight = Number(rowMap.baseWeight);
+
+        if (!name) {
+          rowErrors.push(`Row ${rowIndex + 2}: name is required.`);
+          continue;
+        }
+        if (!isRarity(rarity)) {
+          rowErrors.push(`Row ${rowIndex + 2}: invalid rarity "${rarity}".`);
+          continue;
+        }
+        if (!isFrequency(frequency)) {
+          rowErrors.push(`Row ${rowIndex + 2}: invalid frequency "${frequency}".`);
+          continue;
+        }
+        if (Number.isNaN(baseWeight)) {
+          rowErrors.push(`Row ${rowIndex + 2}: baseWeight must be a number.`);
+          continue;
+        }
+        if (existingNames.has(normalizedName)) {
+          rowErrors.push(`Row ${rowIndex + 2}: skipped duplicate name "${name}".`);
+          continue;
+        }
+
+        existingNames.add(normalizedName);
+
+        await saveItem(uploadKind, {
+          name,
+          description: rowMap.description ?? '',
+          rarity,
+          frequency,
+          baseWeight,
+          decayEnabled: parseBoolean(rowMap.decayEnabled ?? '', true),
+        });
+        savedNames.push(name);
+      }
+
+      if (savedNames.length > 0 && rowErrors.length === 0) {
+        setBatchMessage(`Uploaded ${savedNames.length} ${uploadKind === 'date' ? 'date idea' : 'modifier'} item(s) successfully.`);
+        return;
+      }
+
+      if (savedNames.length > 0) {
+        setBatchMessage(`Uploaded ${savedNames.length} row(s) with ${rowErrors.length} warning(s): ${rowErrors.slice(0, 3).join(' ')}`);
+        return;
+      }
+
+      setBatchMessage(`No rows were imported. ${rowErrors.slice(0, 3).join(' ')}`);
+    } finally {
+      setUploadingBatch(false);
+    }
   };
 
   return (
@@ -76,6 +236,44 @@ export default function Manage() {
           {editing && <Button type="button" variant="ghost" onClick={() => setEditing(null)}>Cancel edit</Button>}
         </div>
       </form>
+
+      <div className="rounded-xl border border-border/60 bg-surface-2/60 p-4 space-y-3">
+        <h3 className="text-lg font-semibold">Batch upload</h3>
+        <p className="text-sm text-text-2">
+          Download a CSV template, fill in each row, then upload to add multiple date ideas or modifiers at once.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Button size="sm" variant="secondary" type="button" onClick={() => downloadTemplate('date')}>
+            Download date ideas CSV template
+          </Button>
+          <Button size="sm" variant="secondary" type="button" onClick={() => downloadTemplate('modifier')}>
+            Download modifiers CSV template
+          </Button>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="text-sm text-text-2">
+            Upload date ideas CSV
+            <input
+              className="mt-2 block w-full text-sm file:mr-3 file:rounded-lg file:border file:border-border file:bg-surface-3 file:px-3 file:py-2 file:text-text"
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(event) => void handleBatchUpload(event, 'date')}
+              disabled={uploadingBatch}
+            />
+          </label>
+          <label className="text-sm text-text-2">
+            Upload modifiers CSV
+            <input
+              className="mt-2 block w-full text-sm file:mr-3 file:rounded-lg file:border file:border-border file:bg-surface-3 file:px-3 file:py-2 file:text-text"
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(event) => void handleBatchUpload(event, 'modifier')}
+              disabled={uploadingBatch}
+            />
+          </label>
+        </div>
+        {batchMessage && <p className="text-sm text-text-2">{batchMessage}</p>}
+      </div>
 
       <ul className="space-y-3">
         {sorted.map((item) => (

--- a/app/tools/date-night/components/Manage.tsx
+++ b/app/tools/date-night/components/Manage.tsx
@@ -33,16 +33,17 @@ const CSV_TEMPLATE_ROWS = [
   ['Picnic at sunset', 'Pack snacks and watch the sunset together', 'common', 'biweekly', '1.1', 'true'],
 ];
 
-const splitCsvLine = (line: string) => {
-  const values: string[] = [];
+const parseCsvContent = (raw: string) => {
+  const rows: string[][] = [];
+  let row: string[] = [];
   let current = '';
   let inQuotes = false;
 
-  for (let idx = 0; idx < line.length; idx += 1) {
-    const char = line[idx];
+  for (let idx = 0; idx < raw.length; idx += 1) {
+    const char = raw[idx];
 
     if (char === '"') {
-      const next = line[idx + 1];
+      const next = raw[idx + 1];
       if (inQuotes && next === '"') {
         current += '"';
         idx += 1;
@@ -53,16 +54,29 @@ const splitCsvLine = (line: string) => {
     }
 
     if (char === ',' && !inQuotes) {
-      values.push(current.trim());
+      row.push(current.trim());
       current = '';
+      continue;
+    }
+
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && raw[idx + 1] === '\n') idx += 1;
+      row.push(current.trim());
+      current = '';
+      const hasContent = row.some((value) => value.length > 0);
+      if (hasContent) rows.push(row);
+      row = [];
       continue;
     }
 
     current += char;
   }
 
-  values.push(current.trim());
-  return values.map((value) => value.replace(/^"(.*)"$/, '$1').trim());
+  row.push(current.trim());
+  const hasContent = row.some((value) => value.length > 0);
+  if (hasContent) rows.push(row);
+
+  return rows;
 };
 
 const parseBoolean = (value: string, fallback = true) => {
@@ -125,18 +139,15 @@ export default function Manage() {
     try {
       setUploadingBatch(true);
       const raw = await file.text();
-      const lines = raw
-        .split(/\r?\n/g)
-        .map((line) => line.trim())
-        .filter(Boolean);
+      const records = parseCsvContent(raw);
 
-      if (lines.length < 2) {
+      if (records.length < 2) {
         setBatchMessage('CSV must include a header row and at least one data row.');
         return;
       }
 
-      const [header, ...rows] = lines;
-      const parsedHeader = splitCsvLine(header).map((column) => column.trim());
+      const [header, ...rows] = records;
+      const parsedHeader = header.map((column) => column.trim());
       const missingColumns = CSV_HEADERS.filter((column) => !parsedHeader.includes(column));
       const existingItems = uploadKind === 'date' ? dates : modifiers;
       const existingNames = new Set(
@@ -154,7 +165,7 @@ export default function Manage() {
       const rowErrors: string[] = [];
 
       for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
-        const values = splitCsvLine(rows[rowIndex]);
+        const values = rows[rowIndex];
         const rowMap = Object.fromEntries(parsedHeader.map((key, index) => [key, values[index] ?? '']));
         const name = rowMap.name?.trim() ?? '';
         const normalizedName = name.toLowerCase();
@@ -185,15 +196,19 @@ export default function Manage() {
 
         existingNames.add(normalizedName);
 
-        await saveItem(uploadKind, {
-          name,
-          description: rowMap.description ?? '',
-          rarity,
-          frequency,
-          baseWeight,
-          decayEnabled: parseBoolean(rowMap.decayEnabled ?? '', true),
-        });
-        savedNames.push(name);
+        try {
+          await saveItem(uploadKind, {
+            name,
+            description: rowMap.description ?? '',
+            rarity,
+            frequency,
+            baseWeight,
+            decayEnabled: parseBoolean(rowMap.decayEnabled ?? '', true),
+          });
+          savedNames.push(name);
+        } catch (error) {
+          rowErrors.push(`Row ${rowIndex + 2}: failed to save "${name}".`);
+        }
       }
 
       if (savedNames.length > 0 && rowErrors.length === 0) {

--- a/public/shared-styles.css
+++ b/public/shared-styles.css
@@ -260,6 +260,25 @@ body {
 .kpi-row .meta .remain  { color:hsl(var(--text-3)); }
 .kpi-row .meta .over    { font-size:.75rem; color:hsl(var(--error)); }
 
+/* ---------- Batch CSV upload helpers ---------- */
+.upload-panel {
+  background: hsl(var(--surface-2));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.upload-columns {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.upload-note {
+  color: hsl(var(--text-2));
+  font-size: 0.875rem;
+}
+
 /* Table helpers */
 .divide-y > * + * { border-top:1px solid hsl(var(--border)); }
 .hover-surface-2:hover { background-color:hsl(var(--surface-2)); }


### PR DESCRIPTION
### Motivation
- Enable bulk management of date ideas and modifiers by adding CSV templates and batch upload support to the Date Night tool. 
- Surface the CSV pattern in the style guide and provide shared styles so future tools can follow the same UX.
- Update documentation to reflect the new batch-import capability across the repo map and architecture notes.

### Description
- Implemented batch CSV support in `app/tools/date-night/components/Manage.tsx` including CSV parsing (`splitCsvLine`), `parseBoolean`, header validation, row-level validation, duplicate detection, `downloadTemplate`, and `handleBatchUpload` with user-facing messages and upload state. 
- Added a CSV template definition and example rows (`CSV_HEADERS`, `CSV_TEMPLATE_ROWS`) and wired file inputs + template download buttons into the Manage UI. 
- Added a CSV upload pattern section to the style guide (`app/style-guide/page.tsx`) exposing `csvUploadHeaders` and a sample UI with a download button and file input. 
- Added shared CSS rules to `public/shared-styles.css` for upload panel layout and copy (`.upload-panel`, `.upload-columns`, `.upload-note`). 
- Updated documentation files (`AI_AGENTS.md`, `ARCHITECTURE.md`, and `README.md`) to mention batch CSV imports for the Date Night tool and to keep the repo map and tool descriptions current.

### Testing
- Ran the project's unit test suite with `npm test` (Vitest) which executed existing Date Night math tests and related unit tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69efb6c919788320ba6b5d5fea3f501e)