### PR TITLE
fix: set Edge runtime for classify and recommend API routes

### DIFF
--- a/app/api/classify/route.ts
+++ b/app/api/classify/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'edge';
 import { NextRequest, NextResponse } from 'next/server';
 import { VIBE_CATEGORIES } from '@/app/tools/shows/lib/vibeCategories';
 

--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'edge';
 import { NextRequest, NextResponse } from 'next/server';
 import type { Show } from '@/app/tools/shows/types';
 import type { MoodEntry, HistoryEntry } from '@/app/tools/shows/lib/recommendationContext';


### PR DESCRIPTION
### Motivation
- Cloudflare Pages requires API routes to explicitly opt into the Edge runtime (`export const runtime = 'edge';`) so the Next.js App Router build does not fail.

### Description
- Add `export const runtime = 'edge';` at the top of both `app/api/classify/route.ts` and `app/api/recommend/route.ts` with no other logic changes and placed before imports/exports.

### Testing
- Verified updated file contents and placement of the runtime exports using `nl`/`sed`/`cat`, staged and committed the two files successfully (`git status`, `git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1688b41208320b506f8fb402124b7)