### PR TITLE
Add show descriptions and delete functionality with improved AI classification

### DIFF
--- a/app/api/classify/route.ts
+++ b/app/api/classify/route.ts
@@ -2,6 +2,9 @@ export const runtime = 'edge';
 import { NextRequest, NextResponse } from 'next/server';
 import { VIBE_CATEGORIES } from '@/app/tools/shows/lib/vibeCategories';
 import { callGemini } from '@/app/lib/aiConfig';
+import type { ShowType } from '@/app/tools/shows/types';
+
+const ALLOWED_TYPES = new Set<string>(['anime', 'tv', 'movie', 'animated_movie']);
 
 export async function POST(req: NextRequest) {
   const key = process.env.GEMINI_API_KEY;
@@ -22,9 +25,13 @@ export async function POST(req: NextRequest) {
   }
 
   const prompt =
-    `Given the show or movie titled "${title.trim()}" (type: ${type}), pick 2 to 4 vibe tags ` +
-    `from this exact list: ${VIBE_CATEGORIES.join(', ')}. ` +
-    `Return ONLY a JSON array of strings.`;
+    `You are classifying a show or movie for a personal watchlist app.\n\n` +
+    `Title: "${title.trim()}"\n\n` +
+    `Return JSON with three fields:\n` +
+    `1. "type": one of "anime", "tv", "movie", "animated_movie"\n` +
+    `2. "vibes": array of 2 to 4 tags from this exact list (no others): ${VIBE_CATEGORIES.join(', ')}\n` +
+    `3. "description": a 1 to 3 sentence description capturing tone, themes, and any standout traits. Max 200 characters. No spoilers. No generic plot summary.\n\n` +
+    `Return JSON only. No prose, no markdown, no code fences.`;
 
   let raw: string;
   try {
@@ -34,24 +41,38 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: message }, { status: 500 });
   }
 
-  const jsonMatch = raw.match(/\[[\s\S]*\]/);
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
   const cleaned = jsonMatch ? jsonMatch[0] : raw;
 
-  let tags: unknown;
+  let parsed: unknown;
   try {
-    tags = JSON.parse(cleaned);
+    parsed = JSON.parse(cleaned);
   } catch {
     return NextResponse.json({ error: 'AI returned invalid JSON.' }, { status: 502 });
   }
 
-  if (!Array.isArray(tags)) {
-    return NextResponse.json({ error: 'AI response was not an array.' }, { status: 502 });
+  if (typeof parsed !== 'object' || parsed === null) {
+    return NextResponse.json({ error: 'AI response was not an object.' }, { status: 502 });
   }
 
+  const obj = parsed as Record<string, unknown>;
+
+  // Validate and normalize type
+  const rawType = typeof obj.type === 'string' ? obj.type : '';
+  const resolvedType: ShowType = ALLOWED_TYPES.has(rawType)
+    ? (rawType as ShowType)
+    : 'anime';
+
+  // Validate and normalize vibes
   const allowed = new Set<string>(VIBE_CATEGORIES);
-  const valid = (tags as unknown[])
+  const rawVibes = Array.isArray(obj.vibes) ? obj.vibes : [];
+  const vibes = (rawVibes as unknown[])
     .filter((t): t is string => typeof t === 'string' && allowed.has(t))
     .slice(0, 4);
 
-  return NextResponse.json({ vibes: valid });
+  // Validate and normalize description
+  const rawDescription = typeof obj.description === 'string' ? obj.description : '';
+  const description = rawDescription.slice(0, 200);
+
+  return NextResponse.json({ type: resolvedType, vibes, description });
 }

--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -16,16 +16,21 @@ function buildPrompt(
   candidates: Show[],
   history: Record<string, HistoryEntry>,
 ): string {
-  const moodLines = Object.values(moods)
-    .map((m) => `${m.name} is feeling: ${m.mood || '(no input)'}`)
-    .join('\n');
-
   const historyLines = Object.values(history)
     .map((h) => {
       const shows =
         h.highScoringShows.length > 0
           ? h.highScoringShows
-              .map((s) => `  - ${s.title}: ${s.vibes.join(', ')} (${s.composite.toFixed(1)})`)
+              .map((s) => {
+                const parts = [
+                  `  - ${s.title}`,
+                  `vibes: ${s.vibes.join(', ')}`,
+                  `composite: ${s.composite.toFixed(1)}`,
+                ];
+                if (s.description) parts.push(`description: ${s.description}`);
+                if (s.notes) parts.push(`notes: ${s.notes}`);
+                return parts.join(' | ');
+              })
               .join('\n')
           : '  (no high-scoring history yet)';
       return `${h.name}'s high-scoring shows (composite ≥ 7):\n${shows}`;
@@ -36,22 +41,33 @@ function buildPrompt(
     .map((s) => {
       const ep =
         s.currentSeason !== null || s.currentEpisode !== null
-          ? ` — S${s.currentSeason ?? '?'} E${s.currentEpisode ?? '?'}`
+          ? ` | current: S${s.currentSeason ?? '?'} E${s.currentEpisode ?? '?'}`
           : '';
       const vibes = s.vibeTags.length > 0 ? s.vibeTags.join(', ') : 'no tags';
-      return `  - id:${s.id} | ${s.title} (${s.type}) | vibes: ${vibes} | status: ${s.status}${ep}`;
+      const parts = [
+        `  - id:${s.id}`,
+        `${s.title} (${s.type})`,
+        `vibes: ${vibes}`,
+        `status: ${s.status}${ep}`,
+      ];
+      if (s.description) parts.push(`description: ${s.description}`);
+      if (s.notes) parts.push(`notes: ${s.notes}`);
+      return parts.join(' | ');
     })
     .join('\n');
 
   return (
-    `Pick one show for these people to watch together right now.\n\n` +
-    `${moodLines}\n\n` +
-    `${historyLines}\n\n` +
-    `Available shows (status: watching/planned/on_hold):\n${candidateLines}\n\n` +
-    `Pick the show that best fits both moods AND the patterns in what each person has historically rated highly. ` +
-    `Prefer shows whose vibes overlap with vibes both people have liked before. ` +
-    `Return JSON only (no prose, no markdown): { "showId": "<id from the list above>", "reason": "<2-3 sentences>" }. ` +
-    `Reason should explain why this fits both moods and aligns with their history.`
+    `Pick one show for these people to watch together right now. Weight your decision in this exact order:\n\n` +
+    `1. VIBES FIRST: Match the candidate's vibe tags to what each person is feeling right now, and to the vibes of shows each person has historically rated highly. This is your strongest signal.\n\n` +
+    `2. SCORE HISTORY SECOND: Each person's high-scoring shows (composite ≥ 7) show what they tend to enjoy. Favor candidates whose vibes overlap with vibes from each person's high-scoring shows.\n\n` +
+    `3. NOTES IF RELEVANT: Personal notes are written by the viewers themselves and are high-signal when they apply. Read each candidate's notes carefully. If a note seems relevant to the current mood or situation (e.g. comments on pacing, content that matches what someone wants tonight, prior watch context), weight it heavily. If a note is unrelated trivia, ignore it. Same for notes on history shows.\n\n` +
+    `4. DESCRIPTION FOURTH: AI-generated descriptions add tone and theme nuance. Use as light context and tiebreaker.\n\n` +
+    Object.values(moods).map((m) => `${m.name} is feeling: ${m.mood || '(no input)'}`).join('\n') +
+    `\n\n${historyLines}\n\n` +
+    `Available shows in their watchlist (status: watching/planned/on_hold):\n${candidateLines}\n\n` +
+    `Pick one. Return JSON only (no prose, no markdown, no code fences):\n` +
+    `{ "showId": "<id from the list above>", "reason": "<2-3 sentences>" }\n\n` +
+    `The reason should lead with the vibe match. Mention score-history connection if relevant. Bring in notes only if a note materially shaped the pick. Description is fine to leave unmentioned.`
   );
 }
 

--- a/app/tools/shows/components/ShowForm.tsx
+++ b/app/tools/shows/components/ShowForm.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { X, Sparkles, Loader2, Trash2 } from 'lucide-react';
 import type { Show, ShowType, ShowStatus, ShowList } from '../types';
 import { VIBE_CATEGORIES } from '../lib/vibeCategories';
-import { isRatable } from '../lib/compositeScore';
 import VibeTagChip from './VibeTagChip';
 import ScoreBlock from './ScoreBlock';
 import { useShows } from '../ShowsContext';
@@ -157,7 +156,7 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
       };
       if (isEdit && show) {
         await updateShow(show.id, payload);
-        if (user && isRatable(status)) {
+        if (user) {
           await updateMyRating(show.id, pendingRating);
         }
       } else {
@@ -175,7 +174,7 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
     show.createdBy === user.uid || (activeList?.adminUids.includes(user.uid) ?? false)
   );
   const showEpisodeFields = hasEpisodes(type);
-  const showScores = isEdit && show && isRatable(status);
+  const showScores = isEdit && show;
 
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
@@ -387,7 +386,7 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
             />
           </div>
 
-          {/* Score blocks — only on edit when ratable */}
+          {/* Score blocks — visible on edit for all statuses */}
           {showScores && user && (
             <div className="space-y-2">
               <p className="text-sm font-medium text-text-2">Scores</p>

--- a/app/tools/shows/components/ShowForm.tsx
+++ b/app/tools/shows/components/ShowForm.tsx
@@ -59,6 +59,7 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
   const [watchers, setWatchers] = useState<string[]>(
     show?.watchers ?? (user ? [user.uid] : []),
   );
+  const [description, setDescription] = useState(show?.description ?? '');
   const [notes, setNotes] = useState(show?.notes ?? '');
   const [vibeTags, setVibeTags] = useState<string[]>(show?.vibeTags ?? []);
   const [classifying, setClassifying] = useState(false);
@@ -93,7 +94,10 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
       });
       if (!res.ok) throw new Error('Classification failed');
       const data = await res.json();
+      // AI owns type, vibes, and description — never touches notes
+      if (data.type) setType(data.type);
       if (data.vibes?.length) setVibeTags(data.vibes);
+      if (typeof data.description === 'string') setDescription(data.description);
     } catch {
       setError('Could not classify — check your connection and try again.');
     } finally {
@@ -150,6 +154,7 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
         totalSeasons: hasEpisodes(type) && totalSeasons ? Number(totalSeasons) : null,
         service: resolvedService,
         watchers,
+        description,
         notes,
         vibeTags,
         ratings: show?.ratings ?? {},
@@ -374,14 +379,26 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
             </div>
           </div>
 
-          {/* Notes */}
+          {/* Description (AI-populated) */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-text-2">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              placeholder="AI will fill this when you classify the show."
+              className="w-full rounded-lg bg-surface-2 border border-border px-3 py-2.5 text-sm text-text placeholder:text-text-3 focus:outline-none focus:border-accent resize-none"
+            />
+          </div>
+
+          {/* Notes (user-only) */}
           <div className="space-y-1.5">
             <label className="text-sm font-medium text-text-2">Notes</label>
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               rows={3}
-              placeholder="Anything to remember…"
+              placeholder="Your personal notes about this show."
               className="w-full rounded-lg bg-surface-2 border border-border px-3 py-2.5 text-sm text-text placeholder:text-text-3 focus:outline-none focus:border-accent resize-none"
             />
           </div>

--- a/app/tools/shows/components/ShowForm.tsx
+++ b/app/tools/shows/components/ShowForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { X, Sparkles, Loader2 } from 'lucide-react';
+import { X, Sparkles, Loader2, Trash2 } from 'lucide-react';
 import type { Show, ShowType, ShowStatus, ShowList } from '../types';
 import { VIBE_CATEGORIES } from '../lib/vibeCategories';
 import { isRatable } from '../lib/compositeScore';
@@ -40,7 +40,7 @@ interface Props {
 }
 
 export default function ShowForm({ show, listId, members, onClose }: Props) {
-  const { user, addShow, updateShow, updateMyRating } = useShows();
+  const { user, activeList, addShow, updateShow, updateMyRating, deleteShow } = useShows();
   const isEdit = !!show;
 
   const [title, setTitle] = useState(show?.title ?? '');
@@ -64,6 +64,8 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
   const [vibeTags, setVibeTags] = useState<string[]>(show?.vibeTags ?? []);
   const [classifying, setClassifying] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [error, setError] = useState('');
 
   // Local rating state for the current user (editable inline)
@@ -97,6 +99,21 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
       setError('Could not classify — check your connection and try again.');
     } finally {
       setClassifying(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!show) return;
+    setDeleting(true);
+    setError('');
+    try {
+      await deleteShow(show.id);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed. Try again.');
+      setShowDeleteConfirm(false);
+    } finally {
+      setDeleting(false);
     }
   }
 
@@ -140,7 +157,6 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
       };
       if (isEdit && show) {
         await updateShow(show.id, payload);
-        // Persist rating changes separately (dot-notation field)
         if (user && isRatable(status)) {
           await updateMyRating(show.id, pendingRating);
         }
@@ -155,6 +171,9 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
     }
   }
 
+  const canDelete = isEdit && show && user && (
+    show.createdBy === user.uid || (activeList?.adminUids.includes(user.uid) ?? false)
+  );
   const showEpisodeFields = hasEpisodes(type);
   const showScores = isEdit && show && isRatable(status);
 
@@ -403,6 +422,20 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
             </div>
           )}
 
+          {/* Delete */}
+          {canDelete && (
+            <div className="border-t border-border pt-4 flex justify-center">
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="flex items-center gap-1.5 text-sm text-error bg-transparent hover:underline"
+              >
+                <Trash2 size={14} />
+                Delete this show
+              </button>
+            </div>
+          )}
+
           {/* Submit */}
           <div className="flex gap-3 pt-2 pb-safe">
             <button
@@ -422,6 +455,37 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
           </div>
         </form>
       </div>
+
+      {/* Delete confirmation dialog */}
+      {showDeleteConfirm && show && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={() => setShowDeleteConfirm(false)}
+          />
+          <div className="relative z-10 w-full max-w-sm rounded-2xl bg-surface-1 border border-border p-6 space-y-4 shadow-2">
+            <h3 className="font-semibold text-text">Delete &ldquo;{show.title}&rdquo;?</h3>
+            <p className="text-sm text-text-2">This can&rsquo;t be undone.</p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                className="flex-1 rounded-xl border border-border bg-surface-2 py-3 text-sm font-medium text-text-2 hover:text-text transition-colors min-h-[48px]"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className="flex-1 rounded-xl bg-error py-3 text-sm font-semibold text-white disabled:opacity-50 transition-opacity min-h-[48px]"
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/tools/shows/lib/recommendationContext.ts
+++ b/app/tools/shows/lib/recommendationContext.ts
@@ -8,7 +8,13 @@ export interface MoodEntry {
 
 export interface HistoryEntry {
   name: string;
-  highScoringShows: Array<{ title: string; vibes: string[]; composite: number }>;
+  highScoringShows: Array<{
+    title: string;
+    vibes: string[];
+    composite: number;
+    description: string;
+    notes: string;
+  }>;
 }
 
 export function buildHistory(
@@ -23,7 +29,13 @@ export function buildHistory(
         if (!rating) return [];
         const composite = memberComposite(rating);
         if (composite === null || composite < 7) return [];
-        return [{ title: show.title, vibes: show.vibeTags, composite }];
+        return [{
+          title: show.title,
+          vibes: show.vibeTags,
+          composite,
+          description: show.description ?? '',
+          notes: show.notes ?? '',
+        }];
       });
     history[member.uid] = { name: member.displayName, highScoringShows };
   }

--- a/app/tools/shows/types.ts
+++ b/app/tools/shows/types.ts
@@ -43,6 +43,7 @@ export interface Show {
   totalSeasons: number | null;
   service: string | null;
   watchers: string[];
+  description: string;
   notes: string;
   vibeTags: string[];
   ratings: Record<string, MemberRating>;

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import { usePathname } from 'next/navigation';
-import Button from '@/components/Button';
 
 /* ------------------------------------------------------------ */
 /* CONFIGURATION: navigation links & classes                    */
@@ -18,13 +17,10 @@ const navLinks = [
 const linkBaseClass = 'transition-all duration-200 ease-in-out hover:text-text focus-ring';
 const activeLinkClass = 'text-text font-medium';
 const inactiveLinkClass = 'text-text-2';
-const mobileMenuTransition =
-  'transition-all duration-200 ease-in-out origin-top transform';
 const navShellClass =
   'sticky top-0 z-50 backdrop-blur-md bg-surface-2/80 border-b border-border shadow-sm';
 const navBarClass = 'container-tight flex items-center justify-between py-2 sm:py-3';
 const brandClass = 'text-base sm:text-lg font-semibold';
-const mobileToggleClass = 'md:hidden p-2 border border-border hover:border-accent';
 
 export default function Nav() {
   const pathname = usePathname();
@@ -35,16 +31,16 @@ export default function Nav() {
         <Link href="/" className={`${brandClass} ${linkBaseClass}`}>
           JB
         </Link>
-        <Button
+        {/* Plain button avoids Button component's py-4 (size="sm") bloating header height */}
+        <button
+          type="button"
           aria-label="Toggle menu"
           aria-expanded={open}
-          variant="ghost"
-          size="sm"
-          className={mobileToggleClass}
+          className="md:hidden inline-flex items-center justify-center rounded-lg border border-border bg-transparent text-text hover:border-accent p-2 min-h-[44px] min-w-[44px] transition-all duration-200 ease-in-out"
           onClick={() => setOpen(!open)}
         >
           {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-        </Button>
+        </button>
         <ul className="hidden md:flex gap-6">
           {navLinks.map((link) => {
             const isActive = pathname === link.href;
@@ -61,11 +57,10 @@ export default function Nav() {
           })}
         </ul>
       </nav>
+      {/* max-h transition collapses height to zero when closed; scale-y-0 left height in DOM flow */}
       <div
-        className={`md:hidden border-t border-border bg-surface-2 overflow-hidden ${mobileMenuTransition} ${
-          open
-            ? 'scale-y-100 opacity-100'
-            : 'scale-y-0 opacity-0 pointer-events-none'
+        className={`md:hidden border-t border-border bg-surface-2 overflow-hidden transition-all duration-200 ease-in-out ${
+          open ? 'max-h-80 opacity-100' : 'max-h-0 opacity-0 pointer-events-none'
         }`}
       >
         <ul className="px-4 py-4 space-y-4">


### PR DESCRIPTION
## Summary
This PR enhances the show management system by introducing AI-generated descriptions, user-initiated show deletion with permission checks, and improved AI classification that now returns type and description in addition to vibes. The recommendation algorithm is also refined to better weight vibe matches and incorporate notes and descriptions.

## Key Changes

**Show Management**
- Added `description` field to Show type, populated by AI during classification
- Implemented delete functionality with confirmation dialog and permission checks (creator or list admin only)
- Separated description (AI-owned) from notes (user-owned) in the form UI with distinct placeholders

**AI Classification (`/api/classify`)**
- Extended classification endpoint to return three fields: `type`, `vibes`, and `description`
- AI now validates and normalizes show type (anime/tv/movie/animated_movie) instead of accepting user input
- Descriptions are AI-generated (1-3 sentences, max 200 chars, no spoilers)
- Improved prompt to guide AI toward tone/themes rather than generic plot summaries

**Recommendation Algorithm (`/api/recommend`)**
- Restructured prompt with explicit priority weighting: vibes first, score history second, notes third, description fourth
- Enhanced candidate and history formatting to include descriptions and notes
- Clarified that notes are high-signal when relevant to mood/situation, and should be weighted accordingly
- Removed mood lines from initial prompt structure for cleaner formatting

**UI/UX**
- Added delete button (Trash2 icon) visible only to authorized users
- Delete confirmation modal with backdrop blur and clear warning
- Updated form labels and placeholders to clarify AI vs. user-owned fields
- Removed `isRatable` check for score visibility—scores now display for all show statuses on edit

**Navigation**
- Replaced Button component usage in Nav with plain button element to avoid height bloat
- Improved mobile menu collapse animation using max-height instead of scale-y

## Implementation Details
- Delete permission logic: `show.createdBy === user.uid || activeList?.adminUids.includes(user.uid)`
- Description field is editable but intended to be AI-populated; notes remain user-only
- Classification no longer touches notes (AI owns type/vibes/description only)
- Recommendation prompt now explicitly instructs AI to lead reasoning with vibe matches and mention score-history connections when relevant

https://claude.ai/code/session_01WtxbhRYpc1VmbMgg3afwAv