### PR TITLE
Date Night: add roll deletion and participant access checks; improve History and Pending UI

### DIFF
--- a/app/tools/date-night/DateNightContext.tsx
+++ b/app/tools/date-night/DateNightContext.tsx
@@ -82,6 +82,7 @@ interface DateNightContextValue {
   acceptCandidate: (candidate: RollCandidate, vetoCount: number) => Promise<void>;
   recordVeto: (candidate: RollCandidate) => Promise<void>;
   archivePendingRollWithoutReview: (rollId: string) => Promise<void>;
+  deleteRoll: (rollId: string) => Promise<void>;
   upsertReview: (rollId: string, slot: 'a' | 'b', review: Omit<DateNightReview, 'submittedAt'>) => Promise<void>;
   addPhoto: (rollId: string, file: File) => Promise<void>;
   markCompleted: (rollId: string) => Promise<void>;
@@ -89,6 +90,16 @@ interface DateNightContextValue {
 }
 
 const DateNightContext = createContext<DateNightContextValue | undefined>(undefined);
+
+
+const requireParticipantAccess = (user: User | null, couple: DateNightCoupleDoc | null) => {
+  const isDateNightParticipant = Boolean(
+    user && (isAdmin(user) || (couple?.participantUids ?? []).includes(user.uid)),
+  );
+  if (!isDateNightParticipant) {
+    throw new Error('Only Date Night participants can perform this action.');
+  }
+};
 
 const incrementCounters = async (
   kind: 'date' | 'modifier',
@@ -245,17 +256,25 @@ export function DateNightProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const archivePendingRollWithoutReview = useCallback(async (rollId: string) => {
+    requireParticipantAccess(user, couple);
     await updateDoc(rollDoc(rollId), { status: 'archived-no-review', updatedAt: serverTimestamp() });
-  }, []);
+  }, [couple, user]);
+
+  const deleteRoll = useCallback(async (rollId: string) => {
+    requireParticipantAccess(user, couple);
+    await deleteDoc(rollDoc(rollId));
+  }, [couple, user]);
 
   const upsertReview = useCallback(async (rollId: string, slot: 'a' | 'b', review: Omit<DateNightReview, 'submittedAt'>) => {
+    requireParticipantAccess(user, couple);
     await updateDoc(rollDoc(rollId), {
       [`reviews.${slot}`]: { ...review, submittedAt: new Date().toISOString() },
       updatedAt: serverTimestamp(),
     });
-  }, []);
+  }, [couple, user]);
 
   const addPhoto = useCallback(async (rollId: string, file: File) => {
+    requireParticipantAccess(user, couple);
     const prepared = await compressFile(file);
     const storagePath = `artifacts/date-night/uploads/${rollId}/${prepared.hash}.${prepared.extension}`;
     const objectRef = ref(storage, storagePath);
@@ -266,11 +285,12 @@ export function DateNightProvider({ children }: { children: ReactNode }) {
       photos: arrayUnion({ url, storagePath, uploadedAt: new Date().toISOString() }),
       updatedAt: serverTimestamp(),
     });
-  }, []);
+  }, [couple, user]);
 
   const markCompleted = useCallback(async (rollId: string) => {
+    requireParticipantAccess(user, couple);
     await updateDoc(rollDoc(rollId), { status: 'completed', updatedAt: serverTimestamp() });
-  }, []);
+  }, [couple, user]);
 
   const saveParticipant = useCallback(async (uid: string, displayName: string) => {
     const current = couple ?? { participantUids: [], displayNames: {} };
@@ -322,6 +342,7 @@ export function DateNightProvider({ children }: { children: ReactNode }) {
     acceptCandidate,
     recordVeto,
     archivePendingRollWithoutReview,
+    deleteRoll,
     upsertReview,
     addPhoto,
     markCompleted,
@@ -345,6 +366,7 @@ export function DateNightProvider({ children }: { children: ReactNode }) {
     acceptCandidate,
     recordVeto,
     archivePendingRollWithoutReview,
+    deleteRoll,
     upsertReview,
     addPhoto,
     markCompleted,

--- a/app/tools/date-night/components/History.tsx
+++ b/app/tools/date-night/components/History.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import Button from '@/components/Button';
 import Input from '@/components/Input';
+import { useDateNight } from '../DateNightContext';
 import { weeksSince } from '../lib/decay';
 import { toDateOrNull } from '../lib/time';
-import { useDateNight } from '../DateNightContext';
 
 /* ------------------------------------------------------------ */
-/* CONFIGURATION: filters + score bins                          */
+/* CONFIGURATION: filters + score bins + empty state text       */
 /* ------------------------------------------------------------ */
 const STATUSES = ['all', 'pending-review', 'completed', 'archived-no-review'] as const;
 const SCORE_BINS = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+const STATS_EMPTY_STATE_TEXT = 'Roll and review more dates to unlock statistics.';
 
 const weekKey = (iso: string) => {
   const date = new Date(iso);
@@ -20,9 +22,10 @@ const weekKey = (iso: string) => {
 };
 
 export default function History() {
-  const { rolls, dates, modifiers } = useDateNight();
+  const { rolls, dates, modifiers, deleteRoll } = useDateNight();
   const [search, setSearch] = useState('');
   const [status, setStatus] = useState<(typeof STATUSES)[number]>('all');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const filtered = useMemo(() => {
     const term = search.toLowerCase();
@@ -33,8 +36,14 @@ export default function History() {
     });
   }, [rolls, search, status]);
 
-  const completedRolls = useMemo(() => rolls.filter((roll) => roll.status === 'completed'), [rolls]);
-  const allScores = completedRolls.flatMap((roll) => [roll.reviews.a?.score, roll.reviews.b?.score].filter(Boolean) as number[]);
+  const completedRolls = useMemo(
+    () => rolls.filter((roll) => roll.status === 'completed'),
+    [rolls],
+  );
+
+  const allScores = completedRolls.flatMap((roll) =>
+    [roll.reviews.a?.score, roll.reviews.b?.score].filter(Boolean) as number[],
+  );
 
   const scoreHistogram = SCORE_BINS.map((score) => ({
     score,
@@ -50,21 +59,37 @@ export default function History() {
   }
 
   const mostLoved = [...lovedMap.values()]
-    .map((entry) => ({ name: entry.name, avg: entry.scores.reduce((a, b) => a + b, 0) / Math.max(1, entry.scores.length) }))
+    .filter((entry) => entry.scores.length > 0)
+    .map((entry) => ({
+      name: entry.name,
+      avg: entry.scores.reduce((a, b) => a + b, 0) / entry.scores.length,
+    }))
     .sort((a, b) => b.avg - a.avg)
     .slice(0, 5);
 
-  const topVetoedDates = [...dates].sort((a, b) => b.timesVetoed - a.timesVetoed).slice(0, 5);
-  const topVetoedModifiers = [...modifiers].sort((a, b) => b.timesVetoed - a.timesVetoed).slice(0, 5);
+  const topVetoedDates = [...dates]
+    .filter((item) => item.timesVetoed > 0)
+    .sort((a, b) => b.timesVetoed - a.timesVetoed)
+    .slice(0, 5);
+
+  const topVetoedModifiers = [...modifiers]
+    .filter((item) => item.timesVetoed > 0)
+    .sort((a, b) => b.timesVetoed - a.timesVetoed)
+    .slice(0, 5);
+
   const longestDormant = [...dates, ...modifiers]
+    .filter((item) => Boolean(item.lastAcceptedAt))
     .map((item) => ({ name: item.name, weeks: weeksSince(item.lastAcceptedAt) }))
     .sort((a, b) => b.weeks - a.weeks)
     .slice(0, 5);
 
-  const weekSet = new Set(completedRolls.flatMap((roll) => {
-    const createdAt = toDateOrNull(roll.createdAt);
-    return createdAt ? [weekKey(createdAt.toISOString())] : [];
-  }));
+  const weekSet = new Set(
+    completedRolls.flatMap((roll) => {
+      const createdAt = toDateOrNull(roll.createdAt);
+      return createdAt ? [weekKey(createdAt.toISOString())] : [];
+    }),
+  );
+
   let streak = 0;
   let cursor = new Date();
   while (true) {
@@ -77,61 +102,200 @@ export default function History() {
   const totalRolls = rolls.length;
   const completed = completedRolls.length;
   const acceptRate = totalRolls ? Math.round((completed / totalRolls) * 100) : 0;
+  const hasAnyStatData =
+    mostLoved.length > 0 ||
+    topVetoedDates.length > 0 ||
+    topVetoedModifiers.length > 0 ||
+    longestDormant.length > 0;
 
   return (
     <section className="rounded-xl3 border border-border bg-surface-1/80 p-5 shadow-md space-y-4">
-      <h2 className="text-xl font-semibold">History & Stats</h2>
+      <h2 className="text-xl font-semibold">History &amp; Stats</h2>
+
       <div className="grid sm:grid-cols-4 gap-3">
-        <div className="kpi"><p className="kpi-label">Total rolls</p><p className="kpi-value">{totalRolls}</p></div>
-        <div className="kpi"><p className="kpi-label">Accept rate</p><p className="kpi-value">{acceptRate}%</p></div>
-        <div className="kpi"><p className="kpi-label">Completed streak</p><p className="kpi-value">{streak} weeks</p></div>
-        <div className="kpi"><p className="kpi-label">Completed</p><p className="kpi-value">{completed}</p></div>
+        <div className="kpi">
+          <p className="kpi-label">Total rolls</p>
+          <p className="kpi-value">{totalRolls}</p>
+        </div>
+        <div className="kpi">
+          <p className="kpi-label">Accept rate</p>
+          <p className="kpi-value">{acceptRate}%</p>
+        </div>
+        <div className="kpi">
+          <p className="kpi-label">Completed streak</p>
+          <p className="kpi-value">{streak} weeks</p>
+        </div>
+        <div className="kpi">
+          <p className="kpi-label">Completed</p>
+          <p className="kpi-value">{completed}</p>
+        </div>
       </div>
 
-      <div className="grid lg:grid-cols-2 gap-4">
-        <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3">
-          <p className="font-medium mb-2">Most-loved dates (avg score)</p>
-          <ul className="space-y-1 text-sm">{mostLoved.map((row) => <li key={row.name}>{row.name} — {row.avg.toFixed(2)}</li>)}</ul>
-        </div>
-        <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3 space-y-2">
-          <p className="font-medium">Score distribution</p>
-          {scoreHistogram.map((entry) => (
-            <div className="kpi-row" key={entry.score}>
-              <div className="meta"><span className="label">{entry.score}</span><span className="current">{entry.count}</span></div>
-              <div className="hbar">
-                <div className="hbar-fill" style={{ width: `${Math.min(150, entry.count * 18)}%` }} />
-                <div className="hbar-marker" style={{ left: '66.666%' }} />
-              </div>
+      {!hasAnyStatData ? (
+        <p className="text-sm text-text-2">{STATS_EMPTY_STATE_TEXT}</p>
+      ) : (
+        <>
+          <div className="grid lg:grid-cols-2 gap-4">
+            <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3">
+              <p className="font-medium mb-2">Most-loved dates (avg score)</p>
+              {mostLoved.length === 0 ? (
+                <p className="text-sm text-text-2">{STATS_EMPTY_STATE_TEXT}</p>
+              ) : (
+                <ul className="space-y-1 text-sm">
+                  {mostLoved.map((row) => (
+                    <li key={row.name}>
+                      {row.name} — {row.avg.toFixed(2)}
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
-          ))}
-        </div>
-      </div>
 
-      <div className="grid lg:grid-cols-3 gap-4">
-        <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3"><p className="font-medium mb-2">Most-vetoed dates</p><ul className="text-sm space-y-1">{topVetoedDates.map((row) => <li key={row.id}>{row.name} ({row.timesVetoed})</li>)}</ul></div>
-        <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3"><p className="font-medium mb-2">Most-vetoed modifiers</p><ul className="text-sm space-y-1">{topVetoedModifiers.map((row) => <li key={row.id}>{row.name} ({row.timesVetoed})</li>)}</ul></div>
-        <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3"><p className="font-medium mb-2">Longest dormant</p><ul className="text-sm space-y-1">{longestDormant.map((row) => <li key={row.name}>{row.name} ({row.weeks.toFixed(1)}w)</li>)}</ul></div>
-      </div>
+            <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3 space-y-2">
+              <p className="font-medium">Score distribution</p>
+              {scoreHistogram.map((entry) => (
+                <div className="kpi-row" key={entry.score}>
+                  <div className="meta">
+                    <span className="label">{entry.score}</span>
+                    <span className="current">{entry.count}</span>
+                  </div>
+                  <div className="hbar">
+                    <div className="hbar-fill" style={{ width: `${Math.min(150, entry.count * 18)}%` }} />
+                    <div className="hbar-marker" style={{ left: '66.666%' }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid lg:grid-cols-3 gap-4">
+            <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3">
+              <p className="font-medium mb-2">Most-vetoed dates</p>
+              {topVetoedDates.length === 0 ? (
+                <p className="text-sm text-text-2">{STATS_EMPTY_STATE_TEXT}</p>
+              ) : (
+                <ul className="text-sm space-y-1">
+                  {topVetoedDates.map((row) => (
+                    <li key={row.id}>
+                      {row.name} ({row.timesVetoed})
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3">
+              <p className="font-medium mb-2">Most-vetoed modifiers</p>
+              {topVetoedModifiers.length === 0 ? (
+                <p className="text-sm text-text-2">{STATS_EMPTY_STATE_TEXT}</p>
+              ) : (
+                <ul className="text-sm space-y-1">
+                  {topVetoedModifiers.map((row) => (
+                    <li key={row.id}>
+                      {row.name} ({row.timesVetoed})
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="rounded-xl border border-border/60 bg-surface-2/70 p-3">
+              <p className="font-medium mb-2">Longest dormant</p>
+              {longestDormant.length === 0 ? (
+                <p className="text-sm text-text-2">{STATS_EMPTY_STATE_TEXT}</p>
+              ) : (
+                <ul className="text-sm space-y-1">
+                  {longestDormant.map((row) => (
+                    <li key={row.name}>
+                      {row.name} ({row.weeks.toFixed(1)}w)
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </>
+      )}
 
       <div className="grid sm:grid-cols-2 gap-3">
         <Input label="Search" value={search} onChange={(e) => setSearch(e.target.value)} />
-        <label className="text-sm">Status
-          <select className="mt-1 w-full rounded-md border-border bg-surface-2" value={status} onChange={(e) => setStatus(e.target.value as (typeof STATUSES)[number])}>
-            {STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+        <label className="text-sm">
+          Status
+          <select
+            className="mt-1 w-full rounded-md border-border bg-surface-2"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as (typeof STATUSES)[number])}
+          >
+            {STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
           </select>
         </label>
       </div>
 
       <div className="space-y-2">
-        {filtered.map((roll) => (
-          <article key={roll.id} className="rounded-xl border border-border/60 bg-surface-2/70 p-3">
-            <div className="flex items-center justify-between gap-3">
-              <p className="font-medium">{roll.date.name}</p>
-              <span className="badge info">{roll.status}</span>
-            </div>
-            <p className="text-sm text-text-3">{roll.modifiers.map((m) => m.name).join(', ') || 'No modifiers'} · vetoes before accept: {roll.vetoCount ?? 0}</p>
-          </article>
-        ))}
+        {filtered.map((roll) => {
+          const isExpanded = expandedId === roll.id;
+
+          return (
+            <article key={roll.id} className="rounded-xl border border-border/60 bg-surface-2/70 p-3 space-y-2">
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-medium">{roll.date.name}</p>
+                <span className="badge info">{roll.status}</span>
+              </div>
+
+              <p className="text-sm text-text-3">
+                {roll.modifiers.map((m) => m.name).join(', ') || 'No modifiers'} · vetoes before accept:{' '}
+                {roll.vetoCount ?? 0}
+              </p>
+
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => setExpandedId(isExpanded ? null : roll.id)}
+                >
+                  {isExpanded ? 'Hide Details' : 'View Details'}
+                </Button>
+                <Button size="sm" variant="danger" onClick={() => void deleteRoll(roll.id)}>
+                  Delete Record
+                </Button>
+              </div>
+
+              {isExpanded && (
+                <div className="rounded-lg border border-border/50 bg-surface-1/60 p-3 text-sm space-y-2">
+                  <p>
+                    <strong>Review A:</strong>{' '}
+                    {roll.reviews.a
+                      ? `${roll.reviews.a.score}/9 · liked: ${roll.reviews.a.liked || '-'} · disliked: ${roll.reviews.a.disliked || '-'} · notes: ${roll.reviews.a.notes || '-'}`
+                      : 'Not submitted.'}
+                  </p>
+                  <p>
+                    <strong>Review B:</strong>{' '}
+                    {roll.reviews.b
+                      ? `${roll.reviews.b.score}/9 · liked: ${roll.reviews.b.liked || '-'} · disliked: ${roll.reviews.b.disliked || '-'} · notes: ${roll.reviews.b.notes || '-'}`
+                      : 'Not submitted.'}
+                  </p>
+
+                  {roll.photos.length > 0 && (
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+                      {roll.photos.map((photo) => (
+                        <img
+                          key={photo.storagePath}
+                          src={photo.url}
+                          alt="review upload"
+                          className="h-24 w-full rounded-lg object-cover border border-border/60"
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/app/tools/date-night/components/PendingDate.tsx
+++ b/app/tools/date-night/components/PendingDate.tsx
@@ -8,49 +8,62 @@ import { REVIEW_SLOT_ORDER, useDateNight } from '../DateNightContext';
 import ScorePicker from './PendingDate/ScorePicker';
 
 /* ------------------------------------------------------------ */
-/* CONFIGURATION: local review defaults + lightbox state        */
+/* CONFIGURATION: review defaults + UI labels                   */
 /* ------------------------------------------------------------ */
 const DEFAULT_SCORE = 7;
+const CANCEL_SPIN_BUTTON_TEXT = 'Cancel Spin';
 
 export default function PendingDate() {
-  const { pendingRoll, reviewSlotNames, upsertReview, addPhoto, markCompleted } = useDateNight();
+  const {
+    pendingRoll,
+    dates,
+    modifiers,
+    reviewSlotNames,
+    upsertReview,
+    addPhoto,
+    markCompleted,
+    archivePendingRollWithoutReview,
+  } = useDateNight();
+
   const fileRef = useRef<HTMLInputElement | null>(null);
   const [lightbox, setLightbox] = useState<string | null>(null);
 
   const [notes, setNotes] = useState<Record<'a' | 'b', string>>({ a: '', b: '' });
   const [liked, setLiked] = useState<Record<'a' | 'b', string>>({ a: '', b: '' });
   const [disliked, setDisliked] = useState<Record<'a' | 'b', string>>({ a: '', b: '' });
-  const [scores, setScores] = useState<Record<'a' | 'b', number>>({ a: DEFAULT_SCORE, b: DEFAULT_SCORE });
+  const [scores, setScores] = useState<Record<'a' | 'b', number>>({
+    a: DEFAULT_SCORE,
+    b: DEFAULT_SCORE,
+  });
+
+  const dateLookup = useMemo(() => new Map(dates.map((item) => [item.id, item])), [dates]);
+  const modifierLookup = useMemo(() => new Map(modifiers.map((item) => [item.id, item])), [modifiers]);
 
   useEffect(() => {
     if (!pendingRoll) return;
-    const nextNotes = { a: pendingRoll.reviews.a?.notes ?? '', b: pendingRoll.reviews.b?.notes ?? '' };
-    const nextLiked = { a: pendingRoll.reviews.a?.liked ?? '', b: pendingRoll.reviews.b?.liked ?? '' };
-    const nextDisliked = { a: pendingRoll.reviews.a?.disliked ?? '', b: pendingRoll.reviews.b?.disliked ?? '' };
-    const nextScores = { a: pendingRoll.reviews.a?.score ?? DEFAULT_SCORE, b: pendingRoll.reviews.b?.score ?? DEFAULT_SCORE };
-    setNotes(nextNotes);
-    setLiked(nextLiked);
-    setDisliked(nextDisliked);
-    setScores(nextScores);
+
+    setNotes({
+      a: pendingRoll.reviews.a?.notes ?? '',
+      b: pendingRoll.reviews.b?.notes ?? '',
+    });
+    setLiked({
+      a: pendingRoll.reviews.a?.liked ?? '',
+      b: pendingRoll.reviews.b?.liked ?? '',
+    });
+    setDisliked({
+      a: pendingRoll.reviews.a?.disliked ?? '',
+      b: pendingRoll.reviews.b?.disliked ?? '',
+    });
+    setScores({
+      a: pendingRoll.reviews.a?.score ?? DEFAULT_SCORE,
+      b: pendingRoll.reviews.b?.score ?? DEFAULT_SCORE,
+    });
   }, [pendingRoll]);
 
-  const canComplete = useMemo(() => Boolean(pendingRoll?.reviews?.a && pendingRoll?.reviews?.b), [pendingRoll]);
-
-  const submitReview = async (slot: 'a' | 'b') => {
-    if (!pendingRoll) return;
-    await upsertReview(pendingRoll.id, slot, {
-      score: scores[slot],
-      liked: liked[slot],
-      disliked: disliked[slot],
-      notes: notes[slot],
-    });
-
-    const other = slot === 'a' ? 'b' : 'a';
-    const otherAlreadySubmitted = Boolean(pendingRoll.reviews?.[other]);
-    if (otherAlreadySubmitted) {
-      await markCompleted(pendingRoll.id);
-    }
-  };
+  const canComplete = useMemo(
+    () => Boolean(pendingRoll?.reviews?.a && pendingRoll?.reviews?.b),
+    [pendingRoll],
+  );
 
   if (!pendingRoll) {
     return (
@@ -61,36 +74,98 @@ export default function PendingDate() {
     );
   }
 
+  const rolledDate = dateLookup.get(pendingRoll.date.id);
+  const rolledModifiers = pendingRoll.modifiers.map((mod) => ({
+    ...mod,
+    description: modifierLookup.get(mod.id)?.description,
+  }));
+
+  const submitReview = async (slot: 'a' | 'b') => {
+    await upsertReview(pendingRoll.id, slot, {
+      score: scores[slot],
+      liked: liked[slot],
+      disliked: disliked[slot],
+      notes: notes[slot],
+    });
+
+    const other = slot === 'a' ? 'b' : 'a';
+    if (pendingRoll.reviews?.[other]) {
+      await markCompleted(pendingRoll.id);
+    }
+  };
+
   return (
     <section className="rounded-xl3 border border-border bg-surface-1/80 p-5 shadow-md space-y-4">
-      <h2 className="text-xl font-semibold">Pinned Pending Card</h2>
-      <p className="text-lg font-medium">{pendingRoll.date.name}</p>
-      <p className="text-sm text-text-2">Modifiers: {pendingRoll.modifiers.map((m) => m.name).join(', ') || 'None'}</p>
-
-      <div className="flex items-center gap-3">
-        <input
-          ref={fileRef}
-          type="file"
-          className="hidden"
-          accept="image/*"
-          onChange={(event) => {
-            const file = event.target.files?.[0];
-            if (file) void addPhoto(pendingRoll.id, file);
-            event.currentTarget.value = '';
-          }}
-        />
-        <Button variant="secondary" onClick={() => fileRef.current?.click()} className="inline-flex items-center gap-2">
-          <Camera size={16} /> Upload photo
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Pinned Pending Card</h2>
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={() => void archivePendingRollWithoutReview(pendingRoll.id)}
+        >
+          {CANCEL_SPIN_BUTTON_TEXT}
         </Button>
       </div>
 
+      <div className="rounded-lg border border-border/60 bg-surface-2/60 p-3 space-y-1">
+        <p className="text-lg font-medium">{pendingRoll.date.name}</p>
+        <p className="text-sm text-text-2">
+          {rolledDate?.description || 'No date description provided yet.'}
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-border/60 bg-surface-2/60 p-3 space-y-2">
+        <p className="font-medium">Modifiers</p>
+        {rolledModifiers.length === 0 ? (
+          <p className="text-sm text-text-2">No modifiers.</p>
+        ) : (
+          rolledModifiers.map((mod) => (
+            <div key={mod.id}>
+              <p className="text-sm font-medium">{mod.name}</p>
+              <p className="text-xs text-text-3">
+                {mod.description || 'No modifier description provided yet.'}
+              </p>
+            </div>
+          ))
+        )}
+      </div>
+
+      <input
+        ref={fileRef}
+        type="file"
+        className="hidden"
+        accept="image/*"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) void addPhoto(pendingRoll.id, file);
+          event.currentTarget.value = '';
+        }}
+      />
+      <Button
+        variant="secondary"
+        onClick={() => fileRef.current?.click()}
+        className="inline-flex items-center gap-2"
+      >
+        <Camera size={16} /> Upload photo
+      </Button>
+
       {pendingRoll.photos.length > 0 && (
         <div className="space-y-2">
-          <p className="text-sm text-text-2 inline-flex items-center gap-2"><Images size={14} /> Photos</p>
+          <p className="text-sm text-text-2 inline-flex items-center gap-2">
+            <Images size={14} /> Photos
+          </p>
           <div className="grid grid-cols-3 gap-2">
             {pendingRoll.photos.map((photo) => (
-              <button type="button" key={photo.storagePath} onClick={() => setLightbox(photo.url)}>
-                <img src={photo.url} alt="date night upload" className="h-24 w-full object-cover rounded-lg border border-border/50" />
+              <button
+                type="button"
+                key={photo.storagePath}
+                onClick={() => setLightbox(photo.url)}
+              >
+                <img
+                  src={photo.url}
+                  alt="date night upload"
+                  className="h-24 w-full object-cover rounded-lg border border-border/50"
+                />
               </button>
             ))}
           </div>
@@ -99,13 +174,33 @@ export default function PendingDate() {
 
       <div className="grid md:grid-cols-2 gap-4">
         {REVIEW_SLOT_ORDER.map((slot) => (
-          <div key={slot} className="rounded-lg border border-border/60 bg-surface-2/70 p-3 space-y-2">
+          <div
+            key={slot}
+            className="rounded-lg border border-border/60 bg-surface-2/70 p-3 space-y-2"
+          >
             <p className="font-medium">{reviewSlotNames[slot]}</p>
-            <ScorePicker value={scores[slot]} onChange={(score) => setScores((p) => ({ ...p, [slot]: score }))} />
-            <Input label="Liked" value={liked[slot]} onChange={(e) => setLiked((p) => ({ ...p, [slot]: e.target.value }))} />
-            <Input label="Disliked" value={disliked[slot]} onChange={(e) => setDisliked((p) => ({ ...p, [slot]: e.target.value }))} />
-            <Input label="Notes" value={notes[slot]} onChange={(e) => setNotes((p) => ({ ...p, [slot]: e.target.value }))} />
-            <Button size="sm" onClick={() => void submitReview(slot)}>Save review</Button>
+            <ScorePicker
+              value={scores[slot]}
+              onChange={(score) => setScores((p) => ({ ...p, [slot]: score }))}
+            />
+            <Input
+              label="Liked"
+              value={liked[slot]}
+              onChange={(e) => setLiked((p) => ({ ...p, [slot]: e.target.value }))}
+            />
+            <Input
+              label="Disliked"
+              value={disliked[slot]}
+              onChange={(e) => setDisliked((p) => ({ ...p, [slot]: e.target.value }))}
+            />
+            <Input
+              label="Notes"
+              value={notes[slot]}
+              onChange={(e) => setNotes((p) => ({ ...p, [slot]: e.target.value }))}
+            />
+            <Button size="sm" onClick={() => void submitReview(slot)}>
+              Save review
+            </Button>
           </div>
         ))}
       </div>
@@ -117,8 +212,15 @@ export default function PendingDate() {
       )}
 
       {lightbox && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-4" onClick={() => setLightbox(null)}>
-          <img src={lightbox} alt="Date night full size" className="max-h-[90vh] max-w-[90vw] rounded-xl border border-border" />
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-4"
+          onClick={() => setLightbox(null)}
+        >
+          <img
+            src={lightbox}
+            alt="Date night full size"
+            className="max-h-[90vh] max-w-[90vw] rounded-xl border border-border"
+          />
         </div>
       )}
     </section>


### PR DESCRIPTION
### Motivation
- Prevent non-participants from mutating Date Night data and expose a way to remove roll records from the UI. 
- Improve the History page presentation and empty-state handling so stats are clearer and roll details are viewable and removable. 
- Make the pending-review card more informative by showing date/modifier descriptions, photo lightbox, and a cancel/archive action.

### Description
- Add `requireParticipantAccess` helper and apply it to mutate actions: `archivePendingRollWithoutReview`, `upsertReview`, `addPhoto`, `markCompleted`, and a new `deleteRoll` method to enforce participant-only access. 
- Expose `deleteRoll` on the `DateNightContext` and wire it into the provider's `value`. 
- Update `History` component to import `Button`, wire `deleteRoll`, add expandable roll details with photos and reviews, add a delete button, refine KPI layout, and show an empty-state message when there is no stats data. 
- Update `PendingDate` component to show a cancel spin button that archives the pending roll, display the rolled date description and modifier descriptions, improve file/photo UI and lightbox, and clean up state initialization and lookups for `dates` and `modifiers`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f238b9554883209142be9ba316a65a)