### PR TITLE
Add Firestore security rules for Conflict Tracker tool

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -38,6 +38,15 @@ service cloud.firestore {
       return request.resource.data.diff(resource.data).affectedKeys().hasOnly(allowed);
     }
 
+    // Conflict Tracker: member of a tracker (by UID or invited email)
+    function isConflictTrackerMember(trackerId) {
+      let tracker = get(/databases/$(database)/documents/artifacts/conflict-tracker/trackers/$(trackerId)).data;
+      return isSignedIn() && (
+        request.auth.uid in tracker.memberUids ||
+        (tracker.memberEmails != null && request.auth.token.email in tracker.memberEmails)
+      );
+    }
+
     // Show Tracker: member of a list
     function isShowsListMember(listId) {
       return isSignedIn() &&
@@ -161,6 +170,39 @@ service cloud.firestore {
 
     match /artifacts/date-night/rolls/{docId} {
       allow read, create, update, delete: if isAdmin() || isDateNightParticipant();
+    }
+
+    /* ==================================================================================
+       CONFLICT TRACKER TOOL
+       ================================================================================== */
+
+    match /artifacts/conflict-tracker/trackers/{trackerId} {
+      allow read: if isAdmin() || isConflictTrackerMember(trackerId);
+
+      allow create: if isSignedIn()
+        && request.resource.data.personAUid == request.auth.uid
+        && request.auth.uid in request.resource.data.memberUids
+        && request.resource.data.createdBy == request.auth.uid;
+
+      // Members can update (add custom tags, claim personB side, etc.)
+      allow update: if isAdmin() || isConflictTrackerMember(trackerId);
+
+      allow delete: if isAdmin();
+    }
+
+    match /artifacts/conflict-tracker/trackers/{trackerId}/conflicts/{conflictId} {
+      allow read: if isAdmin() || isConflictTrackerMember(trackerId);
+      allow create: if isConflictTrackerMember(trackerId)
+        && request.resource.data.createdBy == request.auth.uid;
+      allow update: if isAdmin() || isConflictTrackerMember(trackerId);
+      allow delete: if isAdmin() || isConflictTrackerMember(trackerId);
+    }
+
+    match /artifacts/conflict-tracker/trackers/{trackerId}/conflicts/{conflictId}/reflections/{reflectionId} {
+      allow read: if isAdmin() || isConflictTrackerMember(trackerId);
+      allow create, update: if isConflictTrackerMember(trackerId)
+        && request.resource.data.authorUid == request.auth.uid;
+      allow delete: if isAdmin();
     }
 
     /* ==================================================================================


### PR DESCRIPTION
## Summary
This PR adds comprehensive Firestore security rules for the new Conflict Tracker tool, including a helper function to verify tracker membership and access control rules for tracker documents and their subcollections.

## Key Changes
- **New helper function `isConflictTrackerMember()`**: Validates if the current user is a member of a conflict tracker by checking their UID against `memberUids` or their email against `memberEmails`
- **Tracker document rules** (`/artifacts/conflict-tracker/trackers/{trackerId}`):
  - Read access restricted to admins and tracker members
  - Create restricted to signed-in users who are the `personAUid`, included in `memberUids`, and the `createdBy` user
  - Update allowed for admins and tracker members
  - Delete restricted to admins only
- **Conflicts subcollection rules** (`/trackers/{trackerId}/conflicts/{conflictId}`):
  - Read access restricted to admins and tracker members
  - Create restricted to tracker members who are the `createdBy` user
  - Update allowed for admins and tracker members
  - Delete allowed for admins and tracker members
- **Reflections subcollection rules** (`/conflicts/{conflictId}/reflections/{reflectionId}`):
  - Read access restricted to admins and tracker members
  - Create/update restricted to tracker members who are the `authorUid`
  - Delete restricted to admins only

## Implementation Details
- Membership is determined by either UID matching or email matching, supporting both direct members and invited users
- The `createdBy` field is enforced at creation time to maintain audit trails
- Hierarchical access control ensures subcollection access is gated through parent tracker membership
- Admin users have elevated permissions for management and deletion operations

https://claude.ai/code/session_01Q73yNzGU4UYQk5fUJvRuma