### PR TITLE
fix: normalize Conflict Tracker invite email and process Shows invites in real time

### DIFF
--- a/app/tools/conflict-tracker/lib/db.ts
+++ b/app/tools/conflict-tracker/lib/db.ts
@@ -80,13 +80,14 @@ export const createTracker = async (input: {
   personBName: string;
 }): Promise<string> => {
   const ref = doc(trackersCol());
-  const memberEmails = input.personBEmail ? [input.personBEmail] : [];
+  const normalizedEmail = input.personBEmail ? input.personBEmail.toLowerCase().trim() : null;
+  const memberEmails = normalizedEmail ? [normalizedEmail] : [];
   await setDoc(ref, {
     name: input.name,
     personAUid: input.personAUid,
     personAName: input.personAName,
     personBUid: null,
-    personBEmail: input.personBEmail,
+    personBEmail: normalizedEmail,
     personBName: input.personBName,
     memberUids: [input.personAUid],
     memberEmails,

--- a/app/tools/shows/ShowsContext.tsx
+++ b/app/tools/shows/ShowsContext.tsx
@@ -107,6 +107,41 @@ export function ShowsProvider({ children }: { children: ReactNode }) {
     return unsub;
   }, []);
 
+  // Watch for new pending invites while already signed in and process them immediately.
+  // Without this, invites created after sign-in aren't consumed until the next sign-in.
+  useEffect(() => {
+    if (!user?.email) return;
+    const email = user.email.toLowerCase();
+    const q = query(pendingInvitesCol(), where('email', '==', email));
+    const unsub = onSnapshot(q, async (snap) => {
+      if (snap.empty) return;
+      for (const inviteSnap of snap.docs) {
+        const invite = inviteSnap.data();
+        const lRef = listDoc(invite.listId);
+        try {
+          const listSnap = await getDoc(lRef);
+          if (!listSnap.exists()) { await deleteDoc(inviteSnap.ref); continue; }
+          const listData = listSnap.data() as ShowList;
+          if (listData.memberUids?.includes(user.uid)) { await deleteDoc(inviteSnap.ref); continue; }
+          const member: ListMember = {
+            uid: user.uid,
+            email: user.email ?? '',
+            displayName: user.displayName ?? user.email ?? '',
+            role: 'member',
+            joinedAt: Timestamp.now(),
+          };
+          await updateDoc(lRef, {
+            members: arrayUnion(member),
+            memberUids: arrayUnion(user.uid),
+            updatedAt: serverTimestamp(),
+          });
+          await deleteDoc(inviteSnap.ref);
+        } catch { }
+      }
+    });
+    return unsub;
+  }, [user]);
+
   useEffect(() => {
     if (!user) return;
     const q = query(listsCol(), where('memberUids', 'array-contains', user.uid));


### PR DESCRIPTION
- conflict-tracker/lib/db.ts: normalize personBEmail to lowercase+trim before storing
  in memberEmails — Firestore array-contains is case-sensitive so a mixed-case stored
  email silently prevented invited users from seeing the tracker
- shows/ShowsContext.tsx: add onSnapshot listener for pendingInvites so an invite
  created while the user is already signed in is processed immediately rather than
  waiting for the next sign-in cycle

https://claude.ai/code/session_01GE8WosnV3KzNgPFxyk2vAh