### PR TITLE
Refactor invite processing and improve UX with email autocomplete

### DIFF
--- a/app/tools/conflict-tracker/ConflictContext.tsx
+++ b/app/tools/conflict-tracker/ConflictContext.tsx
@@ -178,7 +178,13 @@ export const ConflictProvider = ({ children }: { children: React.ReactNode }) =>
   useEffect(() => {
     if (!user) { setTrackers([]); return; }
     const unsub = watchUserTrackers(user.uid, user.email, (list) => {
-      if (mountedRef.current) setTrackers(list);
+      if (!mountedRef.current) return;
+      setTrackers(list);
+      // Auto-select the first tracker if none is active yet (mirrors shows tracker behavior)
+      setActiveTrackerId((prev) => {
+        if (prev && list.some((t) => t.id === prev)) return prev;
+        return list[0]?.id ?? null;
+      });
     });
     return () => unsub();
   }, [user]);

--- a/app/tools/conflict-tracker/page.tsx
+++ b/app/tools/conflict-tracker/page.tsx
@@ -267,7 +267,7 @@ const ConflictTrackerShell = () => {
     !activeTracker.personBUid &&
     activeTracker.personAUid !== user?.uid &&
     (activeTracker.personBEmail
-      ? activeTracker.personBEmail === user?.email
+      ? activeTracker.personBEmail.toLowerCase() === (user?.email ?? '').toLowerCase()
       : true);
 
   if (authLoading) {

--- a/app/tools/shows/ShowsContext.tsx
+++ b/app/tools/shows/ShowsContext.tsx
@@ -29,7 +29,6 @@ import {
   updateDoc,
   deleteDoc,
   getDocs,
-  getDoc,
   serverTimestamp,
   arrayUnion,
   arrayRemove,
@@ -118,25 +117,24 @@ export function ShowsProvider({ children }: { children: ReactNode }) {
       for (const inviteSnap of snap.docs) {
         const invite = inviteSnap.data();
         const lRef = listDoc(invite.listId);
+        const member: ListMember = {
+          uid: user.uid,
+          email: user.email ?? '',
+          displayName: user.displayName ?? user.email ?? '',
+          role: 'member',
+          joinedAt: Timestamp.now(),
+        };
+        // Skip the pre-flight getDoc — the invited user isn't in memberUids yet so reading
+        // the list would fail with permission-denied and silently swallow the whole invite.
+        // The self-add security rule handles all the guards server-side.
         try {
-          const listSnap = await getDoc(lRef);
-          if (!listSnap.exists()) { await deleteDoc(inviteSnap.ref); continue; }
-          const listData = listSnap.data() as ShowList;
-          if (listData.memberUids?.includes(user.uid)) { await deleteDoc(inviteSnap.ref); continue; }
-          const member: ListMember = {
-            uid: user.uid,
-            email: user.email ?? '',
-            displayName: user.displayName ?? user.email ?? '',
-            role: 'member',
-            joinedAt: Timestamp.now(),
-          };
           await updateDoc(lRef, {
             members: arrayUnion(member),
             memberUids: arrayUnion(user.uid),
             updatedAt: serverTimestamp(),
           });
-          await deleteDoc(inviteSnap.ref);
-        } catch { }
+        } catch { /* list gone or user already a member — still clean up the invite */ }
+        try { await deleteDoc(inviteSnap.ref); } catch { }
       }
     });
     return unsub;
@@ -353,24 +351,23 @@ async function processPendingInvites(u: User) {
   for (const inviteSnap of snap.docs) {
     const invite = inviteSnap.data();
     const lRef = listDoc(invite.listId);
+    const member: ListMember = {
+      uid: u.uid,
+      email: u.email ?? '',
+      displayName: u.displayName ?? u.email ?? '',
+      role: 'member',
+      joinedAt: Timestamp.now(),
+    };
+    // Skip the pre-flight getDoc — the invited user isn't in memberUids yet so reading
+    // the list would fail with permission-denied and silently swallow the whole invite.
+    // The self-add security rule handles all the guards server-side.
     try {
-      const listSnap = await getDoc(lRef);
-      if (!listSnap.exists()) { await deleteDoc(inviteSnap.ref); continue; }
-      const listData = listSnap.data() as ShowList;
-      if (listData.memberUids?.includes(u.uid)) { await deleteDoc(inviteSnap.ref); continue; }
-      const member: ListMember = {
-        uid: u.uid,
-        email: u.email ?? '',
-        displayName: u.displayName ?? u.email ?? '',
-        role: 'member',
-        joinedAt: Timestamp.now(),
-      };
       await updateDoc(lRef, {
         members: arrayUnion(member),
         memberUids: arrayUnion(u.uid),
         updatedAt: serverTimestamp(),
       });
-      await deleteDoc(inviteSnap.ref);
-    } catch { }
+    } catch { /* list gone or user already a member — still clean up the invite */ }
+    try { await deleteDoc(inviteSnap.ref); } catch { }
   }
 }

--- a/app/tools/shows/settings/page.tsx
+++ b/app/tools/shows/settings/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { collection, getDocs, limit, query } from 'firebase/firestore';
 import { Shield, Trash2, UserMinus, CrownIcon, LogOut } from 'lucide-react';
 import Nav from '@/components/Nav';
+import { db } from '../lib/db';
 import { useShows } from '../ShowsContext';
 
 function ConfirmDialog({
@@ -58,6 +60,18 @@ export default function SettingsPage() {
   const [newListName, setNewListName] = useState('');
   const [inviteEmail, setInviteEmail] = useState('');
   const [newName, setNewName] = useState(activeList?.name ?? '');
+  const [knownEmails, setKnownEmails] = useState<string[]>([]);
+
+  useEffect(() => {
+    getDocs(query(collection(db, 'artifacts', 'trip-cost', 'users'), limit(100)))
+      .then((snap) => {
+        const emails = snap.docs
+          .map((d) => (d.data() as Record<string, unknown>).email as string)
+          .filter(Boolean);
+        setKnownEmails(emails);
+      })
+      .catch(() => {});
+  }, []);
   const [confirm, setConfirm] = useState<{ message: string; action: () => void } | null>(null);
   const [saving, setSaving] = useState<string | null>(null);
   const [feedback, setFeedback] = useState('');
@@ -205,11 +219,17 @@ export default function SettingsPage() {
               <form onSubmit={handleInvite} className="flex gap-2 pt-1">
                 <input
                   type="email"
+                  list="shows-known-emails"
                   value={inviteEmail}
                   onChange={(e) => setInviteEmail(e.target.value)}
                   placeholder="Add member by email"
                   className="flex-1 rounded-xl bg-surface-2 border border-border px-3 py-2.5 text-sm text-text placeholder:text-text-3 focus:outline-none focus:border-accent min-h-[44px]"
                 />
+                <datalist id="shows-known-emails">
+                  {knownEmails
+                    .filter((e) => !members.some((m) => m.email === e))
+                    .map((e) => <option key={e} value={e} />)}
+                </datalist>
                 <button
                   type="submit"
                   disabled={saving === 'invite' || !inviteEmail.trim()}


### PR DESCRIPTION
## Summary
This PR refactors the invite processing logic to rely on server-side security rules instead of client-side validation, adds email autocomplete to the settings page, and improves state management in the conflict tracker.

## Key Changes

- **Simplified invite processing**: Removed pre-flight `getDoc()` calls in both `ShowsContext.tsx` and the `processPendingInvites()` function. The server-side security rules now handle all validation (list existence, membership checks), eliminating permission-denied errors that were silently swallowing invites.

- **Improved error handling**: Separated invite cleanup into its own try-catch block to ensure invites are deleted even if the member addition fails, with clarifying comments about expected failure modes.

- **Email autocomplete in settings**: Added a datalist with known emails from the trip-cost users collection to provide autocomplete suggestions when inviting members. The list filters out emails already in the current list.

- **Conflict tracker auto-selection**: Added logic to automatically select the first tracker when the tracker list loads (mirrors shows tracker behavior), improving UX consistency.

- **Case-insensitive email comparison**: Fixed email comparison in conflict tracker to use `.toLowerCase()` for both sides, preventing false negatives due to case differences.

## Implementation Details

- The invite processing refactor moves validation responsibility to Firestore security rules, simplifying client code and preventing race conditions.
- The datalist approach for email autocomplete is lightweight and doesn't require additional API calls beyond the initial user collection fetch.
- Auto-selection of the first tracker only occurs if no tracker is currently active, preserving user selection when the list updates.

https://claude.ai/code/session_01SKHaFvoGDNvP35DypJLBXX