### PR TITLE
Add pre-scoring and rich viewer profiles for recommendations

### DIFF
--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -1,6 +1,6 @@
 export const runtime = 'edge';
 import { NextRequest, NextResponse } from 'next/server';
-import type { MoodEntry, HistoryEntry } from '@/app/tools/shows/lib/recommendationContext';
+import type { MoodEntry, ViewerPreferenceProfile } from '@/app/tools/shows/lib/recommendationContext';
 import type { Show } from '@/app/tools/shows/types';
 import { buildPrompt } from '@/app/tools/shows/lib/buildRecommendPrompt';
 import { callGemini, RECOMMEND_TEMPERATURE } from '@/app/lib/aiConfig';
@@ -8,7 +8,8 @@ import { callGemini, RECOMMEND_TEMPERATURE } from '@/app/lib/aiConfig';
 interface RecommendBody {
   moods: Record<string, MoodEntry>;
   candidates: Show[];
-  history: Record<string, HistoryEntry>;
+  profiles: Record<string, ViewerPreferenceProfile>;
+  sharedMood?: string;
   excludeIds?: string[];
 }
 
@@ -25,11 +26,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  const { moods, candidates: allCandidates, history, excludeIds = [] } = body;
+  const { moods, candidates: allCandidates, profiles, sharedMood, excludeIds = [] } = body;
 
-  if (!moods || !allCandidates || !history) {
+  if (!moods || !allCandidates || !profiles) {
     return NextResponse.json(
-      { error: 'moods, candidates, and history are required.' },
+      { error: 'moods, candidates, and profiles are required.' },
       { status: 400 },
     );
   }
@@ -43,7 +44,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const prompt = buildPrompt(moods, candidates, history);
+  const prompt = buildPrompt(moods, candidates, profiles, sharedMood);
 
   let raw: string;
   try {

--- a/app/tools/shows/__tests__/preScore.test.ts
+++ b/app/tools/shows/__tests__/preScore.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from 'vitest';
+import {
+  inferFocusLevel,
+  inferVibeKeywords,
+  scoreBrainPower,
+  scoreVibeFit,
+  scoreViewerRatingFit,
+  computeCandidatePreScore,
+} from '../lib/preScore';
+import type { Show } from '../types';
+import { Timestamp } from 'firebase/firestore';
+
+/* ------------------------------------------------------------ */
+/* Fixtures                                                     */
+/* ------------------------------------------------------------ */
+
+function ts(): Timestamp {
+  return { seconds: 0, nanoseconds: 0, toDate: () => new Date(0) } as unknown as Timestamp;
+}
+
+function makeShow(patch: Partial<Show> = {}): Show {
+  return {
+    id: 'show1',
+    listId: 'list1',
+    title: 'Test Show',
+    type: 'anime',
+    status: 'watching',
+    currentSeason: null,
+    currentEpisode: null,
+    totalSeasons: null,
+    service: null,
+    watchers: [],
+    description: '',
+    notes: '',
+    memberNotes: {},
+    vibeTags: [],
+    brainPower: null,
+    ratings: {},
+    createdAt: ts(),
+    updatedAt: ts(),
+    createdBy: 'u1',
+    lastEditedBy: 'u1',
+    ...patch,
+  };
+}
+
+function makeRating(composite: number) {
+  return {
+    story: composite,
+    characters: composite,
+    vibes: composite,
+    wouldRewatch: null as null,
+    ratedAt: null as null,
+  };
+}
+
+/* ------------------------------------------------------------ */
+/* inferFocusLevel                                              */
+/* ------------------------------------------------------------ */
+
+describe('inferFocusLevel', () => {
+  it('detects "brain dead" as low focus', () => {
+    expect(inferFocusLevel('Jimi is brain dead after work')).toBe('low');
+  });
+
+  it('detects "braindead" (no space) as low focus', () => {
+    expect(inferFocusLevel('totally braindead tonight')).toBe('low');
+  });
+
+  it('detects "tired" as low focus', () => {
+    expect(inferFocusLevel('so tired, just want to relax')).toBe('low');
+  });
+
+  it('detects "multitasking" as low focus', () => {
+    expect(inferFocusLevel('will be multitasking on the laptop')).toBe('low');
+  });
+
+  it('detects "low focus" phrase as low focus', () => {
+    expect(inferFocusLevel('in a low focus mood tonight')).toBe('low');
+  });
+
+  it('detects "low energy" as low focus', () => {
+    expect(inferFocusLevel('low energy kind of night')).toBe('low');
+  });
+
+  it('detects "background" as low focus', () => {
+    expect(inferFocusLevel('want something for background')).toBe('low');
+  });
+
+  it('detects "exhausted" as low focus', () => {
+    expect(inferFocusLevel('absolutely exhausted')).toBe('low');
+  });
+
+  it('returns normal for neutral text', () => {
+    expect(inferFocusLevel('want to watch something fun tonight')).toBe('normal');
+  });
+
+  it('detects high focus signals', () => {
+    expect(inferFocusLevel('ready to focus on something complex')).toBe('high');
+  });
+
+  it('returns normal for empty string', () => {
+    expect(inferFocusLevel('')).toBe('normal');
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* inferVibeKeywords                                            */
+/* ------------------------------------------------------------ */
+
+describe('inferVibeKeywords', () => {
+  it('detects funny → comedy tags', () => {
+    const kw = inferVibeKeywords('wants something funny');
+    expect(kw).toContain('Comedy');
+    expect(kw).toContain('Funny');
+  });
+
+  it('detects exciting → action tags', () => {
+    const kw = inferVibeKeywords('wants something exciting');
+    expect(kw).toContain('Action');
+    expect(kw).toContain('Exciting');
+  });
+
+  it('detects chill → cozy tags', () => {
+    const kw = inferVibeKeywords('wants something chill');
+    expect(kw).toContain('Chill');
+    expect(kw).toContain('Cozy');
+  });
+
+  it('returns empty for unrecognized text', () => {
+    const kw = inferVibeKeywords('something completely different');
+    expect(kw).toHaveLength(0);
+  });
+
+  it('detects multiple vibes', () => {
+    const kw = inferVibeKeywords('funny and exciting tonight');
+    expect(kw).toContain('Comedy');
+    expect(kw).toContain('Action');
+  });
+
+  it('deduplicates tags', () => {
+    const kw = inferVibeKeywords('funny humor comedy');
+    const uniqueKw = new Set(kw);
+    expect(uniqueKw.size).toBe(kw.length);
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* scoreBrainPower                                              */
+/* ------------------------------------------------------------ */
+
+describe('scoreBrainPower', () => {
+  it('scores brainPower=1 high when focus is low', () => {
+    expect(scoreBrainPower(1, 'low')).toBe(10);
+  });
+
+  it('scores brainPower=2 high when focus is low', () => {
+    expect(scoreBrainPower(2, 'low')).toBe(10);
+  });
+
+  it('scores brainPower=5 as 0 when focus is low', () => {
+    expect(scoreBrainPower(5, 'low')).toBe(0);
+  });
+
+  it('scores brainPower=4 as 0 when focus is low', () => {
+    expect(scoreBrainPower(4, 'low')).toBe(0);
+  });
+
+  it('scores brainPower=3 in the middle when focus is low', () => {
+    expect(scoreBrainPower(3, 'low')).toBeLessThan(10);
+    expect(scoreBrainPower(3, 'low')).toBeGreaterThan(0);
+  });
+
+  it('scores brainPower=5 high when focus is high', () => {
+    expect(scoreBrainPower(5, 'high')).toBe(10);
+  });
+
+  it('scores brainPower=1 lower when focus is high', () => {
+    expect(scoreBrainPower(1, 'high')).toBeLessThan(scoreBrainPower(5, 'high'));
+  });
+
+  it('returns 5 for null brainPower (neutral)', () => {
+    expect(scoreBrainPower(null, 'low')).toBe(5);
+    expect(scoreBrainPower(null, 'normal')).toBe(5);
+    expect(scoreBrainPower(null, 'high')).toBe(5);
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* scoreVibeFit                                                 */
+/* ------------------------------------------------------------ */
+
+describe('scoreVibeFit', () => {
+  it('returns 5 (neutral) when no vibe keywords', () => {
+    expect(scoreVibeFit(['Comedy', 'Funny'], [])).toBe(5);
+  });
+
+  it('returns higher score for matching tags', () => {
+    const score = scoreVibeFit(['Comedy', 'Funny'], ['Comedy', 'Funny']);
+    expect(score).toBeGreaterThan(5);
+  });
+
+  it('returns low score when no tags match keywords', () => {
+    const score = scoreVibeFit(['Drama', 'Emotional'], ['Comedy', 'Funny']);
+    expect(score).toBeLessThan(5);
+  });
+
+  it('score increases with more matching tags', () => {
+    const oneMatch = scoreVibeFit(['Comedy'], ['Comedy', 'Funny']);
+    const twoMatch = scoreVibeFit(['Comedy', 'Funny'], ['Comedy', 'Funny']);
+    expect(twoMatch).toBeGreaterThan(oneMatch);
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* scoreViewerRatingFit                                         */
+/* ------------------------------------------------------------ */
+
+describe('scoreViewerRatingFit', () => {
+  it('returns 5 (neutral) when no present viewers have rated the show', () => {
+    const show = makeShow({ id: 's1', ratings: {} });
+    expect(scoreViewerRatingFit(show, ['u1', 'u2'])).toBe(5);
+  });
+
+  it('returns high score for highly-rated shows', () => {
+    const show = makeShow({ id: 's1', ratings: { u1: makeRating(9) } });
+    expect(scoreViewerRatingFit(show, ['u1'])).toBeGreaterThan(7);
+  });
+
+  it('returns mid score for 6-7 rated shows', () => {
+    const show = makeShow({ id: 's1', ratings: { u1: makeRating(6.5) } });
+    const score = scoreViewerRatingFit(show, ['u1']);
+    expect(score).toBeGreaterThan(4);
+    expect(score).toBeLessThan(8);
+  });
+
+  it('returns lower score for poorly-rated shows', () => {
+    const show = makeShow({ id: 's1', ratings: { u1: makeRating(2) } });
+    const score = scoreViewerRatingFit(show, ['u1']);
+    expect(score).toBeLessThan(5);
+  });
+
+  it('averages across multiple present viewers', () => {
+    const show = makeShow({
+      id: 's1',
+      ratings: { u1: makeRating(10), u2: makeRating(4) },
+    });
+    const scoreU1Only = scoreViewerRatingFit(show, ['u1']);
+    const scoreBoth = scoreViewerRatingFit(show, ['u1', 'u2']);
+    expect(scoreBoth).toBeLessThan(scoreU1Only);
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* computeCandidatePreScore                                     */
+/* ------------------------------------------------------------ */
+
+describe('computeCandidatePreScore', () => {
+  it('returns correct showId and title', () => {
+    const show = makeShow({ id: 'abc', title: 'My Show', brainPower: 1 });
+    const result = computeCandidatePreScore(show, 'low', [], []);
+    expect(result.showId).toBe('abc');
+    expect(result.title).toBe('My Show');
+  });
+
+  it('brain-dead show with bp=1 gets high overall score for low focus', () => {
+    const show = makeShow({ id: 's1', brainPower: 1, vibeTags: ['Comedy'] });
+    const result = computeCandidatePreScore(show, 'low', ['Comedy', 'Funny'], []);
+    expect(result.brainPowerMatch).toBe(10);
+    expect(result.overallPreScore).toBeGreaterThan(7);
+  });
+
+  it('dense show (bp=5) gets low overall score for low focus', () => {
+    const show = makeShow({ id: 's1', brainPower: 5, vibeTags: ['Drama'] });
+    const result = computeCandidatePreScore(show, 'low', ['Comedy'], []);
+    expect(result.brainPowerMatch).toBe(0);
+    expect(result.overallPreScore).toBeLessThan(5);
+  });
+
+  it('overall score accounts for viewer ratings', () => {
+    const showHigh = makeShow({ id: 's1', brainPower: 1, ratings: { u1: makeRating(9) } });
+    const showLow = makeShow({ id: 's2', brainPower: 1, ratings: { u1: makeRating(2) } });
+    const scoreHigh = computeCandidatePreScore(showHigh, 'low', [], ['u1']).overallPreScore;
+    const scoreLow = computeCandidatePreScore(showLow, 'low', [], ['u1']).overallPreScore;
+    expect(scoreHigh).toBeGreaterThan(scoreLow);
+  });
+
+  it('overallPreScore is between 0 and 10', () => {
+    const show = makeShow({ id: 's1', brainPower: 3, vibeTags: ['Chill'] });
+    const result = computeCandidatePreScore(show, 'normal', ['Chill'], ['u1']);
+    expect(result.overallPreScore).toBeGreaterThanOrEqual(0);
+    expect(result.overallPreScore).toBeLessThanOrEqual(10);
+  });
+});

--- a/app/tools/shows/__tests__/preScore.test.ts
+++ b/app/tools/shows/__tests__/preScore.test.ts
@@ -7,6 +7,7 @@ import {
   scoreViewerRatingFit,
   computeCandidatePreScore,
 } from '../lib/preScore';
+import { VIBE_CATEGORIES } from '../lib/vibeCategories';
 import type { Show } from '../types';
 import { Timestamp } from 'firebase/firestore';
 
@@ -53,6 +54,8 @@ function makeRating(composite: number) {
     ratedAt: null as null,
   };
 }
+
+const VALID_TAGS = new Set<string>(VIBE_CATEGORIES);
 
 /* ------------------------------------------------------------ */
 /* inferFocusLevel                                              */
@@ -105,43 +108,153 @@ describe('inferFocusLevel', () => {
 });
 
 /* ------------------------------------------------------------ */
-/* inferVibeKeywords                                            */
+/* inferVibeKeywords — real VIBE_CATEGORIES tags only           */
 /* ------------------------------------------------------------ */
 
 describe('inferVibeKeywords', () => {
-  it('detects funny → comedy tags', () => {
+  it('every returned tag exists in VIBE_CATEGORIES', () => {
+    const inputs = [
+      'wants something funny and exciting',
+      'brain dead, just wants chill background tv',
+      'romantic and wholesome night',
+      'mystery thriller noir',
+      'musical singing night',
+      'horror and dark',
+      'chaotic and wild',
+      'family and friendship heartwarming',
+      'slow burn psychological',
+      'fantasy epic world-building',
+    ];
+    for (const text of inputs) {
+      const tags = inferVibeKeywords(text);
+      for (const tag of tags) {
+        expect(VALID_TAGS.has(tag), `"${tag}" is not in VIBE_CATEGORIES`).toBe(true);
+      }
+    }
+  });
+
+  it('"funny" maps to Funny and Lighthearted', () => {
     const kw = inferVibeKeywords('wants something funny');
-    expect(kw).toContain('Comedy');
     expect(kw).toContain('Funny');
+    expect(kw).toContain('Lighthearted');
+    // Must NOT contain non-existent tags
+    expect(kw).not.toContain('Comedy');
+    expect(kw).not.toContain('Humor');
   });
 
-  it('detects exciting → action tags', () => {
+  it('"exciting" maps to Action-Packed, Adventurous, Fast-Paced, Intense, Suspenseful', () => {
     const kw = inferVibeKeywords('wants something exciting');
-    expect(kw).toContain('Action');
-    expect(kw).toContain('Exciting');
+    expect(kw).toContain('Action-Packed');
+    expect(kw).toContain('Adventurous');
+    expect(kw).toContain('Fast-Paced');
+    // Must NOT contain non-existent tags
+    expect(kw).not.toContain('Action');
+    expect(kw).not.toContain('Exciting');
+    expect(kw).not.toContain('Thrilling');
   });
 
-  it('detects chill → cozy tags', () => {
+  it('"mystery" maps to Mysterious, Suspenseful, Mind-Bending', () => {
+    const kw = inferVibeKeywords('wants a mystery');
+    expect(kw).toContain('Mysterious');
+    expect(kw).toContain('Suspenseful');
+    expect(kw).toContain('Mind-Bending');
+    // Must NOT contain non-existent tags
+    expect(kw).not.toContain('Mystery');
+    expect(kw).not.toContain('Thriller');
+    expect(kw).not.toContain('Crime');
+  });
+
+  it('"chill" maps to Chill, Cozy, Comfort Watch, Low-Stakes', () => {
     const kw = inferVibeKeywords('wants something chill');
     expect(kw).toContain('Chill');
     expect(kw).toContain('Cozy');
+    expect(kw).toContain('Comfort Watch');
+    // Must NOT contain non-existent tags
+    expect(kw).not.toContain('Relaxing');
+    expect(kw).not.toContain('Comfort');
   });
 
-  it('returns empty for unrecognized text', () => {
-    const kw = inferVibeKeywords('something completely different');
+  it('"romantic" maps to Romantic and Wholesome', () => {
+    const kw = inferVibeKeywords('romantic night');
+    expect(kw).toContain('Romantic');
+    expect(kw).toContain('Wholesome');
+    expect(kw).not.toContain('Romance');
+  });
+
+  it('"emotional" maps to Emotional and Thoughtful', () => {
+    const kw = inferVibeKeywords('something emotional and deep');
+    expect(kw).toContain('Emotional');
+    expect(kw).toContain('Thoughtful');
+    expect(kw).not.toContain('Drama');
+  });
+
+  it('"epic" maps to Epic and Adventurous', () => {
+    const kw = inferVibeKeywords('fantasy epic world-building');
+    expect(kw).toContain('Epic');
+    expect(kw).toContain('Adventurous');
+    expect(kw).not.toContain('Fantasy');
+  });
+
+  it('"chaotic" maps to Chaotic and Fast-Paced', () => {
+    const kw = inferVibeKeywords('something chaotic and wild');
+    expect(kw).toContain('Chaotic');
+    expect(kw).toContain('Fast-Paced');
+  });
+
+  it('"family" maps to Found Family and Wholesome', () => {
+    const kw = inferVibeKeywords('family friendship heartwarming');
+    expect(kw).toContain('Found Family');
+    expect(kw).toContain('Wholesome');
+  });
+
+  it('returns empty array for completely unrecognized text', () => {
+    const kw = inferVibeKeywords('something completely different blah');
     expect(kw).toHaveLength(0);
   });
 
-  it('detects multiple vibes', () => {
+  it('detects multiple vibes from combined text', () => {
     const kw = inferVibeKeywords('funny and exciting tonight');
-    expect(kw).toContain('Comedy');
-    expect(kw).toContain('Action');
+    expect(kw).toContain('Funny');
+    expect(kw).toContain('Action-Packed');
   });
 
   it('deduplicates tags', () => {
     const kw = inferVibeKeywords('funny humor comedy');
     const uniqueKw = new Set(kw);
     expect(uniqueKw.size).toBe(kw.length);
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* scoreVibeFit — with real VIBE_CATEGORIES tags                */
+/* ------------------------------------------------------------ */
+
+describe('scoreVibeFit', () => {
+  it('returns 5 (neutral) when no vibe keywords', () => {
+    expect(scoreVibeFit(['Funny', 'Lighthearted'], [])).toBe(5);
+  });
+
+  it('returns higher score for matching real tags', () => {
+    const score = scoreVibeFit(['Action-Packed', 'Adventurous'], ['Action-Packed', 'Adventurous', 'Fast-Paced', 'Intense', 'Suspenseful']);
+    expect(score).toBeGreaterThan(5);
+  });
+
+  it('returns low score when no tags match', () => {
+    const score = scoreVibeFit(['Emotional', 'Thoughtful'], ['Funny', 'Lighthearted']);
+    expect(score).toBeLessThan(5);
+  });
+
+  it('score increases with more matching tags', () => {
+    const oneMatch = scoreVibeFit(['Action-Packed'], ['Action-Packed', 'Adventurous']);
+    const twoMatch = scoreVibeFit(['Action-Packed', 'Adventurous'], ['Action-Packed', 'Adventurous']);
+    expect(twoMatch).toBeGreaterThan(oneMatch);
+  });
+
+  it('Action-Packed show scores well against "exciting" inferred keywords', () => {
+    // inferred from "exciting" input
+    const excitingKeywords = ['Action-Packed', 'Adventurous', 'Fast-Paced', 'Intense', 'Suspenseful'];
+    const score = scoreVibeFit(['Action-Packed', 'Fast-Paced'], excitingKeywords);
+    expect(score).toBeGreaterThan(5);
   });
 });
 
@@ -183,32 +296,6 @@ describe('scoreBrainPower', () => {
     expect(scoreBrainPower(null, 'low')).toBe(5);
     expect(scoreBrainPower(null, 'normal')).toBe(5);
     expect(scoreBrainPower(null, 'high')).toBe(5);
-  });
-});
-
-/* ------------------------------------------------------------ */
-/* scoreVibeFit                                                 */
-/* ------------------------------------------------------------ */
-
-describe('scoreVibeFit', () => {
-  it('returns 5 (neutral) when no vibe keywords', () => {
-    expect(scoreVibeFit(['Comedy', 'Funny'], [])).toBe(5);
-  });
-
-  it('returns higher score for matching tags', () => {
-    const score = scoreVibeFit(['Comedy', 'Funny'], ['Comedy', 'Funny']);
-    expect(score).toBeGreaterThan(5);
-  });
-
-  it('returns low score when no tags match keywords', () => {
-    const score = scoreVibeFit(['Drama', 'Emotional'], ['Comedy', 'Funny']);
-    expect(score).toBeLessThan(5);
-  });
-
-  it('score increases with more matching tags', () => {
-    const oneMatch = scoreVibeFit(['Comedy'], ['Comedy', 'Funny']);
-    const twoMatch = scoreVibeFit(['Comedy', 'Funny'], ['Comedy', 'Funny']);
-    expect(twoMatch).toBeGreaterThan(oneMatch);
   });
 });
 
@@ -263,16 +350,18 @@ describe('computeCandidatePreScore', () => {
     expect(result.title).toBe('My Show');
   });
 
-  it('brain-dead show with bp=1 gets high overall score for low focus', () => {
-    const show = makeShow({ id: 's1', brainPower: 1, vibeTags: ['Comedy'] });
-    const result = computeCandidatePreScore(show, 'low', ['Comedy', 'Funny'], []);
+  it('brain-dead show with bp=1 and real funny tags gets high overall score for low focus', () => {
+    const show = makeShow({ id: 's1', brainPower: 1, vibeTags: ['Funny', 'Lighthearted'] });
+    const kw = inferVibeKeywords('brain dead and wants something funny');
+    const result = computeCandidatePreScore(show, 'low', kw, []);
     expect(result.brainPowerMatch).toBe(10);
     expect(result.overallPreScore).toBeGreaterThan(7);
   });
 
   it('dense show (bp=5) gets low overall score for low focus', () => {
-    const show = makeShow({ id: 's1', brainPower: 5, vibeTags: ['Drama'] });
-    const result = computeCandidatePreScore(show, 'low', ['Comedy'], []);
+    const show = makeShow({ id: 's1', brainPower: 5, vibeTags: ['Emotional', 'Thoughtful'] });
+    const kw = inferVibeKeywords('brain dead wants something funny');
+    const result = computeCandidatePreScore(show, 'low', kw, []);
     expect(result.brainPowerMatch).toBe(0);
     expect(result.overallPreScore).toBeLessThan(5);
   });

--- a/app/tools/shows/__tests__/recommendationContext.test.ts
+++ b/app/tools/shows/__tests__/recommendationContext.test.ts
@@ -379,6 +379,21 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('7.5/10');
   });
 
+  it('includes story, characters, and vibes component scores in candidate per-viewer section', () => {
+    const uid = 'u1';
+    const candidates = [makeShow({
+      id: 'c1',
+      status: 'watching',
+      ratings: { [uid]: { story: 6, characters: 8, vibes: 9, wouldRewatch: null, ratedAt: null } },
+    })];
+    const moods = { [uid]: makeMood('Alice', 'chill') };
+    const profiles = { [uid]: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('story:6');
+    expect(prompt).toContain('chars:8');
+    expect(prompt).toContain('vibes:9');
+  });
+
   it('includes wouldRewatch in candidate per-viewer section', () => {
     const uid = 'u1';
     const candidates = [makeShow({

--- a/app/tools/shows/__tests__/recommendationContext.test.ts
+++ b/app/tools/shows/__tests__/recommendationContext.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildHistory, candidateShows } from '../lib/recommendationContext';
+import { buildViewerProfiles, candidateShows } from '../lib/recommendationContext';
 import { buildPrompt } from '../lib/buildRecommendPrompt';
 import type { Show, ShowList } from '../types';
-import type { MoodEntry, HistoryEntry } from '../lib/recommendationContext';
+import type { MoodEntry, ViewerPreferenceProfile } from '../lib/recommendationContext';
 import { Timestamp } from 'firebase/firestore';
 
 /* ------------------------------------------------------------ */
@@ -44,7 +44,6 @@ function makeMember(uid: string, displayName: string): ShowList['members'][numbe
 }
 
 function makeRating(composite: number) {
-  // story + characters + vibes averaged = composite → set all equal
   return {
     story: composite,
     characters: composite,
@@ -54,24 +53,67 @@ function makeRating(composite: number) {
   };
 }
 
+function makeProfile(name: string): ViewerPreferenceProfile {
+  return {
+    uid: 'u1',
+    name,
+    stronglyLiked: [],
+    conditionallyLiked: [],
+    weaklyLiked: [],
+    disliked: [],
+    notedButUnrated: [],
+  };
+}
+
 /* ------------------------------------------------------------ */
-/* buildHistory                                                 */
+/* buildViewerProfiles                                          */
 /* ------------------------------------------------------------ */
 
-describe('buildHistory', () => {
-  it('includes high-scoring shows (≥7) in member history', () => {
+describe('buildViewerProfiles', () => {
+  it('puts 8+ shows in stronglyLiked', () => {
     const member = makeMember('u1', 'Alice');
     const show = makeShow({ id: 's1', ratings: { u1: makeRating(8) }, vibeTags: ['Epic'] });
-    const history = buildHistory([show], [member]);
-    expect(history.u1.highScoringShows).toHaveLength(1);
-    expect(history.u1.highScoringShows[0].title).toBe('Test Show');
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.stronglyLiked).toHaveLength(1);
+    expect(profiles.u1.stronglyLiked[0].title).toBe('Test Show');
+    expect(profiles.u1.conditionallyLiked).toHaveLength(0);
   });
 
-  it('excludes shows scoring below 7', () => {
+  it('puts 6-7.9 shows in conditionallyLiked, not excluded', () => {
     const member = makeMember('u1', 'Alice');
     const show = makeShow({ id: 's1', ratings: { u1: makeRating(6) } });
-    const history = buildHistory([show], [member]);
-    expect(history.u1.highScoringShows).toHaveLength(0);
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.conditionallyLiked).toHaveLength(1);
+    expect(profiles.u1.conditionallyLiked[0].composite).toBeCloseTo(6);
+    expect(profiles.u1.stronglyLiked).toHaveLength(0);
+  });
+
+  it('puts 4-5.9 shows in weaklyLiked', () => {
+    const member = makeMember('u1', 'Alice');
+    const show = makeShow({ id: 's1', ratings: { u1: makeRating(5) } });
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.weaklyLiked).toHaveLength(1);
+    expect(profiles.u1.conditionallyLiked).toHaveLength(0);
+  });
+
+  it('puts <4 shows in disliked', () => {
+    const member = makeMember('u1', 'Alice');
+    const show = makeShow({ id: 's1', ratings: { u1: makeRating(3) } });
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.disliked).toHaveLength(1);
+    expect(profiles.u1.weaklyLiked).toHaveLength(0);
+  });
+
+  it('puts unrated shows with notes in notedButUnrated', () => {
+    const member = makeMember('u1', 'Alice');
+    const show = makeShow({
+      id: 's1',
+      ratings: {},
+      memberNotes: { u1: 'really want to try this' },
+    });
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.notedButUnrated).toHaveLength(1);
+    expect(profiles.u1.notedButUnrated[0].note).toBe('really want to try this');
   });
 
   it('uses memberNotes[uid] over legacy notes field', () => {
@@ -82,8 +124,8 @@ describe('buildHistory', () => {
       notes: 'legacy note',
       memberNotes: { u1: 'personal note' },
     });
-    const history = buildHistory([show], [member]);
-    expect(history.u1.highScoringShows[0].note).toBe('personal note');
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.stronglyLiked[0].note).toBe('personal note');
   });
 
   it('falls back to legacy notes when memberNotes is absent', () => {
@@ -94,24 +136,37 @@ describe('buildHistory', () => {
       notes: 'old legacy note',
       memberNotes: undefined,
     });
-    const history = buildHistory([show], [member]);
-    expect(history.u1.highScoringShows[0].note).toBe('old legacy note');
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.stronglyLiked[0].note).toBe('old legacy note');
   });
 
   it('handles member with no ratings gracefully', () => {
     const member = makeMember('u2', 'Bob');
     const show = makeShow({ id: 's1', ratings: {} });
-    const history = buildHistory([show], [member]);
-    expect(history.u2.highScoringShows).toHaveLength(0);
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u2.stronglyLiked).toHaveLength(0);
+    expect(profiles.u2.conditionallyLiked).toHaveLength(0);
+    expect(profiles.u2.notedButUnrated).toHaveLength(0);
   });
 
   it('produces an entry for each member', () => {
     const members = [makeMember('u1', 'Alice'), makeMember('u2', 'Bob')];
-    const shows: Show[] = [];
-    const history = buildHistory(shows, members);
-    expect(Object.keys(history)).toEqual(['u1', 'u2']);
-    expect(history.u1.name).toBe('Alice');
-    expect(history.u2.name).toBe('Bob');
+    const profiles = buildViewerProfiles([], members);
+    expect(Object.keys(profiles)).toEqual(['u1', 'u2']);
+    expect(profiles.u1.name).toBe('Alice');
+    expect(profiles.u2.name).toBe('Bob');
+  });
+
+  it('includes brainPower and wouldRewatch in rated entries', () => {
+    const member = makeMember('u1', 'Alice');
+    const show = makeShow({
+      id: 's1',
+      ratings: { u1: { story: 8, characters: 8, vibes: 8, wouldRewatch: 'yes', ratedAt: null } },
+      brainPower: 2,
+    });
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.stronglyLiked[0].brainPower).toBe(2);
+    expect(profiles.u1.stronglyLiked[0].wouldRewatch).toBe('yes');
   });
 });
 
@@ -159,25 +214,45 @@ describe('candidateShows', () => {
 });
 
 /* ------------------------------------------------------------ */
-/* Recommendation prompt inputs (whitebox)                     */
-/* These tests verify that the data passed to the AI contains  */
-/* the right fields without testing Gemini output itself.      */
+/* candidateShows — tiered filtering                           */
+/* ------------------------------------------------------------ */
+
+describe('candidateShows tiered filtering', () => {
+  it('tier 1: prefers shows where all present viewers are watchers', () => {
+    const allPresent = makeShow({ id: 'all', status: 'planned', watchers: ['u1', 'u2'] });
+    const onePresent = makeShow({ id: 'one', status: 'planned', watchers: ['u1'] });
+    const result = candidateShows([allPresent, onePresent], ['u1', 'u2']);
+    expect(result.map((s) => s.id)).toEqual(['all']);
+  });
+
+  it('tier 1 includes legacy (empty-watcher) shows before tier 2 overlap shows', () => {
+    const legacy = makeShow({ id: 'legacy', status: 'planned', watchers: [] });
+    const partial = makeShow({ id: 'partial', status: 'planned', watchers: ['u1'] });
+    const result = candidateShows([legacy, partial], ['u1', 'u2']);
+    expect(result.map((s) => s.id)).toContain('legacy');
+    expect(result.map((s) => s.id)).not.toContain('partial');
+  });
+
+  it('tier 2: falls back to any-overlap when no all-present matches', () => {
+    const u1only = makeShow({ id: 'u1only', status: 'watching', watchers: ['u1'] });
+    const u2only = makeShow({ id: 'u2only', status: 'watching', watchers: ['u2'] });
+    const result = candidateShows([u1only, u2only], ['u1', 'u2']);
+    expect(result.map((s) => s.id)).toContain('u1only');
+    expect(result.map((s) => s.id)).toContain('u2only');
+  });
+
+  it('tier 3: falls back to all eligible when no viewer overlap', () => {
+    const u3show = makeShow({ id: 'u3', status: 'planned', watchers: ['u3'] });
+    const result = candidateShows([u3show], ['u1', 'u2']);
+    expect(result.map((s) => s.id)).toContain('u3');
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* candidate payload structure                                  */
 /* ------------------------------------------------------------ */
 
 describe('recommendation payload structure', () => {
-  it('buildHistory includes brain power indirectly via composite threshold', () => {
-    // brainPower is on the Show; ensures it survives the data pipeline
-    const member = makeMember('u1', 'Alice');
-    const show = makeShow({
-      id: 's1',
-      ratings: { u1: makeRating(8) },
-      brainPower: 2,
-    });
-    const history = buildHistory([show], [member]);
-    // The HistoryShow carries vibes and note; brainPower is on the Show passed as candidate
-    expect(history.u1.highScoringShows[0].vibes).toEqual(['Chill', 'Cozy']);
-  });
-
   it('candidateShows returns brainPower field on show objects', () => {
     const show = makeShow({ status: 'watching', brainPower: 3 });
     const [candidate] = candidateShows([show]);
@@ -206,44 +281,6 @@ describe('recommendation payload structure', () => {
 });
 
 /* ------------------------------------------------------------ */
-/* candidateShows — tiered filtering                           */
-/* ------------------------------------------------------------ */
-
-describe('candidateShows tiered filtering', () => {
-  it('tier 1: prefers shows where all present viewers are watchers', () => {
-    const allPresent = makeShow({ id: 'all', status: 'planned', watchers: ['u1', 'u2'] });
-    const onePresent = makeShow({ id: 'one', status: 'planned', watchers: ['u1'] });
-    const result = candidateShows([allPresent, onePresent], ['u1', 'u2']);
-    // both present are in allPresent's watchers → tier 1
-    expect(result.map((s) => s.id)).toEqual(['all']);
-  });
-
-  it('tier 1 includes legacy (empty-watcher) shows before tier 2 overlap shows', () => {
-    const legacy = makeShow({ id: 'legacy', status: 'planned', watchers: [] });
-    const partial = makeShow({ id: 'partial', status: 'planned', watchers: ['u1'] });
-    const result = candidateShows([legacy, partial], ['u1', 'u2']);
-    // legacy is in tier 1 (empty watchers) → returned without partial
-    expect(result.map((s) => s.id)).toContain('legacy');
-    expect(result.map((s) => s.id)).not.toContain('partial');
-  });
-
-  it('tier 2: falls back to any-overlap when no all-present matches', () => {
-    const u1only = makeShow({ id: 'u1only', status: 'watching', watchers: ['u1'] });
-    const u2only = makeShow({ id: 'u2only', status: 'watching', watchers: ['u2'] });
-    const result = candidateShows([u1only, u2only], ['u1', 'u2']);
-    // neither has all of [u1,u2] → tier 2 → both appear
-    expect(result.map((s) => s.id)).toContain('u1only');
-    expect(result.map((s) => s.id)).toContain('u2only');
-  });
-
-  it('tier 3: falls back to all eligible when no viewer overlap', () => {
-    const u3show = makeShow({ id: 'u3', status: 'planned', watchers: ['u3'] });
-    const result = candidateShows([u3show], ['u1', 'u2']);
-    expect(result.map((s) => s.id)).toContain('u3');
-  });
-});
-
-/* ------------------------------------------------------------ */
 /* buildPrompt                                                  */
 /* ------------------------------------------------------------ */
 
@@ -251,29 +288,111 @@ function makeMood(name: string, mood = ''): MoodEntry {
   return { name, mood };
 }
 
-function makeHistory(name: string): HistoryEntry {
-  return { name, highScoringShows: [] };
-}
-
 describe('buildPrompt', () => {
   it('includes candidate show ID in the prompt', () => {
     const candidates = [makeShow({ id: 'show-xyz', status: 'watching' })];
     const moods = { u1: makeMood('Alice', 'tired') };
-    const history = { u1: makeHistory('Alice') };
-    const prompt = buildPrompt(moods, candidates, history);
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
     expect(prompt).toContain('id:show-xyz');
   });
 
-  it('includes mood display names in the WHO IS WATCHING section', () => {
+  it('includes mood display names in the mood section', () => {
     const candidates = [makeShow({ status: 'watching' })];
     const moods = { u1: makeMood('Alice', 'chill'), u2: makeMood('Bob', 'hyped') };
-    const history = { u1: makeHistory('Alice'), u2: makeHistory('Bob') };
-    const prompt = buildPrompt(moods, candidates, history);
+    const profiles = { u1: makeProfile('Alice'), u2: makeProfile('Bob') };
+    const prompt = buildPrompt(moods, candidates, profiles);
     expect(prompt).toContain('Alice: chill');
     expect(prompt).toContain('Bob: hyped');
   });
 
-  it('labels per-person notes with display name, not UID', () => {
+  it('includes sharedMood prominently in the prompt', () => {
+    const candidates = [makeShow({ status: 'watching' })];
+    const moods = { u1: makeMood('Alice') };
+    const profiles = { u1: makeProfile('Alice') };
+    const shared = 'Jimi is brain dead after work. Kait wants something exciting.';
+    const prompt = buildPrompt(moods, candidates, profiles, shared);
+    expect(prompt).toContain(shared);
+    expect(prompt).toContain("TONIGHT'S VIBE");
+  });
+
+  it('sharedMood section instructs parsing named viewers', () => {
+    const candidates = [makeShow({ status: 'watching' })];
+    const moods = { u1: makeMood('Alice') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles, 'Jimi is tired');
+    expect(prompt).toContain('parse');
+    expect(prompt).toContain('named');
+  });
+
+  it('does not include sharedMood section when absent', () => {
+    const candidates = [makeShow({ status: 'watching' })];
+    const moods = { u1: makeMood('Alice', 'tired') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    // Section header only appears when sharedMood is provided
+    expect(prompt).not.toContain("TONIGHT'S VIBE (highest priority");
+  });
+
+  it('decision rules mention brain dead and multitasking as low brain-power signals', () => {
+    const candidates = [makeShow({ status: 'watching' })];
+    const moods = { u1: makeMood('Alice') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles, 'Jimi is brain dead');
+    expect(prompt).toContain('brain dead');
+    expect(prompt).toContain('multitasking');
+  });
+
+  it('includes all rating bands in viewer profiles, not only high scores', () => {
+    const member = makeMember('u1', 'Alice');
+    const highShow = makeShow({ id: 's1', ratings: { u1: makeRating(9) }, vibeTags: ['Epic'] });
+    const midShow = makeShow({ id: 's2', title: 'Mid Show', ratings: { u1: makeRating(6.5) }, vibeTags: ['Chill'] });
+    const lowShow = makeShow({ id: 's3', title: 'Low Show', ratings: { u1: makeRating(3) }, vibeTags: ['Drama'] });
+    const profiles = buildViewerProfiles([highShow, midShow, lowShow], [member]);
+    const moods = { u1: makeMood('Alice', 'tired') };
+    const prompt = buildPrompt(moods, [], profiles);
+    expect(prompt).toContain('Loved (8–10)');
+    expect(prompt).toContain('Liked conditionally (6–7.9');
+    expect(prompt).toContain('Disliked (<4)');
+  });
+
+  it('a 6-rated show appears in conditionallyLiked in the prompt', () => {
+    const member = makeMember('u1', 'Alice');
+    const show = makeShow({ id: 's1', title: 'Mid Show', ratings: { u1: makeRating(6) } });
+    const profiles = buildViewerProfiles([show], [member]);
+    const moods = { u1: makeMood('Alice') };
+    const prompt = buildPrompt(moods, [], profiles);
+    expect(prompt).toContain('Liked conditionally');
+    expect(prompt).toContain('Mid Show');
+  });
+
+  it('includes per-viewer composite rating in candidate section', () => {
+    const uid = 'u1';
+    const candidates = [makeShow({
+      id: 'c1',
+      status: 'watching',
+      ratings: { [uid]: makeRating(7.5) },
+    })];
+    const moods = { [uid]: makeMood('Alice', 'chill') };
+    const profiles = { [uid]: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('7.5/10');
+  });
+
+  it('includes wouldRewatch in candidate per-viewer section', () => {
+    const uid = 'u1';
+    const candidates = [makeShow({
+      id: 'c1',
+      status: 'watching',
+      ratings: { [uid]: { story: 8, characters: 8, vibes: 8, wouldRewatch: 'yes', ratedAt: null } },
+    })];
+    const moods = { [uid]: makeMood('Alice', 'chill') };
+    const profiles = { [uid]: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('wr:yes');
+  });
+
+  it('labels per-person notes with display name, not raw UID', () => {
     const uid = 'u1';
     const candidates = [makeShow({
       id: 'ns1',
@@ -281,9 +400,9 @@ describe('buildPrompt', () => {
       memberNotes: { [uid]: 'love this series' },
     })];
     const moods = { [uid]: makeMood('Alice', 'chill') };
-    const history = { [uid]: makeHistory('Alice') };
-    const prompt = buildPrompt(moods, candidates, history);
-    expect(prompt).toContain('[Alice]');
+    const profiles = { [uid]: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('Alice');
     expect(prompt).toContain('love this series');
     expect(prompt).not.toContain(`[${uid}]`);
   });
@@ -295,33 +414,33 @@ describe('buildPrompt', () => {
       memberNotes: { absentUid: 'a note from someone not watching tonight' },
     })];
     const moods = { u1: makeMood('Alice', 'chill') };
-    const history = { u1: makeHistory('Alice') };
-    const prompt = buildPrompt(moods, candidates, history);
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
     expect(prompt).toContain('[absentUid]');
   });
 
-  it('includes brain power label when set', () => {
+  it('includes brain power in candidate section when set', () => {
     const candidates = [makeShow({ status: 'watching', brainPower: 1 })];
     const moods = { u1: makeMood('Alice') };
-    const history = { u1: makeHistory('Alice') };
-    const prompt = buildPrompt(moods, candidates, history);
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
     expect(prompt).toContain('1/5');
     expect(prompt).toContain('braindead');
   });
 
-  it('shows "unknown" brain power when null', () => {
+  it('shows unknown brain power when null', () => {
     const candidates = [makeShow({ status: 'watching', brainPower: null })];
     const moods = { u1: makeMood('Alice') };
-    const history = { u1: makeHistory('Alice') };
-    const prompt = buildPrompt(moods, candidates, history);
-    expect(prompt).toContain('brain power: unknown');
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('brain: unknown');
   });
 
   it('includes service when present', () => {
     const candidates = [makeShow({ status: 'watching', service: 'Crunchyroll' })];
     const moods = { u1: makeMood('Alice') };
-    const history = { u1: makeHistory('Alice') };
-    const prompt = buildPrompt(moods, candidates, history);
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
     expect(prompt).toContain('service: Crunchyroll');
   });
 
@@ -332,19 +451,32 @@ describe('buildPrompt', () => {
       memberNotes: undefined,
     })];
     const moods = { u1: makeMood('Alice') };
-    const history = { u1: makeHistory('Alice') };
-    const prompt = buildPrompt(moods, candidates, history);
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
     expect(prompt).toContain('old shared note');
   });
 
-  it('includes history high-scoring shows with vibes and score', () => {
-    const member = makeMember('u1', 'Alice');
-    const show = makeShow({ ratings: { u1: makeRating(9) }, vibeTags: ['Epic', 'Action'] });
-    const history = buildHistory([show], [member]);
+  it('includes the VIEWER PREFERENCE PROFILES section header', () => {
     const moods = { u1: makeMood('Alice') };
-    const prompt = buildPrompt(moods, [], history);
-    expect(prompt).toContain('Alice\'s high-scoring shows');
-    expect(prompt).toContain('Test Show');
-    expect(prompt).toContain('Epic');
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, [], profiles);
+    expect(prompt).toContain('VIEWER PREFERENCE PROFILES');
+    expect(prompt).toContain('Alice');
+  });
+
+  it('rules instruct not to simply pick the highest-rated show', () => {
+    const moods = { u1: makeMood('Alice') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, [], profiles);
+    expect(prompt).toContain('DO NOT simply pick the highest-rated show');
+  });
+
+  it('includes pre-score for each candidate', () => {
+    const candidates = [makeShow({ id: 'c1', status: 'watching', brainPower: 1, vibeTags: ['Comedy'] })];
+    const moods = { u1: makeMood('Alice', 'brain dead and want something funny') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('preScore:');
+    expect(prompt).toContain('overall=');
   });
 });

--- a/app/tools/shows/lib/buildRecommendPrompt.ts
+++ b/app/tools/shows/lib/buildRecommendPrompt.ts
@@ -124,6 +124,9 @@ export function buildPrompt(
           const composite = memberComposite(rating);
           const scorePart = composite !== null ? `${composite.toFixed(1)}/10` : 'partial';
           const parts = [`${name}: ${scorePart}`];
+          if (rating.story != null) parts.push(`story:${rating.story}`);
+          if (rating.characters != null) parts.push(`chars:${rating.characters}`);
+          if (rating.vibes != null) parts.push(`vibes:${rating.vibes}`);
           if (rating.wouldRewatch) parts.push(`wr:${rating.wouldRewatch}`);
           if (note.trim()) parts.push(`note:"${note}"`);
           return parts.join(' ');
@@ -160,7 +163,7 @@ export function buildPrompt(
     `2. BRAIN POWER FIT: When anyone is tired, brain dead, or multitasking → strongly prefer brain power 1–2. ` +
     `A 6/10 show with brain power 1 beats a 9/10 show with brain power 5 when someone is exhausted. Unknown brain power is neutral.\n` +
     `3. MOOD AND VIBE MATCH: Match show vibe tags to inferred mood. ` +
-    `"funny" → Comedy/Humor/Lighthearted. "exciting" → Action/Thrilling. "chill" → Cozy/Relaxing. Strong vibe overlap = strong positive signal.\n` +
+    `"funny/comedy" → Funny/Lighthearted. "exciting/adventure" → Action-Packed/Adventurous/Fast-Paced/Intense. "chill/cozy" → Chill/Cozy/Comfort Watch. Strong vibe overlap = strong positive signal.\n` +
     `4. USE ALL RATING BANDS AS TASTE EVIDENCE:\n` +
     `   - 8–10 (Loved): strong signal they enjoy this show's style\n` +
     `   - 6–7.9 (Conditionally liked): excellent pick if tonight's mood matches this show's vibes\n` +

--- a/app/tools/shows/lib/buildRecommendPrompt.ts
+++ b/app/tools/shows/lib/buildRecommendPrompt.ts
@@ -1,100 +1,189 @@
 import type { Show } from '../types';
-import type { MoodEntry, HistoryEntry } from './recommendationContext';
+import type { MoodEntry, ViewerPreferenceProfile, RatedShowEntry } from './recommendationContext';
+import { memberComposite } from './compositeScore';
+import { inferFocusLevel, inferVibeKeywords, computeCandidatePreScore } from './preScore';
 
 const BRAIN_POWER_LABELS: Record<number, string> = {
-  1: 'braindead/background-friendly',
+  1: 'braindead/background',
   2: 'easy watch',
   3: 'normal focus',
   4: 'pay attention',
   5: 'dense/thought-provoking',
 };
 
+function formatRatedEntry(e: RatedShowEntry): string {
+  const parts = [`"${e.title}"`, `score:${e.composite.toFixed(1)}`];
+  if (e.wouldRewatch) parts.push(`wr:${e.wouldRewatch}`);
+  if (e.brainPower != null) parts.push(`brain:${e.brainPower}/5`);
+  const vibes = e.vibeTags.length > 0 ? e.vibeTags.join('/') : '';
+  if (vibes) parts.push(`vibes:${vibes}`);
+  if (e.note) parts.push(`note:"${e.note}"`);
+  return parts.join(' ');
+}
+
 export function buildPrompt(
   moods: Record<string, MoodEntry>,
   candidates: Show[],
-  history: Record<string, HistoryEntry>,
+  profiles: Record<string, ViewerPreferenceProfile>,
+  sharedMood?: string,
 ): string {
-  // Build UID → display name lookup from the moods map
+  const presentUids = Object.keys(moods);
+
+  // UID → display name for present viewers
   const uidToName: Record<string, string> = {};
   for (const [uid, entry] of Object.entries(moods)) {
     uidToName[uid] = entry.name;
   }
 
-  const moodLines = Object.values(moods)
-    .map((m) => `  ${m.name}: ${m.mood || '(no input)'}`)
-    .join('\n');
+  // Infer combined focus level and vibe preferences from all mood text
+  const allMoodText = [sharedMood ?? '', ...Object.values(moods).map((m) => m.mood)].join(' ');
+  const focusLevel = inferFocusLevel(allMoodText);
+  const vibeKeywords = inferVibeKeywords(allMoodText);
 
-  const historyLines = Object.values(history)
-    .map((h) => {
-      const shows =
-        h.highScoringShows.length > 0
-          ? h.highScoringShows
-              .map((s) => {
-                const parts = [
-                  `    - "${s.title}"`,
-                  `vibes: ${s.vibes.join(', ')}`,
-                  `score: ${s.composite.toFixed(1)}`,
-                ];
-                if (s.description) parts.push(`desc: ${s.description}`);
-                if (s.note) parts.push(`note: ${s.note}`);
-                return parts.join(' | ');
-              })
-              .join('\n')
-          : '    (no high-scoring history yet)';
-      return `  ${h.name}'s high-scoring shows (≥7):\n${shows}`;
-    })
-    .join('\n\n');
+  // --- SHARED VIBE (highest priority) ---
+  const sharedMoodSection = sharedMood?.trim()
+    ? `TONIGHT'S VIBE (highest priority — parse each named person's mood from this):\n"${sharedMood.trim()}"\n\n`
+    : '';
 
+  // --- PER-PERSON MOOD (secondary) ---
+  const hasMoods = Object.values(moods).some((m) => m.mood.trim());
+  const moodSection = hasMoods
+    ? `PER-PERSON MOOD (secondary context):\n` +
+      Object.values(moods)
+        .map((m) => `  ${m.name}: ${m.mood || '(no input)'}`)
+        .join('\n') +
+      '\n\n'
+    : '';
+
+  // --- VIEWER PREFERENCE PROFILES ---
+  const profileSection =
+    `VIEWER PREFERENCE PROFILES (taste evidence — use all rating bands, not just high scores):\n` +
+    Object.values(profiles)
+      .map((p) => {
+        const lines: string[] = [`  ${p.name}:`];
+        if (p.stronglyLiked.length > 0) {
+          lines.push(`    Loved (8–10): ${p.stronglyLiked.map(formatRatedEntry).join(' | ')}`);
+        }
+        if (p.conditionallyLiked.length > 0) {
+          lines.push(
+            `    Liked conditionally (6–7.9, great if tonight's mood matches): ${p.conditionallyLiked.map(formatRatedEntry).join(' | ')}`,
+          );
+        }
+        if (p.weaklyLiked.length > 0) {
+          lines.push(
+            `    Mixed (4–5.9, use cautiously): ${p.weaklyLiked.map(formatRatedEntry).join(' | ')}`,
+          );
+        }
+        if (p.disliked.length > 0) {
+          lines.push(`    Disliked (<4): ${p.disliked.map((e) => `"${e.title}"`).join(', ')}`);
+        }
+        if (p.notedButUnrated.length > 0) {
+          lines.push(
+            `    Noted but unrated: ${p.notedButUnrated.map((e) => `"${e.title}" note:"${e.note}"`).join(' | ')}`,
+          );
+        }
+        if (
+          p.stronglyLiked.length === 0 &&
+          p.conditionallyLiked.length === 0 &&
+          p.weaklyLiked.length === 0 &&
+          p.disliked.length === 0 &&
+          p.notedButUnrated.length === 0
+        ) {
+          lines.push(`    (no rating history yet)`);
+        }
+        return lines.join('\n');
+      })
+      .join('\n\n') +
+    '\n\n';
+
+  // --- CANDIDATES with per-viewer signals and pre-scores ---
   const candidateLines = candidates
     .map((s) => {
       const ep =
         s.currentSeason !== null || s.currentEpisode !== null
-          ? ` | progress: S${s.currentSeason ?? '?'} E${s.currentEpisode ?? '?'}`
+          ? ` S${s.currentSeason ?? '?'}E${s.currentEpisode ?? '?'}`
           : '';
-      const vibes = s.vibeTags.length > 0 ? s.vibeTags.join(', ') : 'no tags';
+      const vibes = s.vibeTags.length > 0 ? s.vibeTags.join(', ') : 'none';
       const bp =
         s.brainPower != null
           ? `${s.brainPower}/5 (${BRAIN_POWER_LABELS[s.brainPower] ?? ''})`
           : 'unknown';
 
-      const parts = [
-        `  - id:${s.id}`,
-        `"${s.title}" (${s.type})`,
-        `status: ${s.status}${ep}`,
-        `vibes: ${vibes}`,
-        `brain power: ${bp}`,
-      ];
-      if (s.service) parts.push(`service: ${s.service}`);
-      if (s.description) parts.push(`desc: ${s.description}`);
+      const preScore = computeCandidatePreScore(s, focusLevel, vibeKeywords, presentUids);
+      const preScoreStr = `preScore: brain=${preScore.brainPowerMatch.toFixed(0)} vibe=${preScore.vibeFit.toFixed(0)} overall=${preScore.overallPreScore.toFixed(1)}`;
 
-      // Per-person notes labeled by display name (fall back to UID for absent viewers)
+      // Per-viewer rating signals
+      const viewerSignals = presentUids
+        .map((uid) => {
+          const rating = s.ratings[uid];
+          const name = uidToName[uid] ?? uid;
+          const note = s.memberNotes?.[uid] ?? s.notes ?? '';
+          if (!rating) {
+            return note.trim() ? `${name}: unrated note:"${note}"` : `${name}: unrated`;
+          }
+          const composite = memberComposite(rating);
+          const scorePart = composite !== null ? `${composite.toFixed(1)}/10` : 'partial';
+          const parts = [`${name}: ${scorePart}`];
+          if (rating.wouldRewatch) parts.push(`wr:${rating.wouldRewatch}`);
+          if (note.trim()) parts.push(`note:"${note}"`);
+          return parts.join(' ');
+        })
+        .join(' | ');
+
+      // Notes from absent viewers (extra context)
       const memberNotes = s.memberNotes ?? {};
-      const noteEntries = Object.entries(memberNotes).filter(([, v]) => v.trim());
-      if (noteEntries.length > 0) {
-        parts.push(
-          `notes: ${noteEntries.map(([uid, n]) => `[${uidToName[uid] ?? uid}] ${n}`).join(' / ')}`,
-        );
-      } else if (s.notes) {
-        parts.push(`notes: ${s.notes}`);
-      }
+      const absentNotes = Object.entries(memberNotes)
+        .filter(([uid, v]) => !presentUids.includes(uid) && v.trim())
+        .map(([uid, n]) => `[${uidToName[uid] ?? uid}] ${n}`)
+        .join(' / ');
 
-      return parts.join(' | ');
+      const lines = [
+        `  - id:${s.id} | "${s.title}" (${s.type}) | vibes: ${vibes} | brain: ${bp} | status: ${s.status}${ep}`,
+        `    viewers: ${viewerSignals}`,
+        `    ${preScoreStr}`,
+      ];
+      if (s.service) lines.push(`    service: ${s.service}`);
+      if (s.description) lines.push(`    desc: ${s.description}`);
+      if (absentNotes) lines.push(`    absent viewer notes: ${absentNotes}`);
+
+      return lines.join('\n');
     })
     .join('\n');
 
+  // --- DECISION RULES ---
+  const rules =
+    `DECISION RULES (apply in this order):\n` +
+    `1. PARSE TONIGHT'S VIBE FIRST: From the shared vibe text, identify each named person's energy and mood. ` +
+    `"brain dead", "tired", "drained", "multitasking", "background", "low focus", "low energy" → strong LOW brain-power signal. ` +
+    `"funny", "exciting", "chill", "romantic", etc. → vibe preferences. ` +
+    `When two viewers want different things, pick the best compromise.\n` +
+    `2. BRAIN POWER FIT: When anyone is tired, brain dead, or multitasking → strongly prefer brain power 1–2. ` +
+    `A 6/10 show with brain power 1 beats a 9/10 show with brain power 5 when someone is exhausted. Unknown brain power is neutral.\n` +
+    `3. MOOD AND VIBE MATCH: Match show vibe tags to inferred mood. ` +
+    `"funny" → Comedy/Humor/Lighthearted. "exciting" → Action/Thrilling. "chill" → Cozy/Relaxing. Strong vibe overlap = strong positive signal.\n` +
+    `4. USE ALL RATING BANDS AS TASTE EVIDENCE:\n` +
+    `   - 8–10 (Loved): strong signal they enjoy this show's style\n` +
+    `   - 6–7.9 (Conditionally liked): excellent pick if tonight's mood matches this show's vibes\n` +
+    `   - 4–5.9 (Mixed): use cautiously\n` +
+    `   - <4 (Disliked): negative signal — avoid similar vibes/style\n` +
+    `   - wouldRewatch=yes: extra positive signal | wouldRewatch=no: mild negative signal\n` +
+    `   - Unrated but noted: read the note for qualitative signal\n` +
+    `5. DO NOT simply pick the highest-rated show. Pre-scores are hints, not final answers. ` +
+    `A mid-rated show with perfect brain-power and vibe fit beats a high-rated show that is wrong for tonight.\n` +
+    `6. NOTES: High-signal when directly relevant to tonight's mood. Ignore unrelated trivia.\n\n`;
+
+  const jsonInstruction =
+    `Return JSON only (no markdown, no prose, no code fences):\n` +
+    `{ "showId": "<id from list above>", "reason": "<2–4 sentences: how it matched tonight's mood, brain power fit if relevant, how it balanced both viewers, any key rating or note signal that mattered>" }\n\n` +
+    `The showId must be one of the candidate IDs listed above. Do not invent IDs.`;
+
   return (
-    `Pick one show for these people to watch together right now.\n\n` +
-    `WHO IS WATCHING AND THEIR MOODS:\n${moodLines}\n\n` +
-    `THEIR HIGH-SCORING HISTORY (shows they loved):\n${historyLines}\n\n` +
+    `Pick one show for these people to watch together tonight.\n\n` +
+    sharedMoodSection +
+    moodSection +
+    profileSection +
     `CANDIDATE SHOWS (choose exactly one id from this list):\n${candidateLines}\n\n` +
-    `DECISION WEIGHTS (apply in this order):\n` +
-    `1. VIBES FIRST: Match candidate vibe tags to each person's current mood and to the vibes of their high-scoring history. This is the strongest signal.\n` +
-    `2. BRAIN POWER: When moods mention tired, braindead, chill, or low focus → strongly prefer brain power 1-2. When moods mention engaged, thoughtful, mystery, or ready to focus → allow brain power 3-5. Unknown brain power is neutral.\n` +
-    `3. SCORE HISTORY: Favor candidates whose vibes overlap with each person's high-scoring history.\n` +
-    `4. NOTES IF RELEVANT: Personal notes are high-signal when directly relevant to the current mood or situation. Ignore unrelated trivia.\n` +
-    `5. DESCRIPTION: Use as light context/tiebreaker.\n\n` +
-    `Return JSON only (no prose, no markdown, no code fences):\n` +
-    `{ "showId": "<id from list above>", "reason": "<2-3 sentences>" }\n\n` +
-    `The reason should lead with the vibe match. Mention brain power if it was a factor. Bring in notes only if a note materially shaped the pick.`
+    rules +
+    jsonInstruction
   );
 }

--- a/app/tools/shows/lib/preScore.ts
+++ b/app/tools/shows/lib/preScore.ts
@@ -1,0 +1,183 @@
+import type { Show } from '../types';
+import { memberComposite } from './compositeScore';
+
+const LOW_FOCUS_PHRASES = [
+  'brain dead',
+  'braindead',
+  'brain-dead',
+  'tired',
+  'exhausted',
+  'drained',
+  'wiped',
+  'low focus',
+  'low energy',
+  'low-energy',
+  'low-focus',
+  'multitask',
+  'multitasking',
+  'multi-task',
+  'background',
+  'mindless',
+  'no brain',
+];
+
+const HIGH_FOCUS_PHRASES = [
+  'ready to focus',
+  'ready to think',
+  'thinking mood',
+  'analytical',
+  'want to think',
+  'can focus',
+  'full attention',
+];
+
+const VIBE_KEYWORD_MAP: Array<{ keywords: string[]; tags: string[] }> = [
+  {
+    keywords: ['funny', 'comedy', 'humor', 'laugh', 'hilarious', 'comedic', 'lighthearted'],
+    tags: ['Comedy', 'Funny', 'Humor', 'Lighthearted'],
+  },
+  {
+    keywords: ['exciting', 'action', 'thriller', 'thrilling', 'adventure', 'intense', 'hype', 'hyped', 'adrenaline'],
+    tags: ['Action', 'Exciting', 'Thrilling', 'Adventure'],
+  },
+  {
+    keywords: ['chill', 'cozy', 'comfort', 'relax', 'calm', 'mellow', 'slice of life'],
+    tags: ['Chill', 'Cozy', 'Relaxing', 'Comfort', 'Slice of life'],
+  },
+  {
+    keywords: ['romantic', 'romance', 'sweet', 'love story'],
+    tags: ['Romantic', 'Romance'],
+  },
+  {
+    keywords: ['drama', 'emotional', 'touching', 'moving', 'deep'],
+    tags: ['Drama', 'Emotional'],
+  },
+  {
+    keywords: ['mystery', 'suspense', 'crime', 'detective', 'noir', 'whodunit'],
+    tags: ['Mystery', 'Thriller', 'Suspense', 'Crime'],
+  },
+  {
+    keywords: ['musical', 'music', 'singing'],
+    tags: ['Musical'],
+  },
+  {
+    keywords: ['fantasy', 'magic', 'epic', 'world-building'],
+    tags: ['Fantasy', 'Epic'],
+  },
+  {
+    keywords: ['sci-fi', 'scifi', 'futuristic', 'space'],
+    tags: ['Sci-Fi'],
+  },
+];
+
+/** Infers focus level from free-form mood text. */
+export function inferFocusLevel(text: string): 'low' | 'normal' | 'high' {
+  const normalized = text.toLowerCase();
+  if (LOW_FOCUS_PHRASES.some((p) => normalized.includes(p))) return 'low';
+  if (HIGH_FOCUS_PHRASES.some((p) => normalized.includes(p))) return 'high';
+  return 'normal';
+}
+
+/** Infers desired vibe tags from free-form mood text. */
+export function inferVibeKeywords(text: string): string[] {
+  const normalized = text.toLowerCase();
+  const matched: string[] = [];
+  for (const { keywords, tags } of VIBE_KEYWORD_MAP) {
+    if (keywords.some((k) => normalized.includes(k))) {
+      matched.push(...tags);
+    }
+  }
+  return [...new Set(matched)];
+}
+
+/**
+ * Scores how well a show's brain power requirement matches the inferred focus level.
+ * Returns 0–10. Higher = better fit.
+ */
+export function scoreBrainPower(
+  brainPower: number | null | undefined,
+  focusLevel: 'low' | 'normal' | 'high',
+): number {
+  if (brainPower == null) return 5; // unknown → neutral
+
+  if (focusLevel === 'low') {
+    if (brainPower <= 2) return 10;
+    if (brainPower === 3) return 4;
+    return 0; // bp 4–5 is bad when tired/multitasking
+  }
+
+  if (focusLevel === 'high') {
+    if (brainPower >= 4) return 10;
+    if (brainPower === 3) return 7;
+    return 4; // bp 1–2 is fine but slightly under-stimulating
+  }
+
+  // Normal focus: mild preference for 2–3
+  if (brainPower === 2 || brainPower === 3) return 8;
+  if (brainPower === 1 || brainPower === 4) return 6;
+  return 4; // bp=5 slightly heavy for casual viewing
+}
+
+/**
+ * Scores how well a show's vibe tags match the inferred vibe keywords.
+ * Returns 0–10. Higher = better fit.
+ */
+export function scoreVibeFit(vibeTags: string[], vibeKeywords: string[]): number {
+  if (vibeKeywords.length === 0) return 5; // no vibe preference → neutral
+  const tagSet = new Set(vibeTags.map((t) => t.toLowerCase()));
+  const kwSet = new Set(vibeKeywords.map((k) => k.toLowerCase()));
+  const matches = [...tagSet].filter((t) => kwSet.has(t)).length;
+  if (matches === 0) return 2;
+  if (matches === 1) return 6;
+  if (matches === 2) return 8;
+  return 10;
+}
+
+/**
+ * Scores how well present viewers have historically rated this show.
+ * Returns 0–10. Unrated shows return 5 (neutral).
+ */
+export function scoreViewerRatingFit(show: Show, presentUids: string[]): number {
+  const composites: number[] = [];
+  for (const uid of presentUids) {
+    const rating = show.ratings[uid];
+    if (!rating) continue;
+    const c = memberComposite(rating);
+    if (c !== null) composites.push(c);
+  }
+  if (composites.length === 0) return 5;
+  const avg = composites.reduce((a, b) => a + b, 0) / composites.length;
+  // Slight penalty below 6 to de-prioritize disliked shows without ignoring them
+  if (avg >= 6) return avg;
+  if (avg >= 4) return avg - 1;
+  return Math.max(0, avg - 2);
+}
+
+export interface CandidatePreScore {
+  showId: string;
+  title: string;
+  brainPowerMatch: number;
+  vibeFit: number;
+  viewerRatingFit: number;
+  overallPreScore: number;
+}
+
+/**
+ * Computes a lightweight deterministic pre-score for a candidate show.
+ * Brain power match weighted highest because it's the clearest "wrong night" signal.
+ */
+export function computeCandidatePreScore(
+  show: Show,
+  focusLevel: 'low' | 'normal' | 'high',
+  vibeKeywords: string[],
+  presentUids: string[],
+): CandidatePreScore {
+  const brainPowerMatch = scoreBrainPower(show.brainPower, focusLevel);
+  const vibeFit = scoreVibeFit(show.vibeTags, vibeKeywords);
+  const viewerRatingFit = scoreViewerRatingFit(show, presentUids);
+
+  const overallPreScore =
+    brainPowerMatch * 0.4 + vibeFit * 0.35 + viewerRatingFit * 0.25;
+
+  return { showId: show.id, title: show.title, brainPowerMatch, vibeFit, viewerRatingFit, overallPreScore };
+}

--- a/app/tools/shows/lib/preScore.ts
+++ b/app/tools/shows/lib/preScore.ts
@@ -1,4 +1,5 @@
 import type { Show } from '../types';
+import { VIBE_CATEGORIES } from './vibeCategories';
 import { memberComposite } from './compositeScore';
 
 const LOW_FOCUS_PHRASES = [
@@ -31,30 +32,39 @@ const HIGH_FOCUS_PHRASES = [
   'full attention',
 ];
 
+// All tags here must exist in VIBE_CATEGORIES; the filter at the end enforces this at runtime.
 const VIBE_KEYWORD_MAP: Array<{ keywords: string[]; tags: string[] }> = [
   {
     keywords: ['funny', 'comedy', 'humor', 'laugh', 'hilarious', 'comedic', 'lighthearted'],
-    tags: ['Comedy', 'Funny', 'Humor', 'Lighthearted'],
+    tags: ['Funny', 'Lighthearted'],
   },
   {
-    keywords: ['exciting', 'action', 'thriller', 'thrilling', 'adventure', 'intense', 'hype', 'hyped', 'adrenaline'],
-    tags: ['Action', 'Exciting', 'Thrilling', 'Adventure'],
+    keywords: ['exciting', 'action', 'thriller', 'thrilling', 'adventure', 'hype', 'hyped', 'adrenaline'],
+    tags: ['Action-Packed', 'Adventurous', 'Fast-Paced', 'Intense', 'Suspenseful'],
   },
   {
-    keywords: ['chill', 'cozy', 'comfort', 'relax', 'calm', 'mellow', 'slice of life'],
-    tags: ['Chill', 'Cozy', 'Relaxing', 'Comfort', 'Slice of life'],
+    keywords: ['chill', 'cozy', 'comfort', 'relax', 'calm', 'mellow', 'easy watch'],
+    tags: ['Chill', 'Cozy', 'Comfort Watch', 'Low-Stakes'],
+  },
+  {
+    keywords: ['slice of life'],
+    tags: ['Slice of Life', 'Chill', 'Cozy'],
   },
   {
     keywords: ['romantic', 'romance', 'sweet', 'love story'],
-    tags: ['Romantic', 'Romance'],
+    tags: ['Romantic', 'Wholesome'],
   },
   {
     keywords: ['drama', 'emotional', 'touching', 'moving', 'deep'],
-    tags: ['Drama', 'Emotional'],
+    tags: ['Emotional', 'Thoughtful'],
   },
   {
     keywords: ['mystery', 'suspense', 'crime', 'detective', 'noir', 'whodunit'],
-    tags: ['Mystery', 'Thriller', 'Suspense', 'Crime'],
+    tags: ['Mysterious', 'Suspenseful', 'Mind-Bending'],
+  },
+  {
+    keywords: ['mind bending', 'mind-bending', 'trippy', 'psychological', 'twist'],
+    tags: ['Mind-Bending', 'Thoughtful'],
   },
   {
     keywords: ['musical', 'music', 'singing'],
@@ -62,13 +72,31 @@ const VIBE_KEYWORD_MAP: Array<{ keywords: string[]; tags: string[] }> = [
   },
   {
     keywords: ['fantasy', 'magic', 'epic', 'world-building'],
-    tags: ['Fantasy', 'Epic'],
+    tags: ['Epic', 'Adventurous'],
   },
   {
-    keywords: ['sci-fi', 'scifi', 'futuristic', 'space'],
-    tags: ['Sci-Fi'],
+    keywords: ['horror', 'scary', 'creepy'],
+    tags: ['Horror', 'Dark', 'Suspenseful', 'Intense'],
+  },
+  {
+    keywords: ['dark', 'gritty'],
+    tags: ['Dark', 'Intense'],
+  },
+  {
+    keywords: ['chaotic', 'wild', 'crazy'],
+    tags: ['Chaotic', 'Fast-Paced'],
+  },
+  {
+    keywords: ['family', 'friendship', 'heartwarming', 'wholesome', 'feel good'],
+    tags: ['Found Family', 'Wholesome'],
+  },
+  {
+    keywords: ['slow burn', 'slow-burn'],
+    tags: ['Slow Burn', 'Thoughtful'],
   },
 ];
+
+const VALID_VIBE_TAGS = new Set<string>(VIBE_CATEGORIES);
 
 /** Infers focus level from free-form mood text. */
 export function inferFocusLevel(text: string): 'low' | 'normal' | 'high' {
@@ -78,7 +106,10 @@ export function inferFocusLevel(text: string): 'low' | 'normal' | 'high' {
   return 'normal';
 }
 
-/** Infers desired vibe tags from free-form mood text. */
+/**
+ * Infers desired vibe tags from free-form mood text.
+ * All returned values are guaranteed to exist in VIBE_CATEGORIES.
+ */
 export function inferVibeKeywords(text: string): string[] {
   const normalized = text.toLowerCase();
   const matched: string[] = [];
@@ -87,7 +118,8 @@ export function inferVibeKeywords(text: string): string[] {
       matched.push(...tags);
     }
   }
-  return [...new Set(matched)];
+  // Deduplicate and guard against any accidental non-canonical tag
+  return [...new Set(matched)].filter((t) => VALID_VIBE_TAGS.has(t));
 }
 
 /**

--- a/app/tools/shows/lib/recommendationContext.ts
+++ b/app/tools/shows/lib/recommendationContext.ts
@@ -1,4 +1,4 @@
-import type { Show, ShowList } from '../types';
+import type { Show, ShowList, WouldRewatch } from '../types';
 import { memberComposite } from './compositeScore';
 
 export interface MoodEntry {
@@ -6,44 +6,109 @@ export interface MoodEntry {
   mood: string;
 }
 
-export interface HistoryShow {
+/** A single show entry in a viewer's rated history. */
+export interface RatedShowEntry {
   title: string;
-  vibes: string[];
   composite: number;
-  description: string;
-  /** Member's personal note for this show (memberNotes[uid] ?? legacy notes). */
+  story: number | null;
+  characters: number | null;
+  vibes: number | null;
+  wouldRewatch: WouldRewatch | null;
+  vibeTags: string[];
+  brainPower: number | null;
   note: string;
+  description: string;
 }
 
-export interface HistoryEntry {
+/** A show with notes but no composite rating. */
+export interface NotedUnratedEntry {
+  title: string;
+  note: string;
+  vibeTags: string[];
+}
+
+/**
+ * Rich per-viewer preference profile built from all rated/noted shows.
+ *
+ * Rating bands:
+ *   8–10  → stronglyLiked        (clear positive signal)
+ *   6–7.9 → conditionallyLiked   (can still be great if tonight's mood matches)
+ *   4–5.9 → weaklyLiked          (use cautiously)
+ *   <4    → disliked             (negative signal unless notes explain otherwise)
+ *   unrated with note → notedButUnrated
+ */
+export interface ViewerPreferenceProfile {
+  uid: string;
   name: string;
-  highScoringShows: HistoryShow[];
+  stronglyLiked: RatedShowEntry[];
+  conditionallyLiked: RatedShowEntry[];
+  weaklyLiked: RatedShowEntry[];
+  disliked: RatedShowEntry[];
+  notedButUnrated: NotedUnratedEntry[];
 }
 
-export function buildHistory(
+function toRatedEntry(show: Show, uid: string, composite: number): RatedShowEntry {
+  const r = show.ratings[uid];
+  return {
+    title: show.title,
+    composite,
+    story: r?.story ?? null,
+    characters: r?.characters ?? null,
+    vibes: r?.vibes ?? null,
+    wouldRewatch: r?.wouldRewatch ?? null,
+    vibeTags: show.vibeTags,
+    brainPower: show.brainPower ?? null,
+    note: show.memberNotes?.[uid] ?? show.notes ?? '',
+    description: show.description ?? '',
+  };
+}
+
+/**
+ * Builds a rich preference profile for each present viewer using ALL rated
+ * and noted shows — not just high-scoring ones.
+ */
+export function buildViewerProfiles(
   shows: Show[],
   members: ShowList['members'],
-): Record<string, HistoryEntry> {
-  const history: Record<string, HistoryEntry> = {};
+): Record<string, ViewerPreferenceProfile> {
+  const profiles: Record<string, ViewerPreferenceProfile> = {};
+
   for (const member of members) {
-    const highScoringShows = shows.flatMap((show) => {
+    const profile: ViewerPreferenceProfile = {
+      uid: member.uid,
+      name: member.displayName,
+      stronglyLiked: [],
+      conditionallyLiked: [],
+      weaklyLiked: [],
+      disliked: [],
+      notedButUnrated: [],
+    };
+
+    for (const show of shows) {
       const rating = show.ratings[member.uid];
-      if (!rating) return [];
-      const composite = memberComposite(rating);
-      if (composite === null || composite < 7) return [];
-      // Prefer per-person note, fall back to legacy shared notes
+      const composite = rating ? memberComposite(rating) : null;
       const note = show.memberNotes?.[member.uid] ?? show.notes ?? '';
-      return [{
-        title: show.title,
-        vibes: show.vibeTags,
-        composite,
-        description: show.description ?? '',
-        note,
-      }];
-    });
-    history[member.uid] = { name: member.displayName, highScoringShows };
+
+      if (composite !== null) {
+        const entry = toRatedEntry(show, member.uid, composite);
+        if (composite >= 8) {
+          profile.stronglyLiked.push(entry);
+        } else if (composite >= 6) {
+          profile.conditionallyLiked.push(entry);
+        } else if (composite >= 4) {
+          profile.weaklyLiked.push(entry);
+        } else {
+          profile.disliked.push(entry);
+        }
+      } else if (note.trim()) {
+        profile.notedButUnrated.push({ title: show.title, note, vibeTags: show.vibeTags });
+      }
+    }
+
+    profiles[member.uid] = profile;
   }
-  return history;
+
+  return profiles;
 }
 
 /**

--- a/app/tools/shows/mood/page.tsx
+++ b/app/tools/shows/mood/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import { Sparkles, RefreshCw, Play, Loader2, ChevronDown, ChevronUp } from 'lucide-react';
+import { Sparkles, RefreshCw, Play, Loader2, ChevronDown, ChevronUp, Info } from 'lucide-react';
 import Nav from '@/components/Nav';
 import { useShows } from '../ShowsContext';
 import StatusBadge from '../components/StatusBadge';
 import TypeChip from '../components/TypeChip';
 import VibeTagChip from '../components/VibeTagChip';
-import { buildHistory, candidateShows } from '../lib/recommendationContext';
+import { buildViewerProfiles, candidateShows } from '../lib/recommendationContext';
 import { formatScore, groupComposite } from '../lib/compositeScore';
 import type { Show } from '../types';
 
@@ -18,27 +18,25 @@ interface RecommendResult {
 
 export default function MoodPage() {
   const { shows, activeList, updateShow, user } = useShows();
-  // Memoized so the array reference is stable when activeList hasn't changed
   const members = useMemo(() => activeList?.members ?? [], [activeList]);
 
-  // Present viewers — default to all members, update when members load asynchronously
   const [presentUids, setPresentUids] = useState<string[]>([]);
   const [viewerPickerOpen, setViewerPickerOpen] = useState(false);
+  const [infoOpen, setInfoOpen] = useState(false);
 
   const listId = activeList?.id;
 
-  // Reset selection when the active list switches
   useEffect(() => {
     setPresentUids([]);
   }, [listId]);
 
-  // Fill from members once loaded (or after a reset)
   useEffect(() => {
     if (members.length > 0) {
       setPresentUids((prev) => (prev.length === 0 ? members.map((m) => m.uid) : prev));
     }
   }, [members]);
 
+  const [sharedMood, setSharedMood] = useState('');
   const [moods, setMoods] = useState<Record<string, string>>({});
   const [result, setResult] = useState<RecommendResult | null>(null);
   const [excludedIds, setExcludedIds] = useState<string[]>([]);
@@ -47,8 +45,8 @@ export default function MoodPage() {
   const [used, setUsed] = useState(false);
 
   const presentMembers = members.filter((m) => presentUids.includes(m.uid));
+  const absentMembers = members.filter((m) => !presentUids.includes(m.uid));
 
-  // Candidates filtered to shows the present viewers are watching/planned
   const candidates = useMemo(
     () => candidateShows(shows, presentUids),
     [shows, presentUids],
@@ -69,12 +67,18 @@ export default function MoodPage() {
         moodsPayload[m.uid] = { name: m.displayName, mood: moods[m.uid] ?? '' };
       });
 
-      const history = buildHistory(shows, presentMembers);
+      const profiles = buildViewerProfiles(shows, presentMembers);
 
       const res = await fetch('/api/recommend', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ moods: moodsPayload, candidates, history, excludeIds: exclude }),
+        body: JSON.stringify({
+          moods: moodsPayload,
+          candidates,
+          profiles,
+          sharedMood: sharedMood.trim() || undefined,
+          excludeIds: exclude,
+        }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -115,20 +119,58 @@ export default function MoodPage() {
     setUsed(true);
   }
 
+  const hasSharedMood = sharedMood.trim().length > 0;
   const hasMoods = presentMembers.some((m) => (moods[m.uid] ?? '').trim().length > 0);
-
-  const absentMembers = members.filter((m) => !presentUids.includes(m.uid));
+  const canSubmit = hasSharedMood || hasMoods;
 
   return (
     <main className="bg-bg text-text min-h-dvh">
       <Nav />
       <section className="px-4 py-6 space-y-6 max-w-lg mx-auto">
+
+        {/* Heading */}
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold flex items-center gap-2">
             <Sparkles size={22} className="text-accent" />
             What&apos;s the vibe tonight?
           </h1>
-          <p className="text-sm text-text-2">Tell me how everyone&apos;s feeling.</p>
+          <p className="text-sm text-text-2">Describe the mood and get a pick for everyone.</p>
+        </div>
+
+        {/* How recommendations work — collapsible info */}
+        <div className="border border-border rounded-xl overflow-hidden text-sm">
+          <button
+            type="button"
+            onClick={() => setInfoOpen((v) => !v)}
+            className="w-full flex items-center gap-2 px-4 py-3 text-text-2 hover:text-text hover:bg-surface-2 transition-colors"
+          >
+            <Info size={14} className="flex-shrink-0" />
+            <span className="flex-1 text-left">How recommendations work</span>
+            {infoOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </button>
+          {infoOpen && (
+            <div className="px-4 pb-4 pt-2 border-t border-border text-text-2 space-y-1.5">
+              <ul className="space-y-1.5 list-disc list-inside">
+                <li>Prioritizes tonight&apos;s mood first — describe what everyone feels like.</li>
+                <li>
+                  Uses <strong className="text-text">brain power</strong> to avoid dense shows when
+                  someone is tired or multitasking.
+                </li>
+                <li>
+                  Uses <strong className="text-text">all ratings</strong> as taste evidence, not
+                  just high scores.
+                </li>
+                <li>
+                  A mid-rated show can beat a highly-rated one if it fits tonight&apos;s mood and
+                  brain power better.
+                </li>
+                <li>Reads each person&apos;s notes and ratings separately.</li>
+                <li>Prefers shows relevant to the viewers watching tonight.</li>
+                <li>Uses status, progress, and service as secondary context.</li>
+                <li>Does not simply pick the highest-rated show.</li>
+              </ul>
+            </div>
+          )}
         </div>
 
         {candidates.length === 0 && (
@@ -142,27 +184,22 @@ export default function MoodPage() {
 
         {candidates.length > 0 && (
           <form onSubmit={handleSubmit} className="space-y-5">
-            {/* Mood inputs — shown first, prominent */}
-            <div className="space-y-3">
-              {presentMembers.map((m) => (
-                <div key={m.uid} className="space-y-1.5">
-                  <label className="text-sm font-medium text-text-2">
-                    How is {m.displayName} feeling?
-                  </label>
-                  <textarea
-                    value={moods[m.uid] ?? ''}
-                    onChange={(e) =>
-                      setMoods((prev) => ({ ...prev, [m.uid]: e.target.value }))
-                    }
-                    rows={2}
-                    placeholder="e.g. tired and want something chill, or hype for action…"
-                    className="w-full rounded-xl bg-surface-2 border border-border px-3 py-2.5 text-sm text-text placeholder:text-text-3 focus:outline-none focus:border-accent resize-none"
-                  />
-                </div>
-              ))}
+
+            {/* Shared mood — primary, prominent */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-text">
+                Tonight&apos;s vibe
+              </label>
+              <textarea
+                value={sharedMood}
+                onChange={(e) => setSharedMood(e.target.value)}
+                rows={3}
+                placeholder="e.g. Jimi is brain dead after work and wants something funny. Kait wants something a little exciting but will be multitasking."
+                className="w-full rounded-xl bg-surface-2 border border-border px-3 py-2.5 text-sm text-text placeholder:text-text-3 focus:outline-none focus:border-accent resize-none"
+              />
             </div>
 
-            {/* Change viewers — collapsed by default */}
+            {/* Viewer controls + optional per-person mood — collapsed by default */}
             <div className="border border-border rounded-xl overflow-hidden">
               <button
                 type="button"
@@ -173,11 +210,13 @@ export default function MoodPage() {
                   {absentMembers.length === 0
                     ? 'Everyone is watching'
                     : `${presentMembers.length} of ${members.length} watching`}
+                  <span className="text-text-3 ml-1.5">· per-person details (optional)</span>
                 </span>
                 {viewerPickerOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
               </button>
               {viewerPickerOpen && (
-                <div className="px-4 pb-4 pt-2 border-t border-border">
+                <div className="px-4 pb-4 pt-3 border-t border-border space-y-4">
+                  {/* Viewer toggle pills */}
                   <div className="flex flex-wrap gap-2">
                     {members.map((m) => (
                       <button
@@ -194,6 +233,25 @@ export default function MoodPage() {
                       </button>
                     ))}
                   </div>
+                  {/* Per-person mood inputs */}
+                  <div className="space-y-3">
+                    {presentMembers.map((m) => (
+                      <div key={m.uid} className="space-y-1">
+                        <label className="text-xs font-medium text-text-2">
+                          {m.displayName}&apos;s mood
+                        </label>
+                        <textarea
+                          value={moods[m.uid] ?? ''}
+                          onChange={(e) =>
+                            setMoods((prev) => ({ ...prev, [m.uid]: e.target.value }))
+                          }
+                          rows={2}
+                          placeholder="e.g. tired and want something chill…"
+                          className="w-full rounded-xl bg-bg border border-border px-3 py-2 text-sm text-text placeholder:text-text-3 focus:outline-none focus:border-accent resize-none"
+                        />
+                      </div>
+                    ))}
+                  </div>
                 </div>
               )}
             </div>
@@ -206,7 +264,7 @@ export default function MoodPage() {
 
             <button
               type="submit"
-              disabled={loading || !hasMoods || presentMembers.length === 0}
+              disabled={loading || !canSubmit || presentMembers.length === 0}
               className="w-full rounded-xl bg-accent py-3.5 font-semibold text-bg disabled:opacity-50 transition-opacity min-h-[52px] flex items-center justify-center gap-2"
             >
               {loading ? (


### PR DESCRIPTION
## Summary
This PR introduces a deterministic pre-scoring system for candidate shows and refactors viewer preference profiles to use all rating bands (not just high scores). These changes improve recommendation quality by matching shows to the current mood's focus level and vibe preferences, while providing richer context about each viewer's taste.

## Key Changes

### New Pre-Scoring System (`preScore.ts`)
- **`inferFocusLevel()`**: Detects focus level ("low", "normal", "high") from mood text using keyword matching (e.g., "brain dead", "tired", "multitasking" → low focus)
- **`inferVibeKeywords()`**: Extracts desired vibe tags from mood text, mapping user-friendly keywords to canonical VIBE_CATEGORIES tags (e.g., "exciting" → Action-Packed, Adventurous, Fast-Paced, etc.)
- **`scoreBrainPower()`**: Scores show brain power (1–5) against inferred focus level; heavily weights the match (e.g., bp=1 gets 10/10 for low focus, 0/10 for high focus)
- **`scoreVibeFit()`**: Scores how well a show's vibe tags match inferred vibe keywords (0–10)
- **`scoreViewerRatingFit()`**: Scores how well present viewers have historically rated a show (0–10), averaging across multiple viewers
- **`computeCandidatePreScore()`**: Combines all three signals with weights (40% brain power, 35% vibe fit, 25% viewer ratings) into a single 0–10 pre-score

### Refactored Viewer Profiles (`recommendationContext.ts`)
- Renamed `buildHistory()` → `buildViewerProfiles()` and `HistoryEntry` → `ViewerPreferenceProfile`
- Changed from single `highScoringShows` array to five rating bands:
  - **stronglyLiked** (8–10): Clear positive signal
  - **conditionallyLiked** (6–7.9): Great if tonight's mood matches
  - **weaklyLiked** (4–5.9): Use cautiously
  - **disliked** (<4): Negative signal
  - **notedButUnrated**: Shows with notes but no rating
- Each rated entry now includes: composite score, individual ratings (story/characters/vibes), wouldRewatch, brainPower, vibeTags, and note
- Unrated entries include title, note, and vibeTags

### Enhanced Recommendation Prompt (`buildRecommendPrompt.ts`)
- Infers focus level and vibe keywords from combined mood text (shared + per-person)
- Computes pre-scores for all candidates and includes them in the prompt
- Restructured output with sections: shared vibe (highest priority), per-person mood, viewer preference profiles (all bands), and candidates with per-viewer signals
- Per-candidate output now includes: pre-score breakdown, per-viewer ratings with individual dimensions, and notes from both present and absent viewers
- Improved formatting with compact notation (e.g., `brain:2/5`, `wr:yes`, `score:8.5`)

### UI Updates (`mood/page.tsx`)
- Added "shared mood" input field for group-level vibe description (highest priority)
- Added collapsible info section explaining how recommendations work
- Updated recommendation submission to include shared mood and new profiles structure
- Improved viewer picker UX with clearer present/absent member separation

### Test Coverage
- Comprehensive test suite for `preScore.ts` covering all inference and scoring functions
- Updated `recommendationContext.test.ts` to test new profile structure with all rating bands
- Tests verify that all inferred vibe keywords exist in VIBE_CATEGORIES (runtime guard)

## Notable Implementation Details
- **Vibe keyword mapping** is validated at runtime to ensure only canonical tags are returned
- **Brain power scoring** uses different thresholds for low/normal/high focus (e.g., bp=3 is neutral for low focus but good for high focus)
- **Pre-score weighting** prioritizes brain power match (40%) because it's the clearest "wrong night" signal
- **

https://claude.ai/code/session_0152e13iGFRYJkYAW9EZAE11