### PR TITLE
feat(shows): make brain power a per-person rating field

### DIFF
--- a/app/tools/shows/ShowsContext.tsx
+++ b/app/tools/shows/ShowsContext.tsx
@@ -323,7 +323,7 @@ export function ShowsProvider({ children }: { children: ReactNode }) {
     if (!user) return;
     const show = shows.find((s) => s.id === showId);
     const existing: MemberRating = show?.ratings[user.uid] ?? {
-      story: null, characters: null, vibes: null, wouldRewatch: null, ratedAt: null,
+      story: null, characters: null, vibes: null, wouldRewatch: null, brainPower: null, ratedAt: null,
     };
     await updateDoc(showDoc(showId), {
       [`ratings.${user.uid}`]: { ...existing, ...rating, ratedAt: serverTimestamp() },

--- a/app/tools/shows/__tests__/preScore.test.ts
+++ b/app/tools/shows/__tests__/preScore.test.ts
@@ -170,6 +170,30 @@ describe('inferViewerFocusLevel', () => {
       inferViewerFocusLevel('', 'Kait', 'Jimi is tired. Kait is ready to focus.'),
     ).toBe('high');
   });
+
+  it('splits on "but" so Kait is not low-focus when only Jimi is tired', () => {
+    expect(
+      inferViewerFocusLevel('', 'Kait', 'Jimi is tired from work but Kait is up for whatever'),
+    ).toBe('normal');
+  });
+
+  it('identifies Jimi as low-focus when split by "but"', () => {
+    expect(
+      inferViewerFocusLevel('', 'Jimi', 'Jimi is tired from work but Kait is up for whatever'),
+    ).toBe('low');
+  });
+
+  it('splits on "while" as a contrastive conjunction', () => {
+    expect(
+      inferViewerFocusLevel('', 'Kait', 'Jimi is exhausted while Kait is energized'),
+    ).toBe('normal');
+  });
+
+  it('splits on "whereas" as a contrastive conjunction', () => {
+    expect(
+      inferViewerFocusLevel('', 'Alice', 'Bob is brain dead whereas Alice is ready to focus'),
+    ).toBe('high');
+  });
 });
 
 /* ------------------------------------------------------------ */
@@ -477,9 +501,9 @@ describe('computeCandidatePreScore', () => {
 /* ------------------------------------------------------------ */
 
 describe('per-viewer brainpower scoring scenarios', () => {
-  it('Jimi low-focus brain:2, Kait normal brain:5 → reasonable brainpower fit', () => {
+  it('Jimi low-focus brain:2, Kait normal brain:5 → excellent brainpower fit (low-focus viewer drives score)', () => {
     // Jimi thinks the show is easy (bp=2), Kait thinks it is dense (bp=5)
-    // Jimi is tired, Kait is fine. Jimi's estimate should dominate his share.
+    // Only the low-focus viewer (Jimi) drives the brain-power score
     const show = makeShow({
       id: 's1',
       ratings: {
@@ -487,14 +511,14 @@ describe('per-viewer brainpower scoring scenarios', () => {
         kait: { ...makeRating(8), brainPower: 5 },
       },
     });
-    // jimi (low, bp=2) → 10; kait (normal, bp=5) → 4; avg = 7
+    // only low-focus viewer (jimi) scored: scoreBrainPower(2, 'low') = 10
     const result = computeCandidatePreScore(show, { jimi: 'low', kait: 'normal' }, [], ['jimi', 'kait']);
-    expect(result.brainPowerMatch).toBeGreaterThan(5);
+    expect(result.brainPowerMatch).toBe(10);
   });
 
-  it('Jimi low-focus brain:5, Kait normal brain:1 → poor brainpower fit', () => {
+  it('Jimi low-focus brain:5, Kait normal brain:1 → poor brainpower fit (low-focus viewer drives score)', () => {
     // Jimi is tired and thinks the show is dense — bad for Jimi
-    // Kait thinks it is easy, but Kait is not the constraint tonight
+    // Kait's easy-brain estimate is irrelevant because she is not the constraint
     const show = makeShow({
       id: 's1',
       ratings: {
@@ -502,9 +526,9 @@ describe('per-viewer brainpower scoring scenarios', () => {
         kait: { ...makeRating(8), brainPower: 1 },
       },
     });
-    // jimi (low, bp=5) → 0; kait (normal, bp=1) → 6; avg = 3
+    // only low-focus viewer (jimi) scored: scoreBrainPower(5, 'low') = 0
     const result = computeCandidatePreScore(show, { jimi: 'low', kait: 'normal' }, [], ['jimi', 'kait']);
-    expect(result.brainPowerMatch).toBeLessThan(5);
+    expect(result.brainPowerMatch).toBe(0);
   });
 
   it('both viewers low-focus with bp=1 → excellent brainpower fit', () => {

--- a/app/tools/shows/__tests__/preScore.test.ts
+++ b/app/tools/shows/__tests__/preScore.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   inferFocusLevel,
+  inferViewerFocusLevel,
   inferVibeKeywords,
   scoreBrainPower,
   scoreVibeFit,
   scoreViewerRatingFit,
   computeCandidatePreScore,
 } from '../lib/preScore';
+import { memberComposite } from '../lib/compositeScore';
 import { VIBE_CATEGORIES } from '../lib/vibeCategories';
-import type { Show } from '../types';
+import type { Show, MemberRating } from '../types';
 import { Timestamp } from 'firebase/firestore';
 
 /* ------------------------------------------------------------ */
@@ -45,17 +47,40 @@ function makeShow(patch: Partial<Show> = {}): Show {
   };
 }
 
-function makeRating(composite: number) {
+function makeRating(composite: number): MemberRating {
   return {
     story: composite,
     characters: composite,
     vibes: composite,
-    wouldRewatch: null as null,
-    ratedAt: null as null,
+    wouldRewatch: null,
+    brainPower: null,
+    ratedAt: null,
   };
 }
 
 const VALID_TAGS = new Set<string>(VIBE_CATEGORIES);
+
+/* ------------------------------------------------------------ */
+/* memberComposite ignores brainPower                           */
+/* ------------------------------------------------------------ */
+
+describe('memberComposite', () => {
+  it('ignores brainPower when computing composite score', () => {
+    const base: MemberRating = {
+      story: 8, characters: 8, vibes: 8, wouldRewatch: null, brainPower: 1, ratedAt: null,
+    };
+    const high: MemberRating = { ...base, brainPower: 5 };
+    expect(memberComposite(base)).toBe(memberComposite(high));
+    expect(memberComposite(base)).toBeCloseTo(8);
+  });
+
+  it('ignores null brainPower', () => {
+    const base: MemberRating = {
+      story: 7, characters: 9, vibes: 8, wouldRewatch: null, brainPower: null, ratedAt: null,
+    };
+    expect(memberComposite(base)).toBeCloseTo(8);
+  });
+});
 
 /* ------------------------------------------------------------ */
 /* inferFocusLevel                                              */
@@ -104,6 +129,46 @@ describe('inferFocusLevel', () => {
 
   it('returns normal for empty string', () => {
     expect(inferFocusLevel('')).toBe('normal');
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* inferViewerFocusLevel                                        */
+/* ------------------------------------------------------------ */
+
+describe('inferViewerFocusLevel', () => {
+  it('uses individual mood when provided and it is non-neutral', () => {
+    expect(inferViewerFocusLevel('tired', 'Alice')).toBe('low');
+  });
+
+  it('returns normal for empty individual mood with no sharedMood', () => {
+    expect(inferViewerFocusLevel('', 'Alice')).toBe('normal');
+  });
+
+  it('extracts focus from sharedMood when individual mood is empty and name matches', () => {
+    expect(inferViewerFocusLevel('', 'Jimi', 'Jimi is brain dead after work')).toBe('low');
+  });
+
+  it('does not apply another viewer\'s focus from sharedMood', () => {
+    // Only Jimi is brain dead; Kait's clause has no low-focus phrases
+    expect(
+      inferViewerFocusLevel('', 'Kait', 'Jimi is brain dead after work, Kait is up for anything'),
+    ).toBe('normal');
+  });
+
+  it('individual mood overrides sharedMood when individual mood is non-neutral', () => {
+    // Individual says high focus, shared says brain dead — individual wins
+    expect(inferViewerFocusLevel('ready to focus', 'Alice', 'Alice is brain dead')).toBe('high');
+  });
+
+  it('returns normal when name is not mentioned in sharedMood', () => {
+    expect(inferViewerFocusLevel('', 'Bob', 'Alice is tired tonight')).toBe('normal');
+  });
+
+  it('handles high focus from sharedMood name mention', () => {
+    expect(
+      inferViewerFocusLevel('', 'Kait', 'Jimi is tired. Kait is ready to focus.'),
+    ).toBe('high');
   });
 });
 
@@ -345,23 +410,23 @@ describe('scoreViewerRatingFit', () => {
 describe('computeCandidatePreScore', () => {
   it('returns correct showId and title', () => {
     const show = makeShow({ id: 'abc', title: 'My Show', brainPower: 1 });
-    const result = computeCandidatePreScore(show, 'low', [], []);
+    const result = computeCandidatePreScore(show, {}, [], []);
     expect(result.showId).toBe('abc');
     expect(result.title).toBe('My Show');
   });
 
-  it('brain-dead show with bp=1 and real funny tags gets high overall score for low focus', () => {
+  it('brain-dead show with bp=1 and real funny tags gets high overall score for low-focus viewer', () => {
     const show = makeShow({ id: 's1', brainPower: 1, vibeTags: ['Funny', 'Lighthearted'] });
     const kw = inferVibeKeywords('brain dead and wants something funny');
-    const result = computeCandidatePreScore(show, 'low', kw, []);
+    const result = computeCandidatePreScore(show, { u1: 'low' }, kw, ['u1']);
     expect(result.brainPowerMatch).toBe(10);
     expect(result.overallPreScore).toBeGreaterThan(7);
   });
 
-  it('dense show (bp=5) gets low overall score for low focus', () => {
+  it('dense show (bp=5) gets low overall score for low-focus viewer', () => {
     const show = makeShow({ id: 's1', brainPower: 5, vibeTags: ['Emotional', 'Thoughtful'] });
     const kw = inferVibeKeywords('brain dead wants something funny');
-    const result = computeCandidatePreScore(show, 'low', kw, []);
+    const result = computeCandidatePreScore(show, { u1: 'low' }, kw, ['u1']);
     expect(result.brainPowerMatch).toBe(0);
     expect(result.overallPreScore).toBeLessThan(5);
   });
@@ -369,15 +434,99 @@ describe('computeCandidatePreScore', () => {
   it('overall score accounts for viewer ratings', () => {
     const showHigh = makeShow({ id: 's1', brainPower: 1, ratings: { u1: makeRating(9) } });
     const showLow = makeShow({ id: 's2', brainPower: 1, ratings: { u1: makeRating(2) } });
-    const scoreHigh = computeCandidatePreScore(showHigh, 'low', [], ['u1']).overallPreScore;
-    const scoreLow = computeCandidatePreScore(showLow, 'low', [], ['u1']).overallPreScore;
+    const scoreHigh = computeCandidatePreScore(showHigh, { u1: 'low' }, [], ['u1']).overallPreScore;
+    const scoreLow = computeCandidatePreScore(showLow, { u1: 'low' }, [], ['u1']).overallPreScore;
     expect(scoreHigh).toBeGreaterThan(scoreLow);
   });
 
   it('overallPreScore is between 0 and 10', () => {
     const show = makeShow({ id: 's1', brainPower: 3, vibeTags: ['Chill'] });
-    const result = computeCandidatePreScore(show, 'normal', ['Chill'], ['u1']);
+    const result = computeCandidatePreScore(show, { u1: 'normal' }, ['Chill'], ['u1']);
     expect(result.overallPreScore).toBeGreaterThanOrEqual(0);
     expect(result.overallPreScore).toBeLessThanOrEqual(10);
+  });
+
+  it('uses per-person brainPower from rating when available, ignoring show-level', () => {
+    // Viewer has their own brain estimate of 2 (easy), but show-level says 5 (dense)
+    const show = makeShow({
+      id: 's1',
+      brainPower: 5,
+      ratings: { u1: { ...makeRating(7), brainPower: 2 } },
+    });
+    // Low-focus viewer with their own bp=2 → should score well
+    const result = computeCandidatePreScore(show, { u1: 'low' }, [], ['u1']);
+    expect(result.brainPowerMatch).toBe(10); // scoreBrainPower(2, 'low') = 10
+  });
+
+  it('falls back to show-level brainPower when viewer has not set their own', () => {
+    // No per-person rating, show-level bp=1
+    const show = makeShow({ id: 's1', brainPower: 1 });
+    const result = computeCandidatePreScore(show, { u1: 'low' }, [], ['u1']);
+    expect(result.brainPowerMatch).toBe(10); // scoreBrainPower(1, 'low') = 10
+  });
+
+  it('returns neutral (5) for no-viewer scenario when show brainPower is null', () => {
+    const show = makeShow({ id: 's1', brainPower: null });
+    const result = computeCandidatePreScore(show, {}, [], []);
+    expect(result.brainPowerMatch).toBe(5);
+  });
+});
+
+/* ------------------------------------------------------------ */
+/* Per-viewer brainpower scenarios                              */
+/* ------------------------------------------------------------ */
+
+describe('per-viewer brainpower scoring scenarios', () => {
+  it('Jimi low-focus brain:2, Kait normal brain:5 → reasonable brainpower fit', () => {
+    // Jimi thinks the show is easy (bp=2), Kait thinks it is dense (bp=5)
+    // Jimi is tired, Kait is fine. Jimi's estimate should dominate his share.
+    const show = makeShow({
+      id: 's1',
+      ratings: {
+        jimi: { ...makeRating(7), brainPower: 2 },
+        kait: { ...makeRating(8), brainPower: 5 },
+      },
+    });
+    // jimi (low, bp=2) → 10; kait (normal, bp=5) → 4; avg = 7
+    const result = computeCandidatePreScore(show, { jimi: 'low', kait: 'normal' }, [], ['jimi', 'kait']);
+    expect(result.brainPowerMatch).toBeGreaterThan(5);
+  });
+
+  it('Jimi low-focus brain:5, Kait normal brain:1 → poor brainpower fit', () => {
+    // Jimi is tired and thinks the show is dense — bad for Jimi
+    // Kait thinks it is easy, but Kait is not the constraint tonight
+    const show = makeShow({
+      id: 's1',
+      ratings: {
+        jimi: { ...makeRating(7), brainPower: 5 },
+        kait: { ...makeRating(8), brainPower: 1 },
+      },
+    });
+    // jimi (low, bp=5) → 0; kait (normal, bp=1) → 6; avg = 3
+    const result = computeCandidatePreScore(show, { jimi: 'low', kait: 'normal' }, [], ['jimi', 'kait']);
+    expect(result.brainPowerMatch).toBeLessThan(5);
+  });
+
+  it('both viewers low-focus with bp=1 → excellent brainpower fit', () => {
+    const show = makeShow({
+      id: 's1',
+      ratings: {
+        u1: { ...makeRating(8), brainPower: 1 },
+        u2: { ...makeRating(7), brainPower: 2 },
+      },
+    });
+    // u1 (low, bp=1) → 10; u2 (low, bp=2) → 10; avg = 10
+    const result = computeCandidatePreScore(show, { u1: 'low', u2: 'low' }, [], ['u1', 'u2']);
+    expect(result.brainPowerMatch).toBe(10);
+  });
+
+  it('Kait\'s low-focus does not penalize because she rated it easy', () => {
+    // Kait is tired, but she rated the show as easy (bp=1) — should still score well
+    const show = makeShow({
+      id: 's1',
+      ratings: { kait: { ...makeRating(8), brainPower: 1 } },
+    });
+    const result = computeCandidatePreScore(show, { kait: 'low' }, [], ['kait']);
+    expect(result.brainPowerMatch).toBe(10);
   });
 });

--- a/app/tools/shows/__tests__/recommendationContext.test.ts
+++ b/app/tools/shows/__tests__/recommendationContext.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildViewerProfiles, candidateShows } from '../lib/recommendationContext';
 import { buildPrompt } from '../lib/buildRecommendPrompt';
-import type { Show, ShowList } from '../types';
+import type { Show, ShowList, MemberRating } from '../types';
 import type { MoodEntry, ViewerPreferenceProfile } from '../lib/recommendationContext';
 import { Timestamp } from 'firebase/firestore';
 
@@ -43,13 +43,14 @@ function makeMember(uid: string, displayName: string): ShowList['members'][numbe
   return { uid, email: `${uid}@test.com`, displayName, role: 'member', joinedAt: ts() };
 }
 
-function makeRating(composite: number) {
+function makeRating(composite: number): MemberRating {
   return {
     story: composite,
     characters: composite,
     vibes: composite,
-    wouldRewatch: null as null,
-    ratedAt: null as null,
+    wouldRewatch: null,
+    brainPower: null,
+    ratedAt: null,
   };
 }
 
@@ -157,16 +158,47 @@ describe('buildViewerProfiles', () => {
     expect(profiles.u2.name).toBe('Bob');
   });
 
-  it('includes brainPower and wouldRewatch in rated entries', () => {
+  it('includes wouldRewatch in rated entries', () => {
     const member = makeMember('u1', 'Alice');
     const show = makeShow({
       id: 's1',
-      ratings: { u1: { story: 8, characters: 8, vibes: 8, wouldRewatch: 'yes', ratedAt: null } },
+      ratings: { u1: { story: 8, characters: 8, vibes: 8, wouldRewatch: 'yes', brainPower: null, ratedAt: null } },
+    });
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.stronglyLiked[0].wouldRewatch).toBe('yes');
+  });
+
+  it('uses per-person brainPower from rating (not legacy show.brainPower)', () => {
+    const member = makeMember('u1', 'Alice');
+    const show = makeShow({
+      id: 's1',
+      ratings: { u1: { story: 8, characters: 8, vibes: 8, wouldRewatch: null, brainPower: 3, ratedAt: null } },
+      brainPower: 5, // legacy fallback — should NOT be used when per-person is set
+    });
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.stronglyLiked[0].brainPower).toBe(3);
+  });
+
+  it('falls back to legacy show.brainPower when per-person brainPower is null', () => {
+    const member = makeMember('u1', 'Alice');
+    const show = makeShow({
+      id: 's1',
+      ratings: { u1: { story: 8, characters: 8, vibes: 8, wouldRewatch: null, brainPower: null, ratedAt: null } },
       brainPower: 2,
     });
     const profiles = buildViewerProfiles([show], [member]);
     expect(profiles.u1.stronglyLiked[0].brainPower).toBe(2);
-    expect(profiles.u1.stronglyLiked[0].wouldRewatch).toBe('yes');
+  });
+
+  it('brainPower in rated entry is null when neither per-person nor legacy is set', () => {
+    const member = makeMember('u1', 'Alice');
+    const show = makeShow({
+      id: 's1',
+      ratings: { u1: makeRating(9) },
+      brainPower: null,
+    });
+    const profiles = buildViewerProfiles([show], [member]);
+    expect(profiles.u1.stronglyLiked[0].brainPower).toBeNull();
   });
 });
 
@@ -343,11 +375,19 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('multitasking');
   });
 
+  it('decision rules instruct per-viewer brain power evaluation', () => {
+    const candidates = [makeShow({ status: 'watching' })];
+    const moods = { u1: makeMood('Alice') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('per viewer');
+  });
+
   it('includes all rating bands in viewer profiles, not only high scores', () => {
     const member = makeMember('u1', 'Alice');
     const highShow = makeShow({ id: 's1', ratings: { u1: makeRating(9) }, vibeTags: ['Epic'] });
     const midShow = makeShow({ id: 's2', title: 'Mid Show', ratings: { u1: makeRating(6.5) }, vibeTags: ['Chill'] });
-    const lowShow = makeShow({ id: 's3', title: 'Low Show', ratings: { u1: makeRating(3) }, vibeTags: ['Drama'] });
+    const lowShow = makeShow({ id: 's3', title: 'Low Show', ratings: { u1: makeRating(3) }, vibeTags: ['Dark'] });
     const profiles = buildViewerProfiles([highShow, midShow, lowShow], [member]);
     const moods = { u1: makeMood('Alice', 'tired') };
     const prompt = buildPrompt(moods, [], profiles);
@@ -384,7 +424,7 @@ describe('buildPrompt', () => {
     const candidates = [makeShow({
       id: 'c1',
       status: 'watching',
-      ratings: { [uid]: { story: 6, characters: 8, vibes: 9, wouldRewatch: null, ratedAt: null } },
+      ratings: { [uid]: { story: 6, characters: 8, vibes: 9, wouldRewatch: null, brainPower: null, ratedAt: null } },
     })];
     const moods = { [uid]: makeMood('Alice', 'chill') };
     const profiles = { [uid]: makeProfile('Alice') };
@@ -394,12 +434,54 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('vibes:9');
   });
 
+  it('includes per-viewer brainPower in candidate viewer signal', () => {
+    const uid = 'u1';
+    const candidates = [makeShow({
+      id: 'c1',
+      status: 'watching',
+      ratings: { [uid]: { story: 8, characters: 8, vibes: 8, wouldRewatch: null, brainPower: 2, ratedAt: null } },
+    })];
+    const moods = { [uid]: makeMood('Alice', 'tired') };
+    const profiles = { [uid]: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('brain:2/5');
+  });
+
+  it('falls back to legacy show.brainPower in viewer signal when per-person brainPower is null', () => {
+    const candidates = [makeShow({ status: 'watching', brainPower: 1 })];
+    const moods = { u1: makeMood('Alice') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    // Legacy brainPower=1 appears in viewer signal (unrated viewer with legacy fallback)
+    expect(prompt).toContain('brain:1/5');
+  });
+
+  it('no brain in viewer signal when both per-person and legacy brainPower are null', () => {
+    const candidates = [makeShow({ status: 'watching', brainPower: null })];
+    const moods = { u1: makeMood('Alice') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    // Old global format must be gone
+    expect(prompt).not.toContain('brain: unknown');
+    // No brain:N/5 should appear in any viewer signal (the digit distinguishes from rules text)
+    expect(prompt).not.toMatch(/Alice:.*brain:\d/);
+  });
+
+  it('does not show a global brain power header line in the candidate section', () => {
+    const candidates = [makeShow({ status: 'watching', brainPower: 3 })];
+    const moods = { u1: makeMood('Alice') };
+    const profiles = { u1: makeProfile('Alice') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    // Old format "brain: X/5 (label)" should be gone from the candidate header
+    expect(prompt).not.toContain('| brain: 3/5');
+  });
+
   it('includes wouldRewatch in candidate per-viewer section', () => {
     const uid = 'u1';
     const candidates = [makeShow({
       id: 'c1',
       status: 'watching',
-      ratings: { [uid]: { story: 8, characters: 8, vibes: 8, wouldRewatch: 'yes', ratedAt: null } },
+      ratings: { [uid]: { story: 8, characters: 8, vibes: 8, wouldRewatch: 'yes', brainPower: null, ratedAt: null } },
     })];
     const moods = { [uid]: makeMood('Alice', 'chill') };
     const profiles = { [uid]: makeProfile('Alice') };
@@ -432,23 +514,6 @@ describe('buildPrompt', () => {
     const profiles = { u1: makeProfile('Alice') };
     const prompt = buildPrompt(moods, candidates, profiles);
     expect(prompt).toContain('[absentUid]');
-  });
-
-  it('includes brain power in candidate section when set', () => {
-    const candidates = [makeShow({ status: 'watching', brainPower: 1 })];
-    const moods = { u1: makeMood('Alice') };
-    const profiles = { u1: makeProfile('Alice') };
-    const prompt = buildPrompt(moods, candidates, profiles);
-    expect(prompt).toContain('1/5');
-    expect(prompt).toContain('braindead');
-  });
-
-  it('shows unknown brain power when null', () => {
-    const candidates = [makeShow({ status: 'watching', brainPower: null })];
-    const moods = { u1: makeMood('Alice') };
-    const profiles = { u1: makeProfile('Alice') };
-    const prompt = buildPrompt(moods, candidates, profiles);
-    expect(prompt).toContain('brain: unknown');
   });
 
   it('includes service when present', () => {
@@ -487,11 +552,28 @@ describe('buildPrompt', () => {
   });
 
   it('includes pre-score for each candidate', () => {
-    const candidates = [makeShow({ id: 'c1', status: 'watching', brainPower: 1, vibeTags: ['Comedy'] })];
+    const candidates = [makeShow({ id: 'c1', status: 'watching', brainPower: 1, vibeTags: ['Funny', 'Lighthearted'] })];
     const moods = { u1: makeMood('Alice', 'brain dead and want something funny') };
     const profiles = { u1: makeProfile('Alice') };
     const prompt = buildPrompt(moods, candidates, profiles);
     expect(prompt).toContain('preScore:');
     expect(prompt).toContain('overall=');
+  });
+
+  it('per-viewer brainPower differs between viewers in the same candidate line', () => {
+    // Jimi thinks the show is easy (bp=2), Kait thinks it is dense (bp=4)
+    const candidates = [makeShow({
+      id: 'c1',
+      status: 'watching',
+      ratings: {
+        jimi: { story: 8, characters: 8, vibes: 8, wouldRewatch: null, brainPower: 2, ratedAt: null },
+        kait: { story: 7, characters: 7, vibes: 7, wouldRewatch: null, brainPower: 4, ratedAt: null },
+      },
+    })];
+    const moods = { jimi: makeMood('Jimi', 'brain dead'), kait: makeMood('Kait', 'up for anything') };
+    const profiles = { jimi: makeProfile('Jimi'), kait: makeProfile('Kait') };
+    const prompt = buildPrompt(moods, candidates, profiles);
+    expect(prompt).toContain('brain:2/5');
+    expect(prompt).toContain('brain:4/5');
   });
 });

--- a/app/tools/shows/components/ScoreBlock.tsx
+++ b/app/tools/shows/components/ScoreBlock.tsx
@@ -16,6 +16,14 @@ const REWATCH_OPTIONS: { value: WouldRewatch; label: string }[] = [
   { value: 'no',    label: 'No' },
 ];
 
+const BRAIN_POWER_LABELS: Record<number, string> = {
+  1: 'Braindead / background-friendly',
+  2: 'Easy watch',
+  3: 'Normal focus',
+  4: 'Pay attention',
+  5: 'Dense / thought-provoking',
+};
+
 function Slider({
   label,
   value,
@@ -50,6 +58,8 @@ function Slider({
 
 export default function ScoreBlock({ memberName, rating, editable, onChange }: Props) {
   const composite = memberComposite(rating);
+  // Normalize undefined (from legacy Firestore docs) to null
+  const brainPower = rating.brainPower ?? null;
 
   return (
     <div className="rounded-xl border border-border bg-surface-1 p-4 space-y-3">
@@ -98,6 +108,56 @@ export default function ScoreBlock({ memberName, rating, editable, onChange }: P
             </button>
           ))}
         </div>
+      </div>
+
+      {/* Brain power — visually separated; context only, never affects the numeric score */}
+      <div className="pt-3 mt-1 border-t border-border/50">
+        <div className="flex items-baseline gap-2 mb-2">
+          <p className="text-xs font-medium text-text-2">Brain power required</p>
+          <span className="text-xs text-text-3 italic">context only · does not affect score</span>
+        </div>
+
+        {brainPower !== null ? (
+          <>
+            <div className="flex justify-between text-xs mb-1">
+              <span className="text-text-3">{BRAIN_POWER_LABELS[brainPower]}</span>
+              <span className="font-medium text-text-2">{brainPower}/5</span>
+            </div>
+            <input
+              type="range"
+              min={1}
+              max={5}
+              step={1}
+              value={brainPower}
+              disabled={!editable}
+              onChange={(e) => onChange?.({ brainPower: Number(e.target.value) })}
+              className="w-full h-2 accent-[hsl(var(--color-accent))] disabled:opacity-40 cursor-pointer disabled:cursor-default"
+            />
+            <div className="flex justify-between text-xs text-text-3 px-0.5 mt-1">
+              <span>Braindead</span>
+              <span>Dense</span>
+            </div>
+            {editable && (
+              <button
+                type="button"
+                onClick={() => onChange?.({ brainPower: null })}
+                className="text-xs text-text-3 underline mt-1"
+              >
+                Clear
+              </button>
+            )}
+          </>
+        ) : editable ? (
+          <button
+            type="button"
+            onClick={() => onChange?.({ brainPower: 3 })}
+            className="text-xs text-text-3 underline"
+          >
+            Set brain power
+          </button>
+        ) : (
+          <p className="text-xs text-text-3">Not set</p>
+        )}
       </div>
     </div>
   );

--- a/app/tools/shows/components/ShowForm.tsx
+++ b/app/tools/shows/components/ShowForm.tsx
@@ -38,14 +38,6 @@ const STATUS_LABELS: Record<ShowStatus, string> = {
   planned:   'Planned',
 };
 
-const BRAIN_POWER_LABELS: Record<number, string> = {
-  1: 'Braindead / background-friendly',
-  2: 'Easy watch',
-  3: 'Normal focus',
-  4: 'Pay attention',
-  5: 'Dense / thought-provoking',
-};
-
 function hasEpisodes(type: ShowType) {
   return type === 'anime' || type === 'tv' || type === 'cartoon';
 }
@@ -85,7 +77,6 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
   const [customService, setCustomService] = useState(
     show?.service && !SERVICES.includes(show.service) ? show.service : '',
   );
-  const [brainPower, setBrainPower] = useState<number | null>(show?.brainPower ?? null);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const watchersInitialized = useRef(isEdit);
@@ -118,8 +109,14 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
   const [disambigMessage, setDisambigMessage] = useState('');
   const [resolvingOption, setResolvingOption] = useState<string | null>(null); // sourceId being resolved
 
-  const myRating = show?.ratings[user?.uid ?? ''] ?? {
-    story: null, characters: null, vibes: null, wouldRewatch: null, ratedAt: null,
+  const existingRating = show?.ratings[user?.uid ?? ''];
+  const myRating = {
+    story: existingRating?.story ?? null,
+    characters: existingRating?.characters ?? null,
+    vibes: existingRating?.vibes ?? null,
+    wouldRewatch: existingRating?.wouldRewatch ?? null,
+    brainPower: existingRating?.brainPower ?? null,
+    ratedAt: existingRating?.ratedAt ?? null,
   };
   const [pendingRating, setPendingRating] = useState(myRating);
 
@@ -293,7 +290,6 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
         description,
         notes: show?.notes ?? '',
         memberNotes,
-        brainPower,
         vibeTags,
         ratings: show?.ratings ?? {},
       };
@@ -547,50 +543,6 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
                 />
               ))}
             </div>
-          </div>
-
-          {/* Brain power */}
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between">
-              <label className="text-sm font-medium text-text-2">Brain power required</label>
-              {brainPower !== null && (
-                <span className="text-xs text-text-3">
-                  {brainPower}/5 — {BRAIN_POWER_LABELS[brainPower]}
-                </span>
-              )}
-            </div>
-            {brainPower === null ? (
-              <button
-                type="button"
-                onClick={() => setBrainPower(3)}
-                className="text-xs text-text-3 underline"
-              >
-                Set brain power
-              </button>
-            ) : (
-              <>
-                <input
-                  type="range"
-                  min={1}
-                  max={5}
-                  step={1}
-                  value={brainPower}
-                  onChange={(e) => setBrainPower(Number(e.target.value))}
-                  className="w-full h-2 accent-[hsl(var(--color-accent))] cursor-pointer"
-                />
-                <div className="flex justify-between text-xs text-text-3 px-0.5">
-                  <span>Braindead</span>
-                  <span>Dense</span>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setBrainPower(null)}
-                  className="text-xs text-text-3 underline"
-                >
-                  Clear
-                </button>
-              </>
-            )}
           </div>
 
           {/* Description */}

--- a/app/tools/shows/components/ShowForm.tsx
+++ b/app/tools/shows/components/ShowForm.tsx
@@ -38,6 +38,14 @@ const STATUS_LABELS: Record<ShowStatus, string> = {
   planned:   'Planned',
 };
 
+const BRAIN_POWER_LABELS: Record<number, string> = {
+  1: 'Braindead / background-friendly',
+  2: 'Easy watch',
+  3: 'Normal focus',
+  4: 'Pay attention',
+  5: 'Dense / thought-provoking',
+};
+
 function hasEpisodes(type: ShowType) {
   return type === 'anime' || type === 'tv' || type === 'cartoon';
 }
@@ -297,7 +305,10 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
         await updateShow(show.id, payload);
         if (user) await updateMyRating(show.id, pendingRating);
       } else {
-        await addShow(payload);
+        const newShowId = await addShow(payload);
+        if (user && pendingRating.brainPower !== null) {
+          await updateMyRating(newShowId, { brainPower: pendingRating.brainPower });
+        }
       }
       onClose();
     } catch (err) {
@@ -635,10 +646,56 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
                 .filter((m) => m.uid !== user.uid && show!.ratings[m.uid])
                 .map((m) => {
                   const r = show!.ratings[m.uid] ?? {
-                    story: null, characters: null, vibes: null, wouldRewatch: null, ratedAt: null,
+                    story: null, characters: null, vibes: null, wouldRewatch: null, brainPower: null, ratedAt: null,
                   };
                   return <ScoreBlock key={m.uid} memberName={m.displayName} rating={r} editable={false} />;
                 })}
+            </div>
+          )}
+
+          {/* Brain power — add mode only (edit mode shows it inside each ScoreBlock) */}
+          {!isEdit && user && (
+            <div className="rounded-xl border border-border bg-surface-1 p-4 space-y-3">
+              <div className="flex items-baseline gap-2">
+                <p className="text-sm font-medium text-text-2">Brain power required</p>
+                <span className="text-xs text-text-3 italic">context only · does not affect score</span>
+              </div>
+              {pendingRating.brainPower !== null ? (
+                <>
+                  <div className="flex justify-between text-xs mb-1">
+                    <span className="text-text-3">{BRAIN_POWER_LABELS[pendingRating.brainPower]}</span>
+                    <span className="font-medium text-text-2">{pendingRating.brainPower}/5</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={1}
+                    max={5}
+                    step={1}
+                    value={pendingRating.brainPower}
+                    onChange={(e) => setPendingRating((prev) => ({ ...prev, brainPower: Number(e.target.value) }))}
+                    className="w-full h-2 accent-[hsl(var(--color-accent))] cursor-pointer"
+                  />
+                  <div className="flex justify-between text-xs text-text-3 px-0.5 mt-1">
+                    <span>Braindead</span>
+                    <span>Dense</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setPendingRating((prev) => ({ ...prev, brainPower: null }))}
+                    className="text-xs text-text-3 underline mt-1"
+                  >
+                    Clear
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setPendingRating((prev) => ({ ...prev, brainPower: 3 }))}
+                  className="text-xs text-text-3 underline"
+                >
+                  Set brain power
+                </button>
+              )}
             </div>
           )}
 

--- a/app/tools/shows/lib/buildRecommendPrompt.ts
+++ b/app/tools/shows/lib/buildRecommendPrompt.ts
@@ -1,15 +1,7 @@
 import type { Show } from '../types';
 import type { MoodEntry, ViewerPreferenceProfile, RatedShowEntry } from './recommendationContext';
 import { memberComposite } from './compositeScore';
-import { inferFocusLevel, inferVibeKeywords, computeCandidatePreScore } from './preScore';
-
-const BRAIN_POWER_LABELS: Record<number, string> = {
-  1: 'braindead/background',
-  2: 'easy watch',
-  3: 'normal focus',
-  4: 'pay attention',
-  5: 'dense/thought-provoking',
-};
+import { inferViewerFocusLevel, inferVibeKeywords, computeCandidatePreScore } from './preScore';
 
 function formatRatedEntry(e: RatedShowEntry): string {
   const parts = [`"${e.title}"`, `score:${e.composite.toFixed(1)}`];
@@ -35,9 +27,14 @@ export function buildPrompt(
     uidToName[uid] = entry.name;
   }
 
-  // Infer combined focus level and vibe preferences from all mood text
+  // Per-viewer focus levels — each viewer's tiredness only applies to their own brain power estimate
+  const viewerFocusLevels: Record<string, 'low' | 'normal' | 'high'> = {};
+  for (const [uid, entry] of Object.entries(moods)) {
+    viewerFocusLevels[uid] = inferViewerFocusLevel(entry.mood, entry.name, sharedMood);
+  }
+
+  // Vibe keywords from combined mood text (shared across viewers for vibe matching)
   const allMoodText = [sharedMood ?? '', ...Object.values(moods).map((m) => m.mood)].join(' ');
-  const focusLevel = inferFocusLevel(allMoodText);
   const vibeKeywords = inferVibeKeywords(allMoodText);
 
   // --- SHARED VIBE (highest priority) ---
@@ -104,29 +101,33 @@ export function buildPrompt(
           ? ` S${s.currentSeason ?? '?'}E${s.currentEpisode ?? '?'}`
           : '';
       const vibes = s.vibeTags.length > 0 ? s.vibeTags.join(', ') : 'none';
-      const bp =
-        s.brainPower != null
-          ? `${s.brainPower}/5 (${BRAIN_POWER_LABELS[s.brainPower] ?? ''})`
-          : 'unknown';
 
-      const preScore = computeCandidatePreScore(s, focusLevel, vibeKeywords, presentUids);
+      const preScore = computeCandidatePreScore(s, viewerFocusLevels, vibeKeywords, presentUids);
       const preScoreStr = `preScore: brain=${preScore.brainPowerMatch.toFixed(0)} vibe=${preScore.vibeFit.toFixed(0)} overall=${preScore.overallPreScore.toFixed(1)}`;
 
-      // Per-viewer rating signals
+      // Per-viewer rating signals — brain power is shown per viewer, not as a global value
       const viewerSignals = presentUids
         .map((uid) => {
           const rating = s.ratings[uid];
           const name = uidToName[uid] ?? uid;
           const note = s.memberNotes?.[uid] ?? s.notes ?? '';
+          // Prefer per-person brain power; fall back to legacy show.brainPower
+          const viewerBp = rating?.brainPower ?? s.brainPower ?? null;
+
           if (!rating) {
-            return note.trim() ? `${name}: unrated note:"${note}"` : `${name}: unrated`;
+            const parts = [`${name}: unrated`];
+            if (viewerBp != null) parts.push(`brain:${viewerBp}/5`);
+            if (note.trim()) parts.push(`note:"${note}"`);
+            return parts.join(' ');
           }
+
           const composite = memberComposite(rating);
           const scorePart = composite !== null ? `${composite.toFixed(1)}/10` : 'partial';
           const parts = [`${name}: ${scorePart}`];
           if (rating.story != null) parts.push(`story:${rating.story}`);
           if (rating.characters != null) parts.push(`chars:${rating.characters}`);
           if (rating.vibes != null) parts.push(`vibes:${rating.vibes}`);
+          if (viewerBp != null) parts.push(`brain:${viewerBp}/5`);
           if (rating.wouldRewatch) parts.push(`wr:${rating.wouldRewatch}`);
           if (note.trim()) parts.push(`note:"${note}"`);
           return parts.join(' ');
@@ -141,7 +142,7 @@ export function buildPrompt(
         .join(' / ');
 
       const lines = [
-        `  - id:${s.id} | "${s.title}" (${s.type}) | vibes: ${vibes} | brain: ${bp} | status: ${s.status}${ep}`,
+        `  - id:${s.id} | "${s.title}" (${s.type}) | vibes: ${vibes} | status: ${s.status}${ep}`,
         `    viewers: ${viewerSignals}`,
         `    ${preScoreStr}`,
       ];
@@ -157,11 +158,14 @@ export function buildPrompt(
   const rules =
     `DECISION RULES (apply in this order):\n` +
     `1. PARSE TONIGHT'S VIBE FIRST: From the shared vibe text, identify each named person's energy and mood. ` +
-    `"brain dead", "tired", "drained", "multitasking", "background", "low focus", "low energy" → strong LOW brain-power signal. ` +
+    `"brain dead", "tired", "drained", "multitasking", "background", "low focus", "low energy" → strong LOW brain-power signal for that person. ` +
     `"funny", "exciting", "chill", "romantic", etc. → vibe preferences. ` +
     `When two viewers want different things, pick the best compromise.\n` +
-    `2. BRAIN POWER FIT: When anyone is tired, brain dead, or multitasking → strongly prefer brain power 1–2. ` +
-    `A 6/10 show with brain power 1 beats a 9/10 show with brain power 5 when someone is exhausted. Unknown brain power is neutral.\n` +
+    `2. BRAIN POWER FIT (per viewer): Brain power is rated individually — each viewer line shows their own brain:X/5 estimate. ` +
+    `When a named viewer is tired, brain dead, or multitasking, use THAT viewer's own brain power value to judge fit. ` +
+    `Do NOT penalize a show just because another viewer rated it high brain power, unless that viewer is also low-focus. ` +
+    `Example: if Jimi is brain dead and rated a show brain:2/5, the show is a good fit for tonight even if Kait rated it brain:4/5. ` +
+    `A 6/10 show with brain:1–2 for the tired viewer beats a 9/10 show with brain:4–5 for that same viewer. Unknown brain power is neutral.\n` +
     `3. MOOD AND VIBE MATCH: Match show vibe tags to inferred mood. ` +
     `"funny/comedy" → Funny/Lighthearted. "exciting/adventure" → Action-Packed/Adventurous/Fast-Paced/Intense. "chill/cozy" → Chill/Cozy/Comfort Watch. Strong vibe overlap = strong positive signal.\n` +
     `4. USE ALL RATING BANDS AS TASTE EVIDENCE:\n` +

--- a/app/tools/shows/lib/preScore.ts
+++ b/app/tools/shows/lib/preScore.ts
@@ -122,7 +122,7 @@ export function inferViewerFocusLevel(
 
   if (sharedMood?.trim() && viewerName) {
     const name = viewerName.toLowerCase();
-    const clauses = sharedMood.split(/[.!?,;]+/);
+    const clauses = sharedMood.split(/[.!?,;]+|\s+(?:but|while|whereas)\s+/i);
     const relevant = clauses.filter((c) => c.toLowerCase().includes(name));
     if (relevant.length > 0) return inferFocusLevel(relevant.join(' '));
   }
@@ -225,7 +225,12 @@ function scoreBrainPowerForViewers(
     return scoreBrainPower(show.brainPower, 'normal');
   }
 
-  const scores = presentUids.map((uid) => {
+  // When any viewer is low-focus, only their estimates drive the brain-power score —
+  // a tired viewer's constraint should not be diluted by a normal-focus co-viewer.
+  const lowFocusUids = presentUids.filter((uid) => (viewerFocusLevels[uid] ?? 'normal') === 'low');
+  const scoringUids = lowFocusUids.length > 0 ? lowFocusUids : presentUids;
+
+  const scores = scoringUids.map((uid) => {
     const focus = viewerFocusLevels[uid] ?? 'normal';
     // Prefer the viewer's own per-person estimate; fall back to legacy show.brainPower
     const bp = show.ratings[uid]?.brainPower ?? show.brainPower ?? null;

--- a/app/tools/shows/lib/preScore.ts
+++ b/app/tools/shows/lib/preScore.ts
@@ -107,6 +107,30 @@ export function inferFocusLevel(text: string): 'low' | 'normal' | 'high' {
 }
 
 /**
+ * Infers focus level for a single viewer.
+ * Uses their individual mood text first. When that is neutral and sharedMood is provided,
+ * it looks for clauses in sharedMood that contain the viewer's name and infers focus from those.
+ * This prevents one viewer's low-focus state from being attributed to another viewer.
+ */
+export function inferViewerFocusLevel(
+  individualMood: string,
+  viewerName: string,
+  sharedMood?: string,
+): 'low' | 'normal' | 'high' {
+  const focus = inferFocusLevel(individualMood);
+  if (focus !== 'normal') return focus;
+
+  if (sharedMood?.trim() && viewerName) {
+    const name = viewerName.toLowerCase();
+    const clauses = sharedMood.split(/[.!?,;]+/);
+    const relevant = clauses.filter((c) => c.toLowerCase().includes(name));
+    if (relevant.length > 0) return inferFocusLevel(relevant.join(' '));
+  }
+
+  return 'normal';
+}
+
+/**
  * Infers desired vibe tags from free-form mood text.
  * All returned values are guaranteed to exist in VIBE_CATEGORIES.
  */
@@ -185,6 +209,32 @@ export function scoreViewerRatingFit(show: Show, presentUids: string[]): number 
   return Math.max(0, avg - 2);
 }
 
+/**
+ * Computes an aggregate brain power match score across all present viewers.
+ * Each viewer's focus level is compared against their own per-person brain power estimate
+ * (falling back to the legacy show-level brainPower when the viewer has not set their own).
+ * A tired viewer's constraint only applies to that viewer's estimate, not to other viewers'.
+ */
+function scoreBrainPowerForViewers(
+  show: Show,
+  viewerFocusLevels: Record<string, 'low' | 'normal' | 'high'>,
+  presentUids: string[],
+): number {
+  if (presentUids.length === 0) {
+    // No present viewers — fall back to legacy show-level value with neutral focus
+    return scoreBrainPower(show.brainPower, 'normal');
+  }
+
+  const scores = presentUids.map((uid) => {
+    const focus = viewerFocusLevels[uid] ?? 'normal';
+    // Prefer the viewer's own per-person estimate; fall back to legacy show.brainPower
+    const bp = show.ratings[uid]?.brainPower ?? show.brainPower ?? null;
+    return scoreBrainPower(bp, focus);
+  });
+
+  return scores.reduce((a, b) => a + b, 0) / scores.length;
+}
+
 export interface CandidatePreScore {
   showId: string;
   title: string;
@@ -196,15 +246,17 @@ export interface CandidatePreScore {
 
 /**
  * Computes a lightweight deterministic pre-score for a candidate show.
+ * Brain power is evaluated per viewer — a tired viewer's constraint applies only to their
+ * own brain power estimate for this show, not to other viewers'.
  * Brain power match weighted highest because it's the clearest "wrong night" signal.
  */
 export function computeCandidatePreScore(
   show: Show,
-  focusLevel: 'low' | 'normal' | 'high',
+  viewerFocusLevels: Record<string, 'low' | 'normal' | 'high'>,
   vibeKeywords: string[],
   presentUids: string[],
 ): CandidatePreScore {
-  const brainPowerMatch = scoreBrainPower(show.brainPower, focusLevel);
+  const brainPowerMatch = scoreBrainPowerForViewers(show, viewerFocusLevels, presentUids);
   const vibeFit = scoreVibeFit(show.vibeTags, vibeKeywords);
   const viewerRatingFit = scoreViewerRatingFit(show, presentUids);
 

--- a/app/tools/shows/lib/recommendationContext.ts
+++ b/app/tools/shows/lib/recommendationContext.ts
@@ -57,7 +57,8 @@ function toRatedEntry(show: Show, uid: string, composite: number): RatedShowEntr
     vibes: r?.vibes ?? null,
     wouldRewatch: r?.wouldRewatch ?? null,
     vibeTags: show.vibeTags,
-    brainPower: show.brainPower ?? null,
+    // Use the viewer's own per-person estimate; fall back to legacy show-level brainPower
+    brainPower: r?.brainPower ?? show.brainPower ?? null,
     note: show.memberNotes?.[uid] ?? show.notes ?? '',
     description: show.description ?? '',
   };

--- a/app/tools/shows/types.ts
+++ b/app/tools/shows/types.ts
@@ -31,6 +31,8 @@ export interface MemberRating {
   characters: number | null;
   vibes: number | null;
   wouldRewatch: WouldRewatch | null;
+  /** 1–5: how much focus this viewer thinks the show requires. Context only — never affects the score. */
+  brainPower: number | null;
   ratedAt: Timestamp | null;
 }
 


### PR DESCRIPTION
Brain power is moved from a global show field to each member's rating
section (ratings.{uid}.brainPower). Existing show.brainPower data
remains as a fallback so no historical data is lost or broken.

Key changes:
- types.ts: adds brainPower: number | null to MemberRating
- ScoreBlock: renders a 1–5 brain power slider per viewer, visually
  separated with a divider and "context only · does not affect score"
  label; editable for self, read-only for others
- ShowForm: removes global brain power slider; pendingRating now
  carries brainPower via ScoreBlock; show-level payload drops the field
- preScore.ts: adds inferViewerFocusLevel (per-viewer focus from
  individual + shared mood); computeCandidatePreScore now takes a
  viewerFocusLevels map and scores brain power per viewer — a tired
  viewer's constraint applies only to their own estimate
- recommendationContext.ts: toRatedEntry uses ratings[uid].brainPower
  with fallback to legacy show.brainPower
- buildRecommendPrompt.ts: builds per-viewer focus map; viewer signals
  include each person's own brain:X/5; removes global brain header;
  updates decision rules to explain per-viewer brain power logic
- Tests: 191 passing — new coverage for inferViewerFocusLevel,
  per-viewer scenarios (Jimi low-focus/brain:2 vs Kait normal/brain:5),
  memberComposite ignores brainPower, per-viewer brainPower fallback

https://claude.ai/code/session_01QBhHNDsDbxi9mV47RxWfEP