### PR TITLE
feat(calorie-tracker): upgrade energy analysis engine (multi-horizon TDEE, confidence, water noise, profile RMR)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "5.9.3",
-        "vitest": "^2.1.8"
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "5.9.3",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.9"
   }
 }

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -545,9 +545,10 @@ function renderEnergyDetail(results) {
     palSection = `
       <h4 class="font-semibold text-secondary mb-2 text-sm uppercase tracking-wide">Retrospective TDEE by Activity Level</h4>
       <div class="mb-3 p-3 surface-2 rounded-lg border text-xs text-muted space-y-1">
-        <p><strong>What this table is:</strong> A data-fitted model. The PAL multiplier for each training-bump category was chosen by minimising BMR volatility across your history. It reflects what your total expenditure appears to have been on days of each type.</p>
-        <p><strong>Prospective budgets are separate:</strong> Your daily calorie target uses a fixed flat bump (Rest +0, Light +100, Hard +280, HIIT +400 kcal), not these PAL multipliers. That is intentional.</p>
-        ${palInverted ? `<p class="text-warning"><strong>Why does Light show higher than Hard?</strong> Hard-training days often have higher sodium and carbs, which causes temporary water retention. That inflates the apparent scale weight on hard days, making the implied TDEE look smaller — so the grid search assigns a lower PAL. This is a water/glycogen signal, not a bug. Use the flat bumps in your daily plan.</p>` : ''}
+        <p><strong>What this table is:</strong> A retrospective data-fitted model. The PAL multiplier for each activity bucket was chosen by minimising BMR volatility across your history. It reflects what your total expenditure appears to have been on days of each type.</p>
+        <p><strong>Activity categories are a temporary compatibility layer.</strong> The four buckets (Rest / Light +100 / Hard +280 / HIIT +400 kcal) map to the legacy training-bump field. Once structured exercise sessions are fully implemented, these will be replaced by continuous per-session calorie estimates.</p>
+        <p><strong>Prospective budgets are separate:</strong> Your daily calorie target uses fixed flat bumps, not these PAL multipliers. That is intentional — the PALs are retrospective; the bumps are forward-looking planning values.</p>
+        ${palInverted ? `<p class="text-warning"><strong>Why does Light show higher than Hard?</strong> Hard-training days often have higher sodium and carbs, which causes temporary water retention. That inflates the apparent scale weight on hard days, making the implied TDEE look smaller — so the grid search assigns a lower PAL. This is a water/glycogen signal, not a model bug. Use the flat bumps in your daily plan.</p>` : ''}
       </div>
       <div class="overflow-x-auto mb-4">
         <table class="w-full border rounded-lg">

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -1,7 +1,7 @@
 /**
  * @file analysis/analysisUI.js
- * @description Renders the Analysis tab within the dashboard: weight chart,
- * KPIs, TDEE/BMR cards, imputation table, and plateau status.
+ * @description Renders the Analysis tab: weight chart, KPIs, TDEE/BMR cards,
+ * confidence, imputation table, and plateau status.
  */
 
 import { state } from '../state/store.js';
@@ -11,24 +11,21 @@ import { debugLog, showMessage } from '../utils/ui.js';
 import { CONFIG } from '../config.js';
 import { saveEstimatedEntry } from '../services/firebase.js';
 
-// Chart instance for the weight trend chart (separate from nutrition chart)
 let weightChartInstance = null;
 
 // ==========================================
 // MAIN ENTRY: render + wire
 // ==========================================
 
-/**
- * Render the full analysis section HTML and initialize its chart/events.
- * Call this from updateDashboard() in dashboard.js.
- * @returns {string} HTML string for the analysis section
- */
 export function renderAnalysisSection() {
-  // Run analysis pipeline (cached result stored in state for other consumers)
-  const results = runAnalysis(state.weightEntries, state.dailyEntries);
+  const results = runAnalysis(
+    state.weightEntries,
+    state.dailyEntries,
+    state.userProfile || null,
+    state.weightEntriesMulti || null,
+  );
   state.analysisResults = results;
 
-  // Pre-compute blank days once so both the table and event handler can use them.
   state._blankDaysForPopulation = results.error
     ? []
     : getBlankDaysForPopulation(results.rows, state.dailyEntries, state.baselineTargets);
@@ -37,28 +34,17 @@ export function renderAnalysisSection() {
     <div class="mb-8">
       <h2 class="text-responsive-2xl font-bold text-secondary mb-4">📈 Weight & Energy Analysis</h2>
 
-      <!-- CSV Upload -->
       ${renderUploadArea()}
 
       ${results.error
         ? renderNoDataMessage(results.error)
         : `
-          <!-- KPI Cards -->
           ${renderKPICards(results)}
-
-          <!-- Weight Trend Chart -->
+          ${renderConfidenceCard(results.confidence, results)}
           ${renderWeightChart()}
-
-          <!-- Plateau Status -->
           ${renderPlateauStatus(results.plateau)}
-
-          <!-- TDEE / BMR Detail -->
-          ${renderEnergyDetail(results.bmrModel)}
-
-          <!-- Imputation Table -->
+          ${renderEnergyDetail(results)}
           ${renderImputationTable(results.rows)}
-
-          <!-- Fill Blank Days -->
           ${renderBlankDaysSection(state._blankDaysForPopulation)}
         `
       }
@@ -66,12 +52,7 @@ export function renderAnalysisSection() {
   `;
 }
 
-/**
- * Initialize chart and wire events after the HTML has been inserted into the DOM.
- * Must be called after renderAnalysisSection()'s HTML is in the page.
- */
 export function initAnalysisEvents() {
-  // Wire CSV upload
   const uploadInput = document.getElementById('weight-csv-input');
   const uploadBtn   = document.getElementById('weight-upload-btn');
   const uploadArea  = document.getElementById('weight-upload-area');
@@ -80,7 +61,6 @@ export function initAnalysisEvents() {
   const barEl       = document.getElementById('weight-upload-bar');
   const progressTxt = document.getElementById('weight-upload-progress-text');
 
-  /** Update the inline status line and persist across re-renders. */
   function onStatus(msg, isErr = false) {
     state.lastWeightUploadStatus = { message: msg, isError: isErr };
     if (!statusEl) return;
@@ -88,7 +68,6 @@ export function initAnalysisEvents() {
     statusEl.className = `text-xs mt-2 ${isErr ? 'text-negative' : 'text-muted'}`;
   }
 
-  /** Update the progress bar */
   function onProgress(saved, total, bi, bt) {
     if (!progressEl || !barEl || !progressTxt) return;
     const pct = total > 0 ? Math.round((saved / total) * 100) : 0;
@@ -97,11 +76,10 @@ export function initAnalysisEvents() {
     progressTxt.textContent = `Batch ${bi}/${bt} — ${saved}/${total} entries (${pct}%)`;
   }
 
-  /** Shared handler used by both file picker and drag-and-drop */
   async function runUpload(file) {
     if (!file) return;
     if (uploadBtn) uploadBtn.disabled = true;
-    if (progressEl) { progressEl.classList.remove('hidden'); }
+    if (progressEl) progressEl.classList.remove('hidden');
     if (barEl) barEl.style.width = '0%';
     if (progressTxt) progressTxt.textContent = '';
 
@@ -109,14 +87,12 @@ export function initAnalysisEvents() {
 
     if (uploadBtn) uploadBtn.disabled = false;
     if (progressEl && result.saved > 0) {
-      // Show final bar at 100% briefly then hide
       if (barEl) barEl.style.width = '100%';
       setTimeout(() => { if (progressEl) progressEl.classList.add('hidden'); }, 3000);
     } else if (progressEl) {
       progressEl.classList.add('hidden');
     }
 
-    // Show diagnostics summary in status line when the batch save succeeded fully
     if (result.diagnostics && result.parsed > 0 && !result.partialFailure) {
       const d = result.diagnostics;
       const skipStr = d.skippedRows > 0
@@ -125,13 +101,9 @@ export function initAnalysisEvents() {
       const rangeStr = d.detectedDateRange.from
         ? ` | Range: ${d.detectedDateRange.from} → ${d.detectedDateRange.to}`
         : '';
-      onStatus(
-        `Saved ${result.saved}/${result.total} rows${skipStr}${rangeStr}`,
-        false,
-      );
+      onStatus(`Saved ${result.saved}/${result.total} rows${skipStr}${rangeStr}`, false);
     }
 
-    // Re-render dashboard to reflect new weight data
     const { updateDashboard } = await import('../ui/dashboard.js');
     updateDashboard();
   }
@@ -140,13 +112,11 @@ export function initAnalysisEvents() {
     uploadBtn.addEventListener('click', () => uploadInput.click());
     uploadInput.addEventListener('change', async (e) => {
       const file = e.target.files?.[0];
-      // Reset so the same file can be re-selected
       uploadInput.value = '';
       await runUpload(file);
     });
   }
 
-  // Drag and drop — same runUpload path
   if (uploadArea) {
     uploadArea.addEventListener('dragover', (e) => { e.preventDefault(); uploadArea.classList.add('drag-over'); });
     uploadArea.addEventListener('dragleave', () => uploadArea.classList.remove('drag-over'));
@@ -157,12 +127,10 @@ export function initAnalysisEvents() {
     });
   }
 
-  // Draw weight chart if data exists
   if (state.analysisResults && !state.analysisResults.error) {
     drawWeightChart(state.analysisResults.rows);
   }
 
-  // Wire timeframe selector
   const timeframeSelect = document.getElementById('weight-chart-timeframe');
   if (timeframeSelect) {
     timeframeSelect.addEventListener('change', () => {
@@ -172,11 +140,10 @@ export function initAnalysisEvents() {
     });
   }
 
-  // ── Blank-day population controls ──────────────────────────────────────────
+  // Blank-day population controls
   const blankDays = state._blankDaysForPopulation || [];
   if (blankDays.length === 0) return;
 
-  /** Refresh the fill-button label based on checked count. */
   function updateFillBtn() {
     const checked = document.querySelectorAll('.blank-day-check:checked').length;
     const btn = document.getElementById('blank-fill-btn');
@@ -185,35 +152,25 @@ export function initAnalysisEvents() {
     if (countEl) countEl.textContent = checked;
   }
 
-  // Checkbox: update button on every change
   document.getElementById('blank-days-tbody')?.addEventListener('change', e => {
     if (e.target.classList.contains('blank-day-check')) updateFillBtn();
   });
-
-  // Select-all header checkbox
   document.getElementById('blank-check-all')?.addEventListener('change', e => {
-    document.querySelectorAll('.blank-day-check')
-      .forEach(cb => { cb.checked = e.target.checked; });
+    document.querySelectorAll('.blank-day-check').forEach(cb => { cb.checked = e.target.checked; });
     updateFillBtn();
   });
-
-  // Select-all button
   document.getElementById('blank-select-all-btn')?.addEventListener('click', () => {
     document.querySelectorAll('.blank-day-check').forEach(cb => { cb.checked = true; });
     const allBox = document.getElementById('blank-check-all');
     if (allBox) allBox.checked = true;
     updateFillBtn();
   });
-
-  // Deselect-all button
   document.getElementById('blank-deselect-all-btn')?.addEventListener('click', () => {
     document.querySelectorAll('.blank-day-check').forEach(cb => { cb.checked = false; });
     const allBox = document.getElementById('blank-check-all');
     if (allBox) allBox.checked = false;
     updateFillBtn();
   });
-
-  // Select-range button
   document.getElementById('blank-select-range-btn')?.addEventListener('click', () => {
     const fromVal = document.getElementById('blank-range-from')?.value;
     const toVal   = document.getElementById('blank-range-to')?.value;
@@ -224,14 +181,12 @@ export function initAnalysisEvents() {
     updateFillBtn();
   });
 
-  // Fill selected days
   document.getElementById('blank-fill-btn')?.addEventListener('click', async () => {
     const selectedDates = Array.from(document.querySelectorAll('.blank-day-check:checked'))
       .map(cb => cb.dataset.date);
     if (selectedDates.length === 0) return;
 
     const blankMap = new Map(blankDays.map(d => [d.date, d]));
-
     const fillBtn = document.getElementById('blank-fill-btn');
     if (fillBtn) fillBtn.disabled = true;
     showMessage(`Filling ${selectedDates.length} blank day(s)…`, false, 30000);
@@ -249,8 +204,6 @@ export function initAnalysisEvents() {
     }
 
     showMessage(`Filled ${savedCount} blank day(s) with estimated values.`);
-
-    // Re-render dashboard (dynamic import avoids circular dependency)
     const { updateDashboard } = await import('../ui/dashboard.js');
     updateDashboard();
   });
@@ -262,9 +215,6 @@ export function initAnalysisEvents() {
 
 function renderUploadArea() {
   const hasData = state.weightEntries.size > 0;
-
-  // Use the persisted upload status if one exists (survives dashboard re-renders).
-  // Fall back to the default count/hint text when no upload has happened yet.
   const stored = state.lastWeightUploadStatus;
   const statusMsg = stored
     ? stored.message
@@ -311,10 +261,16 @@ function renderKPICards(results) {
     const color = s.totalWeightChange <= 0 ? 'text-positive' : 'text-warning';
     cards.push(kpiCard('Total Change', `${sign}${s.totalWeightChange} lb`, 'fa-arrow-trend-down', color));
   }
-  if (s.tdee != null) {
-    cards.push(kpiCard('Est. TDEE', `${s.tdee} kcal`, 'fa-fire', 'text-warning'));
+
+  // Prefer observed TDEE over model TDEE for the top KPI
+  const displayTdee = s.observedTdee ?? s.tdee;
+  if (displayTdee != null) {
+    cards.push(kpiCard('Observed TDEE', `${displayTdee} kcal`, 'fa-fire', 'text-warning'));
   }
-  if (s.bmr != null) {
+
+  if (s.restDayCaloriesOut != null) {
+    cards.push(kpiCard('Rest-Day Burn', `${s.restDayCaloriesOut} kcal`, 'fa-couch', 'text-accent'));
+  } else if (s.bmr != null) {
     cards.push(kpiCard('Est. BMR', `${s.bmr} kcal`, 'fa-heart-pulse', 'text-accent'));
   }
 
@@ -336,6 +292,58 @@ function kpiCard(label, value, icon, colorClass) {
     </div>
   `;
 }
+
+// ==========================================
+// CONFIDENCE CARD
+// ==========================================
+
+function renderConfidenceCard(confidence, results) {
+  if (!confidence) return '';
+
+  const { label, score, reasons } = confidence;
+
+  const configs = {
+    not_enough: { icon: 'fa-circle-question', color: 'text-muted',    bar: 'bg-muted',     title: 'Not enough data yet',          subtitle: 'Upload weight data and log food consistently to enable estimates.' },
+    rough:      { icon: 'fa-circle-exclamation', color: 'text-warning', bar: 'bg-warning',   title: 'Rough estimate',               subtitle: 'Early data. Treat numbers as ballpark figures, not precision targets.' },
+    moderate:   { icon: 'fa-circle-check', color: 'text-accent',       bar: 'bg-accent',     title: 'Moderate confidence',          subtitle: 'Reasonable estimates. Keep logging for better accuracy.' },
+    high:       { icon: 'fa-circle-check', color: 'text-positive',     bar: 'bg-positive',   title: 'High confidence',              subtitle: 'Strong data history. Estimates are likely within 5–10% of reality.' },
+  };
+  const cfg = configs[label] || configs.not_enough;
+
+  const reasonList = reasons.map(r => `<li class="text-xs text-muted">${r}</li>`).join('');
+
+  // Uncertainty footnote
+  let uncertaintyNote = '';
+  if (results.waterWeightUncertaintyLb != null) {
+    uncertaintyNote = `<p class="text-xs text-muted mt-2">Day-to-day water weight noise: ±${results.waterWeightUncertaintyLb} lb. This sets a floor on how precisely any single weigh-in can be interpreted.</p>`;
+  }
+
+  return `
+    <div class="mb-6 surface-2 rounded-lg border p-4">
+      <div class="flex items-center gap-3 mb-3">
+        <i class="fas ${cfg.icon} ${cfg.color} text-xl"></i>
+        <div>
+          <div class="font-semibold">${cfg.title}</div>
+          <div class="text-xs text-muted">${cfg.subtitle}</div>
+        </div>
+        <div class="ml-auto text-right">
+          <div class="text-xs text-muted mb-1">${score}%</div>
+          <div class="w-24 h-2 rounded-full surface-1 overflow-hidden">
+            <div class="${cfg.bar} h-full rounded-full transition-all" style="width:${score}%;"></div>
+          </div>
+        </div>
+      </div>
+      <ul class="space-y-1 pl-1">
+        ${reasonList}
+      </ul>
+      ${uncertaintyNote}
+    </div>
+  `;
+}
+
+// ==========================================
+// WEIGHT CHART
+// ==========================================
 
 function renderWeightChart() {
   return `
@@ -373,89 +381,206 @@ function renderPlateauStatus(plateau) {
   `;
 }
 
-function renderEnergyDetail(bmrModel) {
-  if (!bmrModel || bmrModel.error) {
-    return `
-      <div class="mb-6 p-4 surface-2 rounded-lg border">
-        <div class="text-sm text-muted">
-          <i class="fas fa-info-circle mr-2"></i>${bmrModel?.error || 'Energy estimates not yet available.'}
-        </div>
-      </div>
-    `;
+// ==========================================
+// ENERGY DETAIL CARD
+// ==========================================
+
+function renderEnergyDetail(results) {
+  const { bmrModel, tdeeByHorizon, loggingResidual, waterWeightUncertaintyLb, profileRmr } = results;
+
+  if (!bmrModel) {
+    return `<div class="mb-6 p-4 surface-2 rounded-lg border"><div class="text-sm text-muted">Energy estimates not yet available.</div></div>`;
   }
 
-  // Detect confusing inversion: light PAL > hard PAL
-  const palLight = bmrModel.pals[100];
-  const palHard  = bmrModel.pals[280];
-  const palInverted = palLight != null && palHard != null && palLight > palHard;
+  const hasError = !!bmrModel.error;
+  const isFallback = bmrModel.source === 'profile_prior';
 
-  const palRows = Object.entries(bmrModel.pals)
+  // ── Section: TDEE horizon table ──────────────────────────────────────────
+  const horizonRows = Object.entries(tdeeByHorizon || {})
     .sort(([a], [b]) => Number(a) - Number(b))
-    .map(([bump, pal]) => {
-      const labels = { '0': 'Rest day', '100': 'Light lift (+100 kcal)', '280': 'Hard lift (+280 kcal)', '400': 'HIIT (+400 kcal)' };
-      const label = labels[bump] || `+${bump} kcal`;
-      const tdee = Math.round(bmrModel.bmr_current * pal);
-      return `<tr>
-        <td class="px-3 py-2 text-sm">${label}</td>
-        <td class="px-3 py-2 text-sm text-center">${pal.toFixed(2)}</td>
-        <td class="px-3 py-2 text-sm text-center">${tdee} kcal</td>
-      </tr>`;
+    .map(([days, info]) => {
+      if (!info.available) return `
+        <tr>
+          <td class="px-3 py-2 text-sm">${days}-day window</td>
+          <td class="px-3 py-2 text-sm text-center text-muted" colspan="2">Not enough data yet</td>
+        </tr>`;
+      return `
+        <tr>
+          <td class="px-3 py-2 text-sm">${days}-day window</td>
+          <td class="px-3 py-2 text-sm text-center font-semibold">${info.tdee} kcal</td>
+          <td class="px-3 py-2 text-sm text-center text-muted">${info.daysUsed} block estimates</td>
+        </tr>`;
     }).join('');
 
-  const adaptationSign = bmrModel.adaptation > 0 ? '+' : '';
-  const adaptationColor = bmrModel.adaptation < 0 ? 'text-negative' : 'text-positive';
-  const sd = bmrModel.adaptationSD ?? '?';
-
-  return `
-    <div class="mb-6 card p-6 shadow-lg">
-      <h3 class="text-responsive-xl font-bold text-secondary mb-4">Energy Model Detail</h3>
-
-      <!-- BMR cards -->
-      <div class="grid grid-cols-1 gap-4 mb-4" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
-        <div class="surface-2 rounded-lg border p-4">
-          <div class="text-sm text-muted mb-1">Baseline BMR (weight-based)</div>
-          <div class="font-bold text-lg">${bmrModel.bmr_baseline} kcal</div>
-          <div class="text-xs text-muted mt-1">Predicted by the BMR ~ a + b × weight_kg regression fit to your historical data.</div>
-        </div>
-        <div class="surface-2 rounded-lg border p-4">
-          <div class="text-sm text-muted mb-1">BMR Model Residual (last 21 days)</div>
-          <div class="font-bold text-lg ${adaptationColor}">${adaptationSign}${bmrModel.adaptation} <span class="font-normal text-base">± ${sd} kcal</span></div>
-          <div class="text-xs text-muted mt-1 space-y-1">
-            <p>Median gap between what the weight-regression predicts for your BMR and what your weight-change + calorie data implies. A negative value means the model over-predicts your burn rate; positive means it under-predicts.</p>
-            <p class="text-warning">The ±${sd} kcal spread is a combined uncertainty — it includes both real day-to-day variation in output <em>and</em> logging noise (missed entries, incorrect amounts, or unmeasured water weight). The two cannot be separated from scale + food-log data alone, so treat this figure as a rough signal, not a precise metabolic measurement.</p>
-          </div>
-        </div>
-        <div class="surface-2 rounded-lg border p-4">
-          <div class="text-sm text-muted mb-1">Adjusted BMR</div>
-          <div class="font-bold text-lg text-accent">${bmrModel.bmr_current} kcal</div>
-          <div class="text-xs text-muted mt-1">= Baseline + Residual. Used as the base for TDEE estimates below. Carry the ±${sd} kcal uncertainty forward when interpreting those numbers.</div>
-        </div>
-      </div>
-
-      <!-- PAL table -->
-      <h4 class="font-semibold text-secondary mb-2 text-sm uppercase tracking-wide">Retrospective TDEE by Activity Level</h4>
-      <div class="mb-3 p-3 surface-2 rounded-lg border text-xs text-muted space-y-1">
-        <p><strong>What this table is:</strong> A data-fitted model. The PAL (Physical Activity Level) multiplier for each training-bump category was chosen by a grid search that minimises BMR volatility in your historical data. It tells you what your actual total energy expenditure appears to have been on days of each type.</p>
-        <p><strong>Two separate systems:</strong> The TDEE estimates here are a <em>retrospective analysis</em> tool. The <em>prospective</em> calorie target you see each day is driven by your base goal + the flat training bump you select (Rest +0, Light +100, Hard +280, HIIT +400 kcal) — not by the PAL multipliers. Changing the activity toggle adjusts your daily budget by exactly that flat amount, which is intentional and diet-plan-consistent.</p>
-        ${palInverted ? `
-        <p class="text-warning"><strong>Why does Light show a higher TDEE than Hard?</strong> This reflects a pattern in your actual data, not a bug. Hard training days often coincide with higher sodium/carb intake and glycogen-driven water retention, which temporarily inflates your scale weight. The EWMA smoother partially absorbs this noise, but if the retention is systematic it makes hard-day weight changes look smaller (or even positive) relative to calories — which pushes the implied TDEE lower, causing the grid search to assign a lower PAL. In short: the model is telling you that your hard days produce less apparent fat loss per calorie than your light days, which is real but primarily a water/glycogen effect. Use the flat bumps in your daily plan; treat the PAL table as a curiosity rather than an action item.
-        </p>` : ''}
-      </div>
+  const horizonSection = Object.keys(tdeeByHorizon || {}).length > 0 ? `
+    <div class="mb-6">
+      <h4 class="font-semibold text-secondary mb-2 text-sm uppercase tracking-wide">Observed TDEE at Different Horizons</h4>
+      <p class="text-xs text-muted mb-2">Each number is a trimmed average of 14-day rolling block estimates in that window. Longer windows are more stable; short windows react faster to recent changes. Do not act on differences smaller than ~100 kcal — that is within normal noise.</p>
       <div class="overflow-x-auto">
         <table class="w-full border rounded-lg">
           <thead class="surface-2">
             <tr>
-              <th class="px-3 py-2 text-left text-xs font-medium text-secondary uppercase">Activity (flat budget bump)</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-secondary uppercase">Window</th>
+              <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">TDEE</th>
+              <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Data points</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">${horizonRows}</tbody>
+        </table>
+      </div>
+    </div>` : '';
+
+  // ── Section: BMR / RMR cards ─────────────────────────────────────────────
+  let bmrSection = '';
+
+  if (!hasError || isFallback) {
+    const profileRmrNote = profileRmr
+      ? `<div class="surface-2 rounded-lg border p-4">
+          <div class="text-sm text-muted mb-1">Profile-predicted RMR</div>
+          <div class="font-bold text-lg">${profileRmr.rmr} kcal</div>
+          <div class="text-xs text-muted mt-1">${profileRmr.note}. Used as a starting point before enough data exists.</div>
+        </div>`
+      : '';
+
+    const adaptationSign = bmrModel.adaptation > 0 ? '+' : '';
+    const adaptationColor = bmrModel.adaptation < 0 ? 'text-negative' : 'text-positive';
+    const sd = bmrModel.adaptationSD ?? '?';
+
+    const bmrCards = isFallback
+      ? `${profileRmrNote}
+         <div class="surface-2 rounded-lg border p-4 text-sm text-warning">
+           <i class="fas fa-info-circle mr-2"></i>${bmrModel.error}
+         </div>`
+      : `
+        ${profileRmrNote}
+        <div class="surface-2 rounded-lg border p-4">
+          <div class="text-sm text-muted mb-1">Fitted BMR (weight-based regression)</div>
+          <div class="font-bold text-lg">${bmrModel.bmr_baseline} kcal</div>
+          <div class="text-xs text-muted mt-1">Weight-only prediction from BMR ~ a + b × weight_kg regression on your historical data.</div>
+        </div>
+        <div class="surface-2 rounded-lg border p-4">
+          <div class="text-sm text-muted mb-1">Model residual (last 21 days)</div>
+          <div class="font-bold text-lg ${adaptationColor}">${adaptationSign}${bmrModel.adaptation} <span class="font-normal text-base">± ${sd} kcal</span></div>
+          <div class="text-xs text-muted mt-1 space-y-1">
+            <p>Gap between the regression prediction and what your weight-change + calories data implies. A negative value means the model over-predicts your burn; positive means it under-predicts.</p>
+            <p class="text-warning">The ±${sd} kcal spread combines biological variation with logging noise (missed entries, incorrect amounts, water weight). These cannot be separated from scale data alone — do not read this as "metabolic adaptation" specifically.</p>
+            ${bmrModel.loggingResidualNote ? `<p class="text-warning">${bmrModel.loggingResidualNote}</p>` : ''}
+          </div>
+        </div>
+        <div class="surface-2 rounded-lg border p-4">
+          <div class="text-sm text-muted mb-1">Adjusted BMR (used in daily plan)</div>
+          <div class="font-bold text-lg text-accent">${bmrModel.bmr_current} kcal</div>
+          <div class="text-xs text-muted mt-1">= Fitted baseline + residual. Carry the ±${sd} kcal uncertainty when reading TDEE estimates.</div>
+        </div>`;
+
+    bmrSection = `
+      <div class="grid grid-cols-1 gap-4 mb-6" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
+        ${bmrCards}
+      </div>`;
+  } else {
+    bmrSection = `
+      <div class="mb-6 p-4 surface-2 rounded-lg border text-sm text-muted">
+        <i class="fas fa-info-circle mr-2"></i>${bmrModel.error}
+      </div>`;
+  }
+
+  // ── Section: Rest-day vs total spend ────────────────────────────────────
+  let expenditureRow = '';
+  if (bmrModel.empiricalRestDayExp != null || bmrModel.observedTdee != null) {
+    const restVal = bmrModel.empiricalRestDayExp != null
+      ? `${bmrModel.empiricalRestDayExp} kcal <span class="font-normal text-xs text-muted">(from ${results.summary?.daysWithCalories ?? '?'} data days)</span>`
+      : '<span class="text-muted">Not enough rest-day data</span>';
+    const totalVal = bmrModel.observedTdee != null
+      ? `${bmrModel.observedTdee} kcal`
+      : '<span class="text-muted">Estimating…</span>';
+
+    expenditureRow = `
+      <div class="mb-6 surface-2 rounded-lg border p-4">
+        <h4 class="font-semibold text-secondary mb-3 text-sm uppercase tracking-wide">Calories Out — Observed</h4>
+        <div class="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <div class="text-muted text-xs mb-1">Rest-day expenditure</div>
+            <div class="font-semibold">${restVal}</div>
+            <div class="text-xs text-muted mt-1">Average of all block estimates on rest/low-activity days. Your floor calorie burn.</div>
+          </div>
+          <div>
+            <div class="text-muted text-xs mb-1">Overall average TDEE</div>
+            <div class="font-semibold">${totalVal}</div>
+            <div class="text-xs text-muted mt-1">Trimmed mean across all available 14-day blocks. Includes all activity levels.</div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  // ── Section: Logging residual ────────────────────────────────────────────
+  let residualSection = '';
+  if (loggingResidual) {
+    const sign = loggingResidual.medianKcalPerDay > 0 ? '+' : '';
+    const color = Math.abs(loggingResidual.medianKcalPerDay) < 100 ? 'text-positive' : 'text-warning';
+    residualSection = `
+      <div class="mb-6 surface-2 rounded-lg border p-4">
+        <h4 class="font-semibold text-secondary mb-2 text-sm uppercase tracking-wide">Model vs Observed Gap</h4>
+        <div class="font-semibold ${color} mb-1">${sign}${loggingResidual.medianKcalPerDay} kcal/day median gap (±${loggingResidual.sdKcalPerDay})</div>
+        <p class="text-xs text-muted">${loggingResidual.note}</p>
+      </div>`;
+  }
+
+  // ── Section: PAL table (only for fitted model) ────────────────────────────
+  let palSection = '';
+  if (!hasError && !isFallback && bmrModel.pals) {
+    const palLight = bmrModel.pals[100];
+    const palHard  = bmrModel.pals[280];
+    const palInverted = palLight != null && palHard != null && palLight > palHard;
+
+    const palRows = Object.entries(bmrModel.pals)
+      .sort(([a], [b]) => Number(a) - Number(b))
+      .map(([bump, pal]) => {
+        const labels = { '0': 'Rest day', '100': 'Light lift (+100 kcal)', '280': 'Hard lift (+280 kcal)', '400': 'HIIT (+400 kcal)' };
+        const label = labels[bump] || `+${bump} kcal`;
+        const tdee = Math.round(bmrModel.bmr_current * pal);
+        return `<tr>
+          <td class="px-3 py-2 text-sm">${label}</td>
+          <td class="px-3 py-2 text-sm text-center">${pal.toFixed(2)}</td>
+          <td class="px-3 py-2 text-sm text-center">${tdee} kcal</td>
+        </tr>`;
+      }).join('');
+
+    palSection = `
+      <h4 class="font-semibold text-secondary mb-2 text-sm uppercase tracking-wide">Retrospective TDEE by Activity Level</h4>
+      <div class="mb-3 p-3 surface-2 rounded-lg border text-xs text-muted space-y-1">
+        <p><strong>What this table is:</strong> A data-fitted model. The PAL multiplier for each training-bump category was chosen by minimising BMR volatility across your history. It reflects what your total expenditure appears to have been on days of each type.</p>
+        <p><strong>Prospective budgets are separate:</strong> Your daily calorie target uses a fixed flat bump (Rest +0, Light +100, Hard +280, HIIT +400 kcal), not these PAL multipliers. That is intentional.</p>
+        ${palInverted ? `<p class="text-warning"><strong>Why does Light show higher than Hard?</strong> Hard-training days often have higher sodium and carbs, which causes temporary water retention. That inflates the apparent scale weight on hard days, making the implied TDEE look smaller — so the grid search assigns a lower PAL. This is a water/glycogen signal, not a bug. Use the flat bumps in your daily plan.</p>` : ''}
+      </div>
+      <div class="overflow-x-auto mb-4">
+        <table class="w-full border rounded-lg">
+          <thead class="surface-2">
+            <tr>
+              <th class="px-3 py-2 text-left text-xs font-medium text-secondary uppercase">Activity</th>
               <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Fitted PAL</th>
               <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Implied TDEE</th>
             </tr>
           </thead>
           <tbody class="divide-y">${palRows}</tbody>
         </table>
-      </div>
+      </div>`;
+  }
+
+  return `
+    <div class="mb-6 card p-6 shadow-lg">
+      <h3 class="text-responsive-xl font-bold text-secondary mb-4">Energy Model Detail</h3>
+      ${horizonSection}
+      ${expenditureRow}
+      ${bmrSection}
+      ${residualSection}
+      ${palSection}
     </div>
   `;
 }
+
+// ==========================================
+// IMPUTATION TABLE
+// ==========================================
 
 function renderImputationTable(rows) {
   const imputed = rows.filter(r => r.calories_imputed);
@@ -482,10 +607,7 @@ function renderImputationTable(rows) {
   return `
     <div class="mb-6 card p-6 shadow-lg">
       <h3 class="text-responsive-xl font-bold text-secondary mb-4">Missing Day Estimates</h3>
-      <p class="text-sm text-muted mb-4">
-        Days without logged calories are estimated using your TDEE model and weight change.
-        Estimates only appear after 14+ days have passed and enough weight data exists.
-      </p>
+      <p class="text-sm text-muted mb-4">Days without logged calories are estimated using your TDEE model and weight change. Estimates only appear after 14+ days have passed and enough weight data exists.</p>
       <div class="overflow-x-auto">
         <table class="w-full border rounded-lg">
           <thead class="surface-2">
@@ -506,6 +628,10 @@ function renderImputationTable(rows) {
   `;
 }
 
+// ==========================================
+// BLANK DAYS SECTION
+// ==========================================
+
 function renderBlankDaysSection(blankDays) {
   if (!blankDays || blankDays.length === 0) return '';
 
@@ -522,7 +648,6 @@ function renderBlankDaysSection(blankDays) {
     </tr>
   `).join('');
 
-  // Date range defaults: full span of available blank days
   const minDate = blankDays[0].date;
   const maxDate = blankDays[blankDays.length - 1].date;
 
@@ -532,12 +657,10 @@ function renderBlankDaysSection(blankDays) {
       <p class="text-sm text-muted mb-4">
         These days have no logged food but enough weight history for the model to estimate calories.
         Macros are distributed to sum to the estimated calorie total (protein and fat from your
-        targets; carbs fill the remainder). All micronutrient fields are set to your baseline targets.
-        Only days after your first logged food entry are shown.
+        targets; carbs fill the remainder).
         <strong>Filling a day overwrites any partial data already there.</strong>
       </p>
 
-      <!-- Range controls -->
       <div class="flex flex-wrap gap-2 mb-3 items-end">
         <div>
           <label class="block text-xs text-muted mb-1">From</label>
@@ -552,7 +675,6 @@ function renderBlankDaysSection(blankDays) {
         <button id="blank-deselect-all-btn" class="btn btn-secondary btn-sm self-end">Deselect All</button>
       </div>
 
-      <!-- Table -->
       <div class="overflow-x-auto mb-4">
         <table class="w-full border rounded-lg">
           <thead class="surface-2">
@@ -593,32 +715,22 @@ function drawWeightChart(rows) {
 
   const timeframeSelect = document.getElementById('weight-chart-timeframe');
   const daysBack = timeframeSelect?.value === 'all' ? rows.length : parseInt(timeframeSelect?.value || '90');
-
-  // Filter rows to timeframe and only those with weight
   const cutoffIdx = Math.max(0, rows.length - daysBack);
   const visible = rows.slice(cutoffIdx);
 
-  const labels = [];
-  const rawData = [];
-  const smoothData = [];
-
+  const labels = [], rawData = [], smoothData = [];
   for (const r of visible) {
     labels.push(r.date);
     rawData.push(r.weight_lb);
     smoothData.push(r.wt_smooth_lb);
   }
 
-  if (weightChartInstance) {
-    weightChartInstance.destroy();
-    weightChartInstance = null;
-  }
+  if (weightChartInstance) { weightChartInstance.destroy(); weightChartInstance = null; }
 
   const chartColors = CONFIG.CHART_COLORS || [];
   const rawColor = chartColors[0] || '#6366f1';
   const smoothColor = chartColors[1] || '#f59e0b';
-
   const css = getComputedStyle(document.documentElement);
-  const borderColor = `hsl(${css.getPropertyValue('--border').trim()})`;
 
   weightChartInstance = new Chart(canvas.getContext('2d'), {
     type: 'line',
@@ -696,11 +808,7 @@ function drawWeightChart(rows) {
             },
           },
         },
-        legend: {
-          display: true,
-          position: 'top',
-          labels: { usePointStyle: true, padding: 15 },
-        },
+        legend: { display: true, position: 'top', labels: { usePointStyle: true, padding: 15 } },
       },
     },
   });

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -269,7 +269,7 @@ function renderKPICards(results) {
   }
 
   if (s.restDayCaloriesOut != null) {
-    cards.push(kpiCard('Rest-Day Burn', `${s.restDayCaloriesOut} kcal`, 'fa-couch', 'text-accent'));
+    cards.push(kpiCard('Predicted Rest-Day TDEE', `${s.restDayCaloriesOut} kcal`, 'fa-couch', 'text-accent'));
   } else if (s.bmr != null) {
     cards.push(kpiCard('Est. BMR', `${s.bmr} kcal`, 'fa-heart-pulse', 'text-accent'));
   }
@@ -315,7 +315,8 @@ function renderConfidenceCard(confidence, results) {
   // Uncertainty footnote
   let uncertaintyNote = '';
   if (results.waterWeightUncertaintyLb != null) {
-    uncertaintyNote = `<p class="text-xs text-muted mt-2">Day-to-day water weight noise: ±${results.waterWeightUncertaintyLb} lb. This sets a floor on how precisely any single weigh-in can be interpreted.</p>`;
+    const methodLabel = results.waterCorrectionMethod === 'ols_regression' ? 'regression-fitted' : 'median-bucket';
+    uncertaintyNote = `<p class="text-xs text-muted mt-2">Day-to-day water weight noise: ±${results.waterWeightUncertaintyLb} lb (${methodLabel} correction). This sets a floor on how precisely any single weigh-in can be interpreted.</p>`;
   }
 
   return `
@@ -442,9 +443,10 @@ function renderEnergyDetail(results) {
         </div>`
       : '';
 
-    const adaptationSign = bmrModel.adaptation > 0 ? '+' : '';
-    const adaptationColor = bmrModel.adaptation < 0 ? 'text-negative' : 'text-positive';
-    const sd = bmrModel.adaptationSD ?? '?';
+    const residualSign = (bmrModel.modelResidual ?? bmrModel.adaptation ?? 0) > 0 ? '+' : '';
+    const residual = bmrModel.modelResidual ?? bmrModel.adaptation ?? 0;
+    const residualColor = residual < 0 ? 'text-negative' : 'text-positive';
+    const sd = bmrModel.modelResidualSd ?? bmrModel.adaptationSD ?? '?';
 
     const bmrCards = isFallback
       ? `${profileRmrNote}
@@ -455,22 +457,17 @@ function renderEnergyDetail(results) {
         ${profileRmrNote}
         <div class="surface-2 rounded-lg border p-4">
           <div class="text-sm text-muted mb-1">Fitted BMR (weight-based regression)</div>
-          <div class="font-bold text-lg">${bmrModel.bmr_baseline} kcal</div>
-          <div class="text-xs text-muted mt-1">Weight-only prediction from BMR ~ a + b × weight_kg regression on your historical data.</div>
+          <div class="font-bold text-lg text-accent">${bmrModel.fittedBmr ?? bmrModel.bmr_current} kcal</div>
+          <div class="text-xs text-muted mt-1">Pure regression output: BMR ~ a + b × weight_kg, fitted to your historical data. Used directly in daily targets and rest-day TDEE prediction.</div>
         </div>
         <div class="surface-2 rounded-lg border p-4">
           <div class="text-sm text-muted mb-1">Model residual (last 21 days)</div>
-          <div class="font-bold text-lg ${adaptationColor}">${adaptationSign}${bmrModel.adaptation} <span class="font-normal text-base">± ${sd} kcal</span></div>
+          <div class="font-bold text-lg ${residualColor}">${residualSign}${residual} <span class="font-normal text-base">± ${sd} kcal</span></div>
           <div class="text-xs text-muted mt-1 space-y-1">
             <p>Gap between the regression prediction and what your weight-change + calories data implies. A negative value means the model over-predicts your burn; positive means it under-predicts.</p>
-            <p class="text-warning">The ±${sd} kcal spread combines biological variation with logging noise (missed entries, incorrect amounts, water weight). These cannot be separated from scale data alone — do not read this as "metabolic adaptation" specifically.</p>
+            <p class="text-warning">This gap is ambiguous — it reflects some combination of logging inaccuracy (missed entries, incorrect amounts), water weight noise, and activity variation. Scale data alone cannot separate these. Do not label this "metabolic adaptation."</p>
             ${bmrModel.loggingResidualNote ? `<p class="text-warning">${bmrModel.loggingResidualNote}</p>` : ''}
           </div>
-        </div>
-        <div class="surface-2 rounded-lg border p-4">
-          <div class="text-sm text-muted mb-1">Adjusted BMR (used in daily plan)</div>
-          <div class="font-bold text-lg text-accent">${bmrModel.bmr_current} kcal</div>
-          <div class="text-xs text-muted mt-1">= Fitted baseline + residual. Carry the ±${sd} kcal uncertainty when reading TDEE estimates.</div>
         </div>`;
 
     bmrSection = `
@@ -486,25 +483,25 @@ function renderEnergyDetail(results) {
 
   // ── Section: Rest-day vs total spend ────────────────────────────────────
   let expenditureRow = '';
-  if (bmrModel.empiricalRestDayExp != null || bmrModel.observedTdee != null) {
-    const restVal = bmrModel.empiricalRestDayExp != null
-      ? `${bmrModel.empiricalRestDayExp} kcal <span class="font-normal text-xs text-muted">(from ${results.summary?.daysWithCalories ?? '?'} data days)</span>`
-      : '<span class="text-muted">Not enough rest-day data</span>';
+  if (bmrModel.modelPredictedRestDayTdee != null || bmrModel.observedTdee != null) {
+    const restVal = bmrModel.modelPredictedRestDayTdee != null
+      ? `${bmrModel.modelPredictedRestDayTdee} kcal`
+      : '<span class="text-muted">Not enough model data</span>';
     const totalVal = bmrModel.observedTdee != null
       ? `${bmrModel.observedTdee} kcal`
       : '<span class="text-muted">Estimating…</span>';
 
     expenditureRow = `
       <div class="mb-6 surface-2 rounded-lg border p-4">
-        <h4 class="font-semibold text-secondary mb-3 text-sm uppercase tracking-wide">Calories Out — Observed</h4>
+        <h4 class="font-semibold text-secondary mb-3 text-sm uppercase tracking-wide">Calories Out — Model Estimates</h4>
         <div class="grid grid-cols-2 gap-4 text-sm">
           <div>
-            <div class="text-muted text-xs mb-1">Rest-day expenditure</div>
+            <div class="text-muted text-xs mb-1">Predicted rest-day TDEE</div>
             <div class="font-semibold">${restVal}</div>
-            <div class="text-xs text-muted mt-1">Average of all block estimates on rest/low-activity days. Your floor calorie burn.</div>
+            <div class="text-xs text-muted mt-1">Fitted BMR × rest-day PAL. Model-predicted energy burn on days without intentional exercise.</div>
           </div>
           <div>
-            <div class="text-muted text-xs mb-1">Overall average TDEE</div>
+            <div class="text-muted text-xs mb-1">Overall observed TDEE</div>
             <div class="font-semibold">${totalVal}</div>
             <div class="text-xs text-muted mt-1">Trimmed mean across all available 14-day blocks. Includes all activity levels.</div>
           </div>

--- a/public/tools/CalorieTracker/analysis/engine.js
+++ b/public/tools/CalorieTracker/analysis/engine.js
@@ -17,22 +17,26 @@ export const ANALYSIS_CONFIG = {
   // EWMA smoothing
   EWMA_SPAN: 10, // equivalent "span" — alpha = 2/(span+1) ≈ 0.182
 
-  // Water noise correction: bucket thresholds
+  // Water noise correction: fallback bucket thresholds (used when regression unavailable)
   SODIUM_HIGH_THRESHOLD: 2800, // mg
   CARBS_HIGH_THRESHOLD: 200,   // g
+  // Minimum complete-predictor days required to attempt OLS regression
+  MIN_DAYS_FOR_WATER_REGRESSION: 20,
 
   // TDEE block
   TDEE_BLOCK_DAYS: 14,
   TDEE_PLAUSIBLE_MIN: 1200,
   TDEE_PLAUSIBLE_MAX: 4500,
 
+  // Multi-horizon TDEE estimates (days)
+  HORIZONS: { QUICK: 14, PRIMARY: 28, STABILITY_1: 42, STABILITY_2: 56 },
+
   // PAL constraints — maps to training bump levels
-  // training bump: 0=rest, 100=light, 280=hard, 400=hiit
   PAL_RANGES: {
-    0:   [1.20, 1.40],  // rest / sedentary WFH
-    100: [1.30, 1.55],  // light lift
-    280: [1.45, 1.70],  // hard lift
-    400: [1.55, 1.85],  // HIIT / endurance
+    0:   [1.20, 1.40],
+    100: [1.30, 1.55],
+    280: [1.45, 1.70],
+    400: [1.55, 1.85],
   },
   PAL_GRID_STEPS: 11,
 
@@ -45,18 +49,23 @@ export const ANALYSIS_CONFIG = {
   // Plateau detection
   PLATEAU_WINDOW_DAYS: 21,
   PLATEAU_SLOPE_THRESHOLD_LB_PER_WEEK: 0.25,
+
+  // Confidence thresholds (minimum days with both weight and logged calories)
+  DATA_SUFFICIENCY_THRESHOLDS: { ROUGH: 14, MODERATE: 28, HIGH: 42 },
+
+  // Default preferred weigh-in window: 6–9 AM (minutes from midnight)
+  WEIGH_IN_WINDOW_DEFAULT: { startMin: 360, endMin: 540 },
+
+  // Minimum rest-day blocks needed to compute empirical rest-day expenditure
+  MIN_REST_DAY_BLOCKS: 5,
 };
 
 // ==========================================
 // HELPERS
 // ==========================================
 
-/** Compute EWMA alpha from span */
-function ewmaAlpha(span) {
-  return 2 / (span + 1);
-}
+function ewmaAlpha(span) { return 2 / (span + 1); }
 
-/** Simple median of an array */
 function median(arr) {
   if (arr.length === 0) return 0;
   const sorted = [...arr].sort((a, b) => a - b);
@@ -64,7 +73,6 @@ function median(arr) {
   return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
-/** Population standard deviation (returns 0 for fewer than 2 elements) */
 function stdDev(arr) {
   if (arr.length < 2) return 0;
   const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
@@ -72,13 +80,11 @@ function stdDev(arr) {
   return Math.sqrt(variance);
 }
 
-/** Median absolute deviation */
 function mad(arr) {
   const med = median(arr);
   return median(arr.map(v => Math.abs(v - med)));
 }
 
-/** Trimmed mean — drop top/bottom p fraction */
 function trimmedMean(arr, p = 0.1) {
   if (arr.length < 4) return median(arr);
   const sorted = [...arr].sort((a, b) => a - b);
@@ -87,7 +93,6 @@ function trimmedMean(arr, p = 0.1) {
   return trimmed.reduce((s, v) => s + v, 0) / trimmed.length;
 }
 
-/** Linear regression: returns { slope, intercept } */
 function linearRegression(xs, ys) {
   const n = xs.length;
   if (n < 2) return { slope: 0, intercept: ys[0] || 0 };
@@ -102,9 +107,101 @@ function linearRegression(xs, ys) {
   return { slope, intercept };
 }
 
-/** Days between two YYYY-MM-DD strings */
 function daysBetween(a, b) {
   return Math.round((new Date(b + 'T00:00:00') - new Date(a + 'T00:00:00')) / 86400000);
+}
+
+/**
+ * Solve Ax = b via Gauss-Jordan elimination with partial pivoting.
+ * Returns the solution vector or null if the system is singular.
+ */
+function solveLinearSystem(A, b) {
+  const n = b.length;
+  // Augmented matrix [A | b]
+  const M = A.map((row, i) => [...row, b[i]]);
+
+  for (let col = 0; col < n; col++) {
+    // Partial pivot
+    let pivot = col;
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(M[row][col]) > Math.abs(M[pivot][col])) pivot = row;
+    }
+    [M[col], M[pivot]] = [M[pivot], M[col]];
+    if (Math.abs(M[col][col]) < 1e-12) return null;
+
+    // Eliminate all other rows
+    for (let row = 0; row < n; row++) {
+      if (row === col) continue;
+      const factor = M[row][col] / M[col][col];
+      for (let k = col; k <= n; k++) M[row][k] -= factor * M[col][k];
+    }
+  }
+  return M.map((row, i) => row[n] / row[i]);
+}
+
+/**
+ * Ordinary least squares via normal equations with a small ridge term for stability.
+ * X: array of feature-row arrays, y: response array.
+ * Returns coefficient vector or null on failure.
+ */
+function solveOLS(X, y) {
+  const n = X.length;
+  const p = X[0].length;
+  const RIDGE = 0.01; // tiny ridge for numerical stability only
+
+  const XtX = Array.from({ length: p }, () => Array(p).fill(0));
+  const Xty = Array(p).fill(0);
+
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < p; j++) {
+      Xty[j] += X[i][j] * y[i];
+      for (let k = 0; k < p; k++) XtX[j][k] += X[i][j] * X[i][k];
+    }
+  }
+  for (let j = 0; j < p; j++) XtX[j][j] += RIDGE;
+
+  return solveLinearSystem(XtX, Xty);
+}
+
+// ==========================================
+// DAILY WEIGHT SELECTION (multi-weigh-in)
+// ==========================================
+
+/**
+ * Given an array of weigh-in readings for one day, select the single best representative.
+ *
+ * Priority:
+ *  1. If a preferred window is defined and any reading falls in it, return the
+ *     median (by weight) of those in-window readings.
+ *  2. Otherwise return the reading with the smallest time_min (earliest in day).
+ *  3. If all time_min are null, return the first reading.
+ *
+ * @param {Array<{weight_lb:number, time_min:number|null}>} readings
+ * @param {{startMin:number, endMin:number}|null} preferredWindow
+ * @returns {object}
+ */
+export function selectDailyWeight(readings, preferredWindow = null) {
+  if (!readings || readings.length === 0) return null;
+  if (readings.length === 1) return readings[0];
+
+  if (preferredWindow) {
+    const { startMin, endMin } = preferredWindow;
+    const inWindow = readings.filter(
+      r => r.time_min != null && r.time_min >= startMin && r.time_min <= endMin
+    );
+    if (inWindow.length > 0) {
+      // Median of in-window readings (robust to single outlier syncs)
+      const sorted = [...inWindow].sort((a, b) => a.weight_lb - b.weight_lb);
+      return sorted[Math.floor(sorted.length / 2)];
+    }
+  }
+
+  // Fall back to earliest reading
+  const withTime = readings.filter(r => r.time_min != null);
+  if (withTime.length > 0) {
+    return withTime.reduce((best, r) => r.time_min < best.time_min ? r : best, withTime[0]);
+  }
+  return readings[0];
 }
 
 // ==========================================
@@ -113,24 +210,41 @@ function daysBetween(a, b) {
 
 /**
  * Merge weight entries and nutrition entries into a unified daily array.
- * One row per date, sorted chronologically.
- * @param {Map} weightEntries - state.weightEntries
- * @param {Map} dailyEntries  - state.dailyEntries
+ *
+ * @param {Map} weightEntries      - state.weightEntries (docId → entry)
+ * @param {Map} dailyEntries       - state.dailyEntries
+ * @param {Map|null} weightEntriesMulti - state.weightEntriesMulti (date → Array), optional
+ * @param {object|null} profile    - state.userProfile for preferred weigh-in window, optional
  * @returns {Array<object>} Sorted array of daily rows
  */
-export function mergeDailyData(weightEntries, dailyEntries) {
+export function mergeDailyData(weightEntries, dailyEntries, weightEntriesMulti = null, profile = null) {
   const dateMap = new Map();
 
-  // Aggregate weight: if multiple readings per day, take earliest (lowest time_min)
+  // Determine preferred weigh-in window from profile or use default
+  let preferredWindow = ANALYSIS_CONFIG.WEIGH_IN_WINDOW_DEFAULT;
+  if (profile) {
+    const s = parseFloat(profile.preferredWeighInStartMin);
+    const e = parseFloat(profile.preferredWeighInEndMin);
+    if (!isNaN(s) && !isNaN(e) && s < e) preferredWindow = { startMin: s, endMin: e };
+  }
+
+  // Build per-date weight representative using multi-weigh-in map when available
   const weightByDate = new Map();
-  for (const [, entry] of weightEntries) {
-    const d = entry.date;
-    if (!weightByDate.has(d) || entry.time_min < weightByDate.get(d).time_min) {
-      weightByDate.set(d, entry);
+  if (weightEntriesMulti && weightEntriesMulti.size > 0) {
+    for (const [dateStr, readings] of weightEntriesMulti) {
+      const best = selectDailyWeight(readings, preferredWindow);
+      if (best) weightByDate.set(dateStr, best);
+    }
+  } else {
+    // Fall back: from the flat map, keep the reading with the lowest time_min per date
+    for (const [, entry] of weightEntries) {
+      const d = entry.date;
+      if (!weightByDate.has(d) || entry.time_min < weightByDate.get(d).time_min) {
+        weightByDate.set(d, entry);
+      }
     }
   }
 
-  // Create rows for every date that has either weight or nutrition
   const allDates = new Set([...weightByDate.keys(), ...dailyEntries.keys()]);
 
   for (const dateStr of allDates) {
@@ -153,19 +267,33 @@ export function mergeDailyData(weightEntries, dailyEntries) {
 }
 
 // ==========================================
-// STEP 2: WATER NOISE CORRECTION (median-bucket approach)
+// STEP 2: WATER NOISE CORRECTION
 // ==========================================
 
 /**
- * Compute a water noise correction per row based on sodium/carb buckets.
- * Returns a new array with `weight_corr` added to each row.
+ * Estimate and remove systematic water-weight noise from daily weigh-ins.
+ *
+ * Strategy:
+ *  1. Compute a 7-day rolling baseline for each weight reading.
+ *  2. Fit an OLS regression (intercept + sodium_z + carbs_z [+ fiber_z]) to the
+ *     residuals from that baseline, provided ≥20 complete-predictor days exist.
+ *     A small ridge term prevents overfitting on sparse data.
+ *  3. If insufficient data for regression, fall back to adaptive median buckets
+ *     (using the data-driven median sodium/carb as thresholds, not fixed values).
+ *  4. Remove the fitted component from each weight reading → weight_corr.
+ *  5. Return { rows, uncertaintyLb } where uncertaintyLb is the RMSE of the
+ *     residuals AFTER correction — an honest uncertainty band (±lb) that the
+ *     UI should surface rather than hide.
+ *
+ * IMPORTANT: corrections here are statistical estimates, not exact physiology.
+ * Water weight is also influenced by stress, sleep, hormones, and dozens of other
+ * factors not captured in the food log. The returned uncertaintyLb reflects this.
  */
 export function waterCorrect(rows) {
   const C = ANALYSIS_CONFIG;
+  const result = rows.map(r => ({ ...r }));
 
-  // First pass: compute baseline rolling mean (7-day backward)
-  const result = rows.map((r, i) => ({ ...r }));
-
+  // Pass 1: 7-day rolling baseline
   for (let i = 0; i < result.length; i++) {
     if (result[i].weight_lb == null) continue;
     let sum = 0, count = 0;
@@ -175,83 +303,126 @@ export function waterCorrect(rows) {
     result[i]._baseline = count >= 3 ? sum / count : result[i].weight_lb;
   }
 
-  // Build buckets: high-sodium vs low, high-carb vs low
-  // Then compute median residual per bucket
-  const buckets = { hh: [], hl: [], lh: [], ll: [] };
+  // Gather rows with complete predictor data
+  const trainRows = result.filter(
+    r => r.weight_lb != null && r._baseline != null && r.sodium != null && r.carbs != null
+  );
 
-  for (const r of result) {
-    if (r.weight_lb == null || r._baseline == null) continue;
-    const resid = r.weight_lb - r._baseline;
-    const sHigh = r.sodium != null && r.sodium > C.SODIUM_HIGH_THRESHOLD;
-    const cHigh = r.carbs != null && r.carbs > C.CARBS_HIGH_THRESHOLD;
+  let correctFn = null;   // (row) => correction in lb
+  let uncertaintyLb = null;
 
-    if (r.sodium == null || r.carbs == null) continue; // skip days without nutrition
-    const key = (sHigh ? 'h' : 'l') + (cHigh ? 'h' : 'l');
-    buckets[key].push(resid);
+  if (trainRows.length >= C.MIN_DAYS_FOR_WATER_REGRESSION) {
+    // Standardise predictors
+    const sodVals = trainRows.map(r => r.sodium);
+    const carbVals = trainRows.map(r => r.carbs);
+    const sodMean = sodVals.reduce((s, v) => s + v, 0) / sodVals.length;
+    const carbMean = carbVals.reduce((s, v) => s + v, 0) / carbVals.length;
+    const sodSd = Math.max(1, stdDev(sodVals));
+    const carbSd = Math.max(1, stdDev(carbVals));
+
+    // Include fiber only when it has >50% coverage
+    const fibRows = trainRows.filter(r => r.fiber != null);
+    const useFiber = fibRows.length > trainRows.length * 0.5;
+    const fibMean = useFiber ? fibRows.reduce((s, r) => s + r.fiber, 0) / fibRows.length : 0;
+    const fibSd = useFiber ? Math.max(1, stdDev(fibRows.map(r => r.fiber))) : 1;
+
+    const fitRows = useFiber ? fibRows : trainRows;
+    const X = fitRows.map(r => [
+      1,
+      (r.sodium - sodMean) / sodSd,
+      (r.carbs - carbMean) / carbSd,
+      ...(useFiber ? [(r.fiber - fibMean) / fibSd] : []),
+    ]);
+    const y = fitRows.map(r => r.weight_lb - r._baseline);
+
+    try {
+      const beta = solveOLS(X, y);
+      if (beta && beta.every(v => !isNaN(v) && isFinite(v))) {
+        correctFn = (r) => {
+          if (r.sodium == null || r.carbs == null) return 0;
+          const fib = useFiber && r.fiber != null ? (r.fiber - fibMean) / fibSd : 0;
+          return beta[0]
+            + beta[1] * (r.sodium - sodMean) / sodSd
+            + beta[2] * (r.carbs - carbMean) / carbSd
+            + (useFiber ? beta[3] * fib : 0);
+        };
+
+        const residAfter = fitRows.map(r => {
+          const resid = r.weight_lb - r._baseline;
+          return resid - correctFn(r);
+        });
+        uncertaintyLb = +(Math.sqrt(
+          residAfter.reduce((s, v) => s + v * v, 0) / residAfter.length
+        )).toFixed(2);
+      }
+    } catch (_e) {
+      correctFn = null;
+    }
   }
 
-  const corrections = {};
-  for (const key of Object.keys(buckets)) {
-    corrections[key] = buckets[key].length >= 3 ? median(buckets[key]) : 0;
+  if (!correctFn) {
+    // Adaptive median-bucket fallback (data-driven thresholds)
+    const sodThr = trainRows.length > 0
+      ? median(trainRows.map(r => r.sodium))
+      : C.SODIUM_HIGH_THRESHOLD;
+    const carbThr = trainRows.length > 0
+      ? median(trainRows.map(r => r.carbs))
+      : C.CARBS_HIGH_THRESHOLD;
+
+    const buckets = { hh: [], hl: [], lh: [], ll: [] };
+    for (const r of result) {
+      if (r.weight_lb == null || r._baseline == null || r.sodium == null || r.carbs == null) continue;
+      const key = (r.sodium > sodThr ? 'h' : 'l') + (r.carbs > carbThr ? 'h' : 'l');
+      buckets[key].push(r.weight_lb - r._baseline);
+    }
+    const medCorr = {};
+    for (const key of Object.keys(buckets)) {
+      medCorr[key] = buckets[key].length >= 3 ? median(buckets[key]) : 0;
+    }
+    correctFn = (r) => {
+      if (r.sodium == null || r.carbs == null) return 0;
+      const key = (r.sodium > sodThr ? 'h' : 'l') + (r.carbs > carbThr ? 'h' : 'l');
+      return medCorr[key] || 0;
+    };
+
+    const allResid = Object.values(buckets).flat();
+    if (allResid.length > 3) {
+      uncertaintyLb = +(mad(allResid) * 1.4826).toFixed(2); // MAD → σ equiv.
+    }
   }
 
   // Apply corrections
   for (const r of result) {
-    if (r.weight_lb == null) {
-      r.weight_corr = null;
-      continue;
-    }
-    if (r.sodium == null || r.carbs == null) {
-      r.weight_corr = r.weight_lb; // no nutrition data to correct with
-      continue;
-    }
-    const sHigh = r.sodium > C.SODIUM_HIGH_THRESHOLD;
-    const cHigh = r.carbs > C.CARBS_HIGH_THRESHOLD;
-    const key = (sHigh ? 'h' : 'l') + (cHigh ? 'h' : 'l');
-    r.weight_corr = r.weight_lb - corrections[key];
+    if (r.weight_lb == null) { r.weight_corr = null; r._waterCorrection = 0; continue; }
+    const corr = correctFn(r);
+    r._waterCorrection = corr;
+    r.weight_corr = r.weight_lb - corr;
   }
 
-  return result;
+  return { rows: result, uncertaintyLb: uncertaintyLb ?? null };
 }
 
 // ==========================================
-// STEP 3: EWMA SMOOTHING for "true weight"
+// STEP 3: EWMA SMOOTHING
 // ==========================================
 
-/**
- * Apply EWMA smoothing to weight_corr, producing wt_smooth_lb.
- * Gaps (null weight) are skipped — EWMA resumes from last known value.
- */
 export function smoothWeight(rows) {
   const alpha = ewmaAlpha(ANALYSIS_CONFIG.EWMA_SPAN);
   const result = rows.map(r => ({ ...r }));
   let prev = null;
 
   for (const r of result) {
-    if (r.weight_corr == null) {
-      r.wt_smooth_lb = prev; // carry forward
-      continue;
-    }
-    if (prev == null) {
-      r.wt_smooth_lb = r.weight_corr;
-    } else {
-      r.wt_smooth_lb = alpha * r.weight_corr + (1 - alpha) * prev;
-    }
+    if (r.weight_corr == null) { r.wt_smooth_lb = prev; continue; }
+    r.wt_smooth_lb = prev == null ? r.weight_corr : alpha * r.weight_corr + (1 - alpha) * prev;
     prev = r.wt_smooth_lb;
   }
-
   return result;
 }
 
 // ==========================================
-// STEP 4: TDEE BLOCK ESTIMATION
+// STEP 4: TDEE BLOCK ESTIMATION (14-day rolling)
 // ==========================================
 
-/**
- * Compute rolling-block TDEE estimates.
- * For each day t with a full window of calories and smoothed weight,
- * computes: TDEE = avg_intake - (energy_density * Δweight_kg / window_days)
- */
 export function estimateTDEE(rows) {
   const C = ANALYSIS_CONFIG;
   const result = rows.map(r => ({ ...r }));
@@ -259,12 +430,9 @@ export function estimateTDEE(rows) {
 
   for (let i = blockDays; i < result.length; i++) {
     const window = result.slice(i - blockDays, i + 1);
-
-    // Need calories for every day in the window
     const cals = window.map(r => r.calories).filter(c => c != null);
-    if (cals.length < blockDays * 0.7) continue; // need at least 70% coverage
+    if (cals.length < blockDays * 0.7) continue;
 
-    // Need smoothed weight at start and end
     const wStart = window[0].wt_smooth_lb;
     const wEnd = window[window.length - 1].wt_smooth_lb;
     if (wStart == null || wEnd == null) continue;
@@ -278,8 +446,113 @@ export function estimateTDEE(rows) {
       result[i].tdee_block = Math.round(tdee);
     }
   }
-
   return result;
+}
+
+// ==========================================
+// MULTI-HORIZON TDEE ESTIMATES
+// ==========================================
+
+/**
+ * Compute aggregate TDEE estimates at multiple horizons.
+ * Uses the same block logic as estimateTDEE but condenses each horizon
+ * into a single point estimate (trimmed mean of all block estimates within
+ * that window from the end of the record).
+ *
+ * @param {Array} rows - Rows with tdee_block populated
+ * @returns {object} { 14: {...}, 28: {...}, 42: {...}, 56: {...} }
+ */
+export function estimateTDEEByHorizon(rows) {
+  const C = ANALYSIS_CONFIG;
+  const horizons = C.HORIZONS;
+  const result = {};
+  const valid = rows.filter(r => r.tdee_block != null && r.wt_smooth_lb != null);
+
+  for (const [label, days] of Object.entries(horizons)) {
+    const windowRows = valid.slice(-days);
+    const tdees = windowRows.map(r => r.tdee_block).filter(t => t != null);
+    if (tdees.length < 5) {
+      result[days] = { tdee: null, daysUsed: tdees.length, available: false, label };
+    } else {
+      result[days] = {
+        tdee: Math.round(trimmedMean(tdees)),
+        daysUsed: tdees.length,
+        available: true,
+        label,
+      };
+    }
+  }
+  return result;
+}
+
+// ==========================================
+// PROFILE-BASED RMR ESTIMATE
+// ==========================================
+
+/**
+ * Compute a profile-predicted RMR using Mifflin-St Jeor (primary) or a
+ * weight-only fallback. This is used as a Bayesian prior / sanity anchor
+ * for the data-driven BMR model.
+ *
+ * @param {object|null} profile    - state.userProfile
+ * @param {number|null} weightLb   - latest smoothed weight in lb
+ * @returns {{ rmr:number, method:string, note:string }|null}
+ */
+export function estimateProfileRmr(profile, weightLb) {
+  if (!weightLb || weightLb <= 0) return null;
+  const C = ANALYSIS_CONFIG;
+  const weightKg = weightLb * C.LB_TO_KG;
+
+  if (profile) {
+    const age = (() => {
+      if (profile.birthDate) {
+        const birth = new Date(profile.birthDate);
+        if (!isNaN(birth.getTime())) {
+          const today = new Date();
+          let a = today.getFullYear() - birth.getFullYear();
+          const m = today.getMonth() - birth.getMonth();
+          if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) a--;
+          if (a > 0 && a < 120) return a;
+        }
+      }
+      const n = Number(profile.age);
+      return !isNaN(n) && n > 0 && n < 120 ? n : null;
+    })();
+
+    const hv = parseFloat(profile.heightValue);
+    const heightCm = hv > 0
+      ? (profile.heightUnit === 'cm' ? hv : hv * 2.54)
+      : null;
+
+    const sex = profile.sex; // 'male' | 'female'
+
+    if (age && heightCm && (sex === 'male' || sex === 'female')) {
+      // Mifflin-St Jeor
+      const rmr = sex === 'male'
+        ? 10 * weightKg + 6.25 * heightCm - 5 * age + 5
+        : 10 * weightKg + 6.25 * heightCm - 5 * age - 161;
+      return {
+        rmr: Math.round(rmr),
+        method: 'mifflin_st_jeor',
+        note: 'Mifflin-St Jeor equation (height + age + sex)',
+      };
+    }
+
+    // Cunningham if BF% available
+    const bf = parseFloat(profile.bodyFatPercent);
+    if (!isNaN(bf) && bf > 0 && bf < 60) {
+      const ffmKg = weightKg * (1 - bf / 100);
+      const rmr = 500 + 22 * ffmKg;
+      return { rmr: Math.round(rmr), method: 'cunningham', note: 'Cunningham equation (lean mass)' };
+    }
+  }
+
+  // Weight-only fallback (~21 kcal/kg is a rough population midpoint)
+  return {
+    rmr: Math.round(21 * weightKg),
+    method: 'weight_only',
+    note: 'Weight-only estimate (no height/age/sex available). Use profile for accuracy.',
+  };
 }
 
 // ==========================================
@@ -287,21 +560,68 @@ export function estimateTDEE(rows) {
 // ==========================================
 
 /**
- * Estimate BMR by finding PAL values per training bump level that minimize
- * BMR volatility (MAD of residuals from a weight-based BMR model).
- * @param {Array} rows - Rows with tdee_block and wt_smooth_lb populated
- * @returns {object} BMR model: { pals, a, b, bmr_current, adaptation, tdee_current, error? }
+ * Estimate BMR via PAL grid search.
+ *
+ * When `profileRmrKcal` is supplied it acts as a fallback/prior:
+ *  - If data is insufficient, a profile-based estimate is returned instead
+ *    of a plain error so that new users still get a reasonable model.
+ *  - The fitted BMR is compared to the profile prediction; a large deviation
+ *    is flagged as potential logging noise rather than labelled "metabolic
+ *    adaptation" (which would over-claim biological certainty).
+ *
+ * Returns an extended object that now includes:
+ *  - profilePredictedRmr   : from Mifflin-St Jeor / Cunningham / weight-only
+ *  - observedTdee          : trimmed mean of all valid block estimates
+ *  - empiricalRestDayExp   : trimmed mean of block estimates on rest days
+ *  - loggingResidualNote   : plain-language flag about residual size
  */
-export function estimateBMR(rows) {
+export function estimateBMR(rows, profileRmrKcal = null) {
   const C = ANALYSIS_CONFIG;
 
-  // Filter to rows with valid TDEE and weight
   const valid = rows.filter(r => r.tdee_block != null && r.wt_smooth_lb != null);
+
+  // Observed TDEE across all block estimates (not model-dependent)
+  const allTDEEs = valid.map(r => r.tdee_block).filter(t => t != null);
+  const observedTdee = allTDEEs.length >= 5 ? Math.round(trimmedMean(allTDEEs)) : null;
+
+  // Empirical rest-day expenditure: block estimates on days with trainingBump=0
+  const restValid = valid.filter(r => (r.trainingBump || 0) === 0);
+  const restTDEEs = restValid.map(r => r.tdee_block).filter(t => t != null);
+  const empiricalRestDayExp = restTDEEs.length >= C.MIN_REST_DAY_BLOCKS
+    ? Math.round(trimmedMean(restTDEEs))
+    : null;
+
   if (valid.length < 30) {
-    return { error: 'Not enough data (need 30+ days with both weight and calorie data).' };
+    // Not enough data for grid search — use profile RMR as fallback if available
+    if (profileRmrKcal && profileRmrKcal > 0) {
+      const restPal = 1.30; // conservative rest-day PAL
+      return {
+        pals: { 0: restPal, 100: 1.45, 280: 1.58, 400: 1.70 },
+        a: 0, b: 0,
+        bmr_current: profileRmrKcal,
+        bmr_baseline: profileRmrKcal,
+        adaptation: 0,
+        adaptationSD: 0,
+        tdee_current: observedTdee ?? Math.round(profileRmrKcal * restPal),
+        tdee_rest_day: Math.round(profileRmrKcal * restPal),
+        observedTdee,
+        empiricalRestDayExp,
+        profilePredictedRmr: profileRmrKcal,
+        score: null,
+        source: 'profile_prior',
+        insufficientData: true,
+        error: `Only ${valid.length} day(s) with both weight and calories — need 30 for a fitted model. Showing profile-based estimate.`,
+      };
+    }
+    return {
+      observedTdee,
+      empiricalRestDayExp,
+      profilePredictedRmr: profileRmrKcal,
+      error: `Not enough data (need 30+ days with both weight and calorie data; have ${valid.length}).`,
+    };
   }
 
-  // Discretize PAL ranges into grids
+  // Grid search (unchanged from v1)
   const palKeys = Object.keys(C.PAL_RANGES).map(Number).sort((a, b) => a - b);
   const grids = {};
   for (const k of palKeys) {
@@ -310,134 +630,89 @@ export function estimateBMR(rows) {
     grids[k] = Array.from({ length: C.PAL_GRID_STEPS }, (_, i) => lo + i * step);
   }
 
-  // For tractability with 4 PAL levels × 11 steps each = 14641 combos — fine
-  let bestScore = Infinity;
-  let bestPals = {};
-  let bestModel = {};
+  let bestScore = Infinity, bestPals = {}, bestModel = {};
 
-  // Helper to run one PAL combo
   function tryPals(pals) {
-    const wts = [];
-    const bmrs = [];
-
+    const wts = [], bmrs = [];
     for (const r of valid) {
       const bump = r.trainingBump || 0;
-      // Find closest PAL key
-      const palKey = palKeys.reduce((best, k) => Math.abs(k - bump) < Math.abs(best - bump) ? k : best, palKeys[0]);
-      const pal = pals[palKey];
-      const impliedBMR = r.tdee_block / pal;
-      const wtKg = r.wt_smooth_lb * C.LB_TO_KG;
-
-      wts.push(wtKg);
+      const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
+      const impliedBMR = r.tdee_block / pals[palKey];
+      wts.push(r.wt_smooth_lb * C.LB_TO_KG);
       bmrs.push(impliedBMR);
     }
-
-    // Robust fit: BMR ~ a + b * weight_kg
-    // Use trimmed regression: drop top/bottom 10% of residuals and refit
     const reg1 = linearRegression(wts, bmrs);
     const resid1 = bmrs.map((b, i) => b - (reg1.intercept + reg1.slope * wts[i]));
     const cutoff = 1.5 * mad(resid1);
-
-    const keepIdx = [];
-    for (let i = 0; i < resid1.length; i++) {
-      if (Math.abs(resid1[i]) <= cutoff) keepIdx.push(i);
-    }
-
+    const keepIdx = resid1.map((r, i) => [Math.abs(r), i]).filter(([v]) => v <= cutoff).map(([, i]) => i);
     if (keepIdx.length < 20) return null;
-
     const wts2 = keepIdx.map(i => wts[i]);
     const bmrs2 = keepIdx.map(i => bmrs[i]);
     const reg2 = linearRegression(wts2, bmrs2);
-
-    // Score: MAD of residuals from trimmed fit
     const resid2 = bmrs2.map((b, i) => b - (reg2.intercept + reg2.slope * wts2[i]));
-    const score = mad(resid2);
-
-    return { score, a: reg2.intercept, b: reg2.slope };
+    return { score: mad(resid2), a: reg2.intercept, b: reg2.slope };
   }
-
-  // Grid search over all PAL combos
-  // To keep it tractable, do 2-level search:
-  // 1) Coarse: step by 2 across grid
-  // 2) Fine: refine around best
 
   function searchPals(gridSubset) {
     const keys = Object.keys(gridSubset).map(Number).sort((a, b) => a - b);
-
     function recurse(depth, current) {
       if (depth === keys.length) {
-        const result = tryPals(current);
-        if (result && result.score < bestScore) {
-          bestScore = result.score;
-          bestPals = { ...current };
-          bestModel = result;
-        }
+        const res = tryPals(current);
+        if (res && res.score < bestScore) { bestScore = res.score; bestPals = { ...current }; bestModel = res; }
         return;
       }
       const k = keys[depth];
-      for (const palVal of gridSubset[k]) {
-        current[k] = palVal;
-        recurse(depth + 1, current);
-      }
+      for (const v of gridSubset[k]) { current[k] = v; recurse(depth + 1, current); }
     }
-
     recurse(0, {});
   }
 
-  // Coarse search (every other grid point)
   const coarseGrids = {};
-  for (const k of palKeys) {
-    coarseGrids[k] = grids[k].filter((_, i) => i % 2 === 0);
-  }
+  for (const k of palKeys) coarseGrids[k] = grids[k].filter((_, i) => i % 2 === 0);
   searchPals(coarseGrids);
 
-  // Fine search: ±1 step around best
   if (Object.keys(bestPals).length > 0) {
     const fineGrids = {};
     for (const k of palKeys) {
-      const bestVal = bestPals[k];
-      const [lo, hi] = C.PAL_RANGES[k];
+      const bv = bestPals[k], [lo, hi] = C.PAL_RANGES[k];
       const step = (hi - lo) / (C.PAL_GRID_STEPS - 1);
-      fineGrids[k] = [
-        Math.max(lo, bestVal - step),
-        bestVal,
-        Math.min(hi, bestVal + step)
-      ];
+      fineGrids[k] = [Math.max(lo, bv - step), bv, Math.min(hi, bv + step)];
     }
     searchPals(fineGrids);
   }
 
-  if (!bestModel.a) {
-    return { error: 'BMR model fitting failed.' };
+  if (!bestModel.a && bestModel.a !== 0) {
+    return { observedTdee, empiricalRestDayExp, profilePredictedRmr: profileRmrKcal, error: 'BMR model fitting failed.' };
   }
 
-  // Current values
   const lastValid = [...valid].reverse().find(r => r.wt_smooth_lb != null);
   const currentWtKg = lastValid.wt_smooth_lb * C.LB_TO_KG;
   const bmrBase = bestModel.a + bestModel.b * currentWtKg;
 
-  // Adaptation: recent median of (implied BMR - fitted BMR)
   const recent = valid.slice(-21);
   const adaptResiduals = recent.map(r => {
     const bump = r.trainingBump || 0;
-    const palKey = palKeys.reduce((best, k) => Math.abs(k - bump) < Math.abs(best - bump) ? k : best, palKeys[0]);
+    const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
     const impliedBMR = r.tdee_block / bestPals[palKey];
     const fittedBMR = bestModel.a + bestModel.b * r.wt_smooth_lb * C.LB_TO_KG;
     return impliedBMR - fittedBMR;
   });
   const adaptation = Math.round(median(adaptResiduals));
-  // SD of the residuals: captures both true day-to-day variation and logging noise
-  // (missed entries or incorrect amounts shift the apparent energy balance, so this
-  // is a combined "biological + measurement" uncertainty, not just physiology).
   const adaptationSD = Math.round(stdDev(adaptResiduals));
 
-  // Current TDEE estimate for a rest day
   const restPal = bestPals[0] || 1.3;
   const tdeeRestDay = Math.round((bmrBase + adaptation) * restPal);
 
-  // Recent TDEE: trimmed mean of last 21 block estimates
   const recentTDEEs = valid.slice(-21).map(r => r.tdee_block).filter(t => t != null);
   const tdeeRecent = recentTDEEs.length >= 7 ? Math.round(trimmedMean(recentTDEEs)) : tdeeRestDay;
+
+  // Flag large residuals plainly without claiming "metabolic adaptation"
+  let loggingResidualNote = null;
+  if (Math.abs(adaptation) > 150) {
+    loggingResidualNote = Math.abs(adaptation) > 300
+      ? 'Large gap between predicted and observed energy balance — likely reflects logging gaps or water weight noise, not just biology.'
+      : 'Moderate gap between predicted and observed balance — could be logging error, activity change, or water noise.';
+  }
 
   return {
     pals: bestPals,
@@ -449,20 +724,146 @@ export function estimateBMR(rows) {
     adaptationSD,
     tdee_current: tdeeRecent,
     tdee_rest_day: tdeeRestDay,
+    observedTdee,
+    empiricalRestDayExp,
+    profilePredictedRmr: profileRmrKcal,
+    loggingResidualNote,
     score: bestScore,
+    source: 'fitted',
   };
 }
 
 // ==========================================
-// STEP 6: CALORIE IMPUTATION for missing days
+// DATA SUFFICIENCY & CONFIDENCE
 // ==========================================
 
 /**
- * Impute calories for missing days using TDEE + weight change, with lag gating.
- * @param {Array} rows - Daily rows with wt_smooth_lb
- * @param {object} bmrModel - The BMR model from estimateBMR
- * @returns {Array} Rows with imputed calories and metadata
+ * Assess how confident we should be in the energy model.
+ *
+ * @param {Array}  rows     - Merged daily rows
+ * @param {object} bmrModel - Output of estimateBMR
+ * @returns {{ label, score, reasons, daysWithWeight, daysWithLoggedCalories }}
  */
+export function computeConfidence(rows, bmrModel) {
+  const C = ANALYSIS_CONFIG;
+  const thresholds = C.DATA_SUFFICIENCY_THRESHOLDS;
+
+  const daysWithWeight = rows.filter(r => r.weight_lb != null).length;
+  const daysWithLoggedCalories = rows.filter(r => r.calories != null && !r.calories_imputed).length;
+  const minDays = Math.min(daysWithWeight, daysWithLoggedCalories);
+
+  let label;
+  if (minDays < thresholds.ROUGH) label = 'not_enough';
+  else if (minDays < thresholds.MODERATE) label = 'rough';
+  else if (minDays < thresholds.HIGH) label = 'moderate';
+  else label = 'high';
+
+  // Score: 0–100
+  const score = label === 'not_enough' ? 0
+    : label === 'rough' ? 20
+    : label === 'moderate' ? 55
+    : 85;
+
+  const reasons = [];
+
+  if (daysWithWeight >= thresholds.HIGH) {
+    reasons.push(`${daysWithWeight} days of weight data — strong foundation.`);
+  } else if (daysWithWeight >= thresholds.MODERATE) {
+    reasons.push(`${daysWithWeight} days of weight data — moderate. 42+ gives higher confidence.`);
+  } else {
+    reasons.push(`Only ${daysWithWeight} days of weight data. Need at least ${thresholds.ROUGH} to start.`);
+  }
+
+  if (daysWithLoggedCalories >= thresholds.HIGH) {
+    reasons.push(`${daysWithLoggedCalories} days with logged calories — good coverage.`);
+  } else if (daysWithLoggedCalories >= thresholds.ROUGH) {
+    reasons.push(`${daysWithLoggedCalories} days with logged calories. More logging = better estimates.`);
+  } else {
+    reasons.push(`Only ${daysWithLoggedCalories} logged food days. Log consistently for useful estimates.`);
+  }
+
+  // Recent gaps
+  const recent30 = rows.slice(-30);
+  const recentGaps = recent30.filter(r => r.calories == null && r.weight_lb != null).length;
+  if (recentGaps > 7) {
+    reasons.push(`${recentGaps} recent days without calorie logs — gaps reduce recent accuracy.`);
+  }
+
+  // BMR model quality
+  if (bmrModel && !bmrModel.error && bmrModel.score != null) {
+    if (bmrModel.score < 50) reasons.push('BMR model fit is tight — consistent logging pattern.');
+    else if (bmrModel.score > 150) reasons.push('BMR model fit is loose — variable logging or activity.');
+  }
+
+  if (bmrModel?.source === 'profile_prior') {
+    reasons.push('Using profile-based estimate — not enough data yet for a fitted model.');
+  }
+
+  return { label, score, reasons, daysWithWeight, daysWithLoggedCalories };
+}
+
+// ==========================================
+// LOGGING RESIDUAL
+// ==========================================
+
+/**
+ * Estimate the gap between what the TDEE model predicts and what the weight
+ * data implies, expressed as a daily calorie residual.
+ *
+ * A positive residual means the model over-predicts expenditure relative to
+ * the scale (could be under-logging OR lower-than-predicted activity OR water
+ * noise). A negative residual means the opposite.
+ *
+ * This function explicitly declines to label the residual as "metabolic
+ * adaptation" because scale + food-log data cannot separate that from
+ * logging error and water weight noise.
+ *
+ * @param {Array}  rows     - Rows with tdee_block and calories
+ * @param {object} bmrModel
+ * @returns {{ medianKcalPerDay, sdKcalPerDay, note } | null}
+ */
+export function computeLoggingResidual(rows, bmrModel) {
+  if (!bmrModel || bmrModel.error) return null;
+
+  const C = ANALYSIS_CONFIG;
+  const palKeys = Object.keys(C.PAL_RANGES).map(Number).sort((a, b) => a - b);
+
+  // For each row with both tdee_block and actual calories, compute:
+  // residual = predictedTDEE(by PAL model) - observedTDEE(block estimate)
+  const residuals = [];
+  for (const r of rows) {
+    if (r.tdee_block == null || r.calories == null) continue;
+    const bump = r.trainingBump || 0;
+    const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
+    const pal = bmrModel.pals?.[palKey];
+    if (!pal) continue;
+    const wtKg = r.wt_smooth_lb != null ? r.wt_smooth_lb * C.LB_TO_KG : null;
+    if (!wtKg) continue;
+    const predictedTDEE = (bmrModel.a + bmrModel.b * wtKg + (bmrModel.adaptation || 0)) * pal;
+    residuals.push(predictedTDEE - r.tdee_block);
+  }
+
+  if (residuals.length < 5) return null;
+
+  const med = Math.round(median(residuals));
+  const sd = Math.round(stdDev(residuals));
+
+  let note;
+  if (Math.abs(med) < 100) {
+    note = 'Model and observations agree closely.';
+  } else if (med > 0) {
+    note = `Model predicts ~${med} kcal/day more than observed — could reflect under-logging, lower actual activity, or water noise. Cannot distinguish from scale data alone.`;
+  } else {
+    note = `Model predicts ~${Math.abs(med)} kcal/day less than observed — could reflect over-logging, higher actual activity, or water noise. Cannot distinguish from scale data alone.`;
+  }
+
+  return { medianKcalPerDay: med, sdKcalPerDay: sd, note };
+}
+
+// ==========================================
+// STEP 6: CALORIE IMPUTATION
+// ==========================================
+
 export function imputeCalories(rows, bmrModel) {
   const C = ANALYSIS_CONFIG;
   const result = rows.map(r => ({ ...r, calories_imputed: false, impute_status: null }));
@@ -475,42 +876,28 @@ export function imputeCalories(rows, bmrModel) {
 
   for (let i = 1; i < result.length; i++) {
     const r = result[i];
-
-    // Only impute if calories are missing
     if (r.calories != null) continue;
 
-    // Gate 1: must be old enough
     const age = daysBetween(r.date, today);
-    if (age < C.IMPUTE_LAG_DAYS) {
-      r.impute_status = 'pending';
-      continue;
-    }
+    if (age < C.IMPUTE_LAG_DAYS) { r.impute_status = 'pending'; continue; }
 
-    // Gate 2: need smoothed weight at this day and the previous day
     if (r.wt_smooth_lb == null || result[i - 1].wt_smooth_lb == null) {
       r.impute_status = 'insufficient_weight_data';
       continue;
     }
 
-    // Gate 3: need enough future weight readings (use the full configured threshold,
-    // not Math.min(..., 3) which would silently cap it to 3 and allow imputation
-    // on far sparser follow-up data than IMPUTE_MIN_FUTURE_WEIGHTS advertises).
     const futureWeights = result.slice(i + 1, i + 1 + C.IMPUTE_MIN_FUTURE_WEIGHTS)
       .filter(fr => fr.weight_lb != null);
-    if (futureWeights.length < C.IMPUTE_MIN_FUTURE_WEIGHTS) {
-      r.impute_status = 'pending';
-      continue;
-    }
+    if (futureWeights.length < C.IMPUTE_MIN_FUTURE_WEIGHTS) { r.impute_status = 'pending'; continue; }
 
-    // Predict TDEE for this day
     const bump = r.trainingBump || 0;
-    const palKey = palKeys.reduce((best, k) => Math.abs(k - bump) < Math.abs(best - bump) ? k : best, palKeys[0]);
-    const pal = bmrModel.pals[palKey];
-    const wtKg = r.wt_smooth_lb * C.LB_TO_KG;
-    const predictedBMR = bmrModel.a + bmrModel.b * wtKg + bmrModel.adaptation;
-    const predictedTDEE = predictedBMR * pal;
+    const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
+    const pal = bmrModel.pals?.[palKey];
+    if (!pal) { r.impute_status = 'insufficient_weight_data'; continue; }
 
-    // Infer calories from weight change
+    const wtKg = r.wt_smooth_lb * C.LB_TO_KG;
+    const predictedBMR = (bmrModel.a || 0) + (bmrModel.b || 0) * wtKg + (bmrModel.adaptation || 0);
+    const predictedTDEE = predictedBMR > 0 ? predictedBMR * pal : (bmrModel.tdee_current || 2000);
     const deltaKg = (r.wt_smooth_lb - result[i - 1].wt_smooth_lb) * C.LB_TO_KG;
     const calHat = predictedTDEE + C.ENERGY_DENSITY_KCAL_PER_KG * deltaKg;
 
@@ -522,7 +909,6 @@ export function imputeCalories(rows, bmrModel) {
       r.impute_status = 'out_of_range';
     }
   }
-
   return result;
 }
 
@@ -530,31 +916,19 @@ export function imputeCalories(rows, bmrModel) {
 // STEP 7: PLATEAU DETECTION
 // ==========================================
 
-/**
- * Detect whether the user is in a weight loss plateau.
- * Uses the slope of smoothed weight over the last N days.
- * @param {Array} rows - Daily rows with wt_smooth_lb
- * @returns {object} { isPlateaued, slopeLbPerWeek, daysCovered, message }
- */
 export function detectPlateau(rows) {
   const C = ANALYSIS_CONFIG;
-  const windowDays = C.PLATEAU_WINDOW_DAYS;
-
-  // Get rows from the last N days that have smoothed weight
-  const recent = rows.slice(-windowDays).filter(r => r.wt_smooth_lb != null);
+  const recent = rows.slice(-C.PLATEAU_WINDOW_DAYS).filter(r => r.wt_smooth_lb != null);
 
   if (recent.length < 10) {
     return { isPlateaued: false, slopeLbPerWeek: null, daysCovered: 0, message: 'Not enough recent weight data for plateau detection.' };
   }
 
-  // Compute slope via linear regression (days as x, weight as y)
   const firstDate = recent[0].date;
   const xs = recent.map(r => daysBetween(firstDate, r.date));
   const ys = recent.map(r => r.wt_smooth_lb);
-
   const { slope } = linearRegression(xs, ys);
   const slopeLbPerWeek = slope * 7;
-
   const isPlateaued = Math.abs(slopeLbPerWeek) < C.PLATEAU_SLOPE_THRESHOLD_LB_PER_WEEK;
 
   let message;
@@ -573,25 +947,7 @@ export function detectPlateau(rows) {
 // BLANK DAY POPULATION
 // ==========================================
 
-/**
- * Return all days eligible to be filled with estimated nutrient data.
- *
- * A day qualifies when:
- *  - Its date is on or after the first date that has REAL (non-imputed) food data.
- *  - The engine successfully imputed a calorie value for it (calories_imputed === true).
- *
- * Each returned object is a ready-to-save Firestore entry whose macros sum to
- * the imputed calorie total (protein and fat are taken from the user's baseline
- * targets; carbs fill the remainder).  All micronutrient fields are set to the
- * baseline targets so that the saved document represents a plausible day.
- *
- * @param {Array}  rows            - Output of imputeCalories() (rows with calories_imputed).
- * @param {Map}    dailyEntries    - state.dailyEntries
- * @param {object} baselineTargets - state.baselineTargets
- * @returns {Array<object>} Estimated daily entries, one per eligible blank day.
- */
 export function getBlankDaysForPopulation(rows, dailyEntries, baselineTargets) {
-  // Find the earliest date with genuinely logged food (not imputed).
   const firstFoodRow = rows.find(r => {
     if (!r.calories_imputed && r.calories != null) {
       const entry = dailyEntries.get(r.date);
@@ -609,28 +965,19 @@ export function getBlankDaysForPopulation(rows, dailyEntries, baselineTargets) {
     'selenium', 'iodine', 'phosphorus', 'iron', 'zinc', 'omega3',
   ];
 
-  // ── Compute per-nutrient averages from all actually-logged days ──────────
-  // Using the historical average of what the user actually ate is a better
-  // estimate for a blank day than the static baseline target, which may differ
-  // substantially from habitual intake.  Falls back to the baseline target only
-  // when no logged data exists for a given nutrient.
   const loggedEntries = [];
   for (const entry of dailyEntries.values()) {
     if ((parseFloat(entry.calories) || 0) > 0) loggedEntries.push(entry);
   }
 
   function avgNutrient(key, fallback) {
-    const vals = loggedEntries
-      .map(e => parseFloat(e[key]))
-      .filter(v => !isNaN(v) && v > 0);
+    const vals = loggedEntries.map(e => parseFloat(e[key])).filter(v => !isNaN(v) && v > 0);
     if (vals.length === 0) return fallback ?? 0;
     return vals.reduce((a, b) => a + b, 0) / vals.length;
   }
 
   const avgProtein = avgNutrient('protein', parseFloat(baselineTargets.protein) || 150);
-  const avgFat     = avgNutrient('fat',     parseFloat(baselineTargets.fatMinimum ?? baselineTargets.fat) || 50);
-
-  // Pre-compute micro averages once (not per-row).
+  const avgFat = avgNutrient('fat', parseFloat(baselineTargets.fatMinimum ?? baselineTargets.fat) || 50);
   const avgMicros = {};
   for (const key of MICRO_KEYS) {
     avgMicros[key] = avgNutrient(key, parseFloat(baselineTargets[key]) || 0);
@@ -642,13 +989,8 @@ export function getBlankDaysForPopulation(rows, dailyEntries, baselineTargets) {
       const existingEntry = dailyEntries.get(r.date) || {};
       const trainingBump = parseFloat(existingEntry.trainingBump) || 0;
       const estCals = r.calories;
-
-      // Carbs absorb the remainder after protein and fat floors.
       const carbsG = Math.max(0, Math.round((estCals - avgProtein * 4 - avgFat * 9) / 4));
 
-      // The food item carries ALL nutrients so that when the user adjusts quantity
-      // (or removes the item), updateItemQuantity() correctly recomputes every
-      // entry-level nutrient total — macros and micros alike.
       const foodItem = {
         id: `est-${r.date}`,
         name: "Day's estimate",
@@ -662,11 +1004,7 @@ export function getBlankDaysForPopulation(rows, dailyEntries, baselineTargets) {
       };
 
       const now = new Date().toISOString();
-
-      // Build the entry with nutrient totals mirroring qty=1 × foodItem values.
-      // schemaVersion=2 marks this as a v2 entry; entryType='estimate' lets the
-      // UI and export layer distinguish it from manually-logged days.
-      const entry = {
+      return {
         date: r.date,
         schemaVersion: 2,
         entryType: 'estimate',
@@ -682,7 +1020,7 @@ export function getBlankDaysForPopulation(rows, dailyEntries, baselineTargets) {
         calorieAdjustmentItems: [],
         estimateMeta: {
           method: 'tdee_weight_delta',
-          modelVersion: '1.0',
+          modelVersion: '2.0',
           confidence: 'medium',
           sourceDataWindow: ANALYSIS_CONFIG.TDEE_BLOCK_DAYS,
           createdAt: now,
@@ -691,43 +1029,54 @@ export function getBlankDaysForPopulation(rows, dailyEntries, baselineTargets) {
         },
         ...avgMicros,
       };
-
-      return entry;
     });
 }
 
 // ==========================================
-// MAIN PIPELINE: run all steps
+// MAIN PIPELINE
 // ==========================================
 
 /**
  * Run the full analysis pipeline.
- * @param {Map} weightEntries - From state.weightEntries
- * @param {Map} dailyEntries  - From state.dailyEntries
+ *
+ * @param {Map}         weightEntries      - state.weightEntries
+ * @param {Map}         dailyEntries       - state.dailyEntries
+ * @param {object|null} profile            - state.userProfile (for preferred window + profile RMR)
+ * @param {Map|null}    weightEntriesMulti - state.weightEntriesMulti (multi-weigh-in map)
  * @returns {object} Complete analysis results
  */
-export function runAnalysis(weightEntries, dailyEntries) {
+export function runAnalysis(weightEntries, dailyEntries, profile = null, weightEntriesMulti = null) {
   if (weightEntries.size === 0) {
     return { error: 'No weight data. Upload a weight CSV to begin analysis.', rows: [] };
   }
 
-  // Step 1: Merge
-  let rows = mergeDailyData(weightEntries, dailyEntries);
+  // Step 1: Merge (preferred-window weigh-in selection)
+  let rows = mergeDailyData(weightEntries, dailyEntries, weightEntriesMulti, profile);
   if (rows.length < 7) {
     return { error: 'Not enough data for analysis (need at least 7 days).', rows };
   }
 
-  // Step 2: Water correction
-  rows = waterCorrect(rows);
+  // Step 2: Water correction (returns {rows, uncertaintyLb})
+  const { rows: correctedRows, uncertaintyLb: waterWeightUncertaintyLb } = waterCorrect(rows);
+  rows = correctedRows;
 
   // Step 3: Smooth
   rows = smoothWeight(rows);
 
-  // Step 4: TDEE
+  // Step 4: TDEE (14-day rolling)
   rows = estimateTDEE(rows);
 
-  // Step 5: BMR
-  const bmrModel = estimateBMR(rows);
+  // Step 4b: Multi-horizon TDEE
+  const tdeeByHorizon = estimateTDEEByHorizon(rows);
+
+  // Profile RMR (used as prior/fallback)
+  const withWeight = rows.filter(r => r.wt_smooth_lb != null);
+  const latestWeightLb = withWeight.length > 0 ? withWeight[withWeight.length - 1].wt_smooth_lb : null;
+  const profileRmrResult = estimateProfileRmr(profile, latestWeightLb);
+  const profileRmrKcal = profileRmrResult?.rmr ?? null;
+
+  // Step 5: BMR (with profile prior)
+  const bmrModel = estimateBMR(rows, profileRmrKcal);
 
   // Step 6: Impute
   rows = imputeCalories(rows, bmrModel);
@@ -735,10 +1084,15 @@ export function runAnalysis(weightEntries, dailyEntries) {
   // Step 7: Plateau
   const plateau = detectPlateau(rows);
 
+  // Confidence
+  const confidence = computeConfidence(rows, bmrModel);
+
+  // Logging residual
+  const loggingResidual = computeLoggingResidual(rows, bmrModel);
+
   // Summary stats
-  const withWeight = rows.filter(r => r.wt_smooth_lb != null);
-  const currentWeight = withWeight.length > 0 ? withWeight[withWeight.length - 1].wt_smooth_lb : null;
   const startWeight = withWeight.length > 0 ? withWeight[0].wt_smooth_lb : null;
+  const currentWeight = latestWeightLb;
 
   const imputedDays = rows.filter(r => r.calories_imputed);
   const pendingDays = rows.filter(r => r.impute_status === 'pending');
@@ -747,6 +1101,11 @@ export function runAnalysis(weightEntries, dailyEntries) {
     rows,
     bmrModel,
     plateau,
+    tdeeByHorizon,
+    waterWeightUncertaintyLb,
+    loggingResidual,
+    confidence,
+    profileRmr: profileRmrResult,
     summary: {
       currentWeight: currentWeight ? +currentWeight.toFixed(1) : null,
       startWeight: startWeight ? +startWeight.toFixed(1) : null,
@@ -758,6 +1117,13 @@ export function runAnalysis(weightEntries, dailyEntries) {
       daysPendingImputation: pendingDays.length,
       tdee: bmrModel.error ? null : bmrModel.tdee_current,
       bmr: bmrModel.error ? null : bmrModel.bmr_current,
+      observedTdee: bmrModel.observedTdee ?? null,
+      restDayCaloriesOut: bmrModel.empiricalRestDayExp ?? bmrModel.tdee_rest_day ?? null,
+      profilePredictedRmr: profileRmrKcal,
+      confidenceLabel: confidence.label,
+      confidenceScore: confidence.score,
+      confidenceReasons: confidence.reasons,
+      waterWeightUncertaintyLb,
     },
   };
 }

--- a/public/tools/CalorieTracker/analysis/engine.js
+++ b/public/tools/CalorieTracker/analysis/engine.js
@@ -117,6 +117,16 @@ function dateOffset(dateStr, offsetDays) {
   return d.toISOString().slice(0, 10);
 }
 
+/** Return the PAL bucket key (0 | 100 | 280 | 400) nearest to `bump`. */
+function nearestPalKey(palKeys, bump) {
+  return palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
+}
+
+/** Resolve exercise calories for a merged row: sessions take priority over legacy bump. */
+function rowExerciseCalories(r) {
+  return r.exerciseCalories != null ? r.exerciseCalories : (r.trainingBump || 0);
+}
+
 /**
  * Solve Ax = b via Gauss-Jordan elimination with partial pivoting.
  * Returns the solution vector or null if the system is singular.
@@ -498,7 +508,7 @@ export function estimateTDEE(rows) {
   for (let i = blockDays; i < result.length; i++) {
     const window = result.slice(i - blockDays, i + 1);
     const cals = window.map(r => r.calories).filter(c => c != null);
-    if (cals.length < blockDays * 0.7) continue;
+    if (cals.length < window.length * 0.7) continue;
 
     const wStart = window[0].wt_smooth_lb;
     const wEnd = window[window.length - 1].wt_smooth_lb;
@@ -510,7 +520,7 @@ export function estimateTDEE(rows) {
     const tdee = avgIntake - avgStorage;
 
     if (tdee >= C.TDEE_PLAUSIBLE_MIN && tdee <= C.TDEE_PLAUSIBLE_MAX) {
-      const calCoverage = cals.length / blockDays;
+      const calCoverage = cals.length / window.length;
       result[i].tdee_block = Math.round(tdee);
       result[i].calCoverage = +calCoverage.toFixed(2);
       result[i].tdee_block_quality = calCoverage >= 0.85 ? 'high' : 'medium';
@@ -681,22 +691,28 @@ export function estimateProfileRmr(profile, weightLb) {
  *    is flagged as potential logging noise rather than labelled "metabolic
  *    adaptation" (which would over-claim biological certainty).
  *
- * Returns an extended object that now includes:
- *  - profilePredictedRmr   : from Mifflin-St Jeor / Cunningham / weight-only
- *  - observedTdee          : trimmed mean of all valid block estimates
- *  - empiricalRestDayExp   : trimmed mean of block estimates on rest days
- *  - loggingResidualNote   : plain-language flag about residual size
+ * Returns an extended object including:
+ *  - profilePredictedRmr      : from Mifflin-St Jeor / Cunningham / weight-only
+ *  - observedTdee             : trimmed mean of high-quality block estimates
+ *  - modelPredictedRestDayTdee: fittedBmr × restPal (model output, not empirical)
+ *  - fittedDataQuality        : 'high' | 'mixed' — whether the fit used only full-coverage blocks
+ *  - loggingResidualNote      : plain-language flag about residual size
  */
 export function estimateBMR(rows, profileRmrKcal = null) {
   const C = ANALYSIS_CONFIG;
 
   const valid = rows.filter(r => r.tdee_block != null && r.wt_smooth_lb != null);
 
-  // Observed TDEE: prefer high-quality blocks when enough exist
+  // Prefer high-quality blocks (full calorie coverage) for all estimates
   const highQualValid = valid.filter(r => r.tdee_block_quality === 'high');
   const tdeeSource = highQualValid.length >= 5 ? highQualValid : valid;
   const allTDEEs = tdeeSource.map(r => r.tdee_block);
   const observedTdee = allTDEEs.length >= 5 ? Math.round(trimmedMean(allTDEEs)) : null;
+
+  // Use high-quality blocks for BMR fitting when enough exist;
+  // 20 matches the minimum post-outlier-rejection count in tryPals.
+  const fitSource = highQualValid.length >= 20 ? highQualValid : valid;
+  const fittedDataQuality = fitSource === highQualValid ? 'high' : 'mixed';
 
   if (valid.length < 30) {
     // Not enough data for grid search — use profile RMR as fallback if available
@@ -719,6 +735,7 @@ export function estimateBMR(rows, profileRmrKcal = null) {
         modelPredictedRestDayTdee: tdeeRestDay,
         observedTdee,
         profilePredictedRmr: profileRmrKcal,
+        fittedDataQuality: null,
         score: null,
         source: 'profile_prior',
         insufficientData: true,
@@ -744,10 +761,8 @@ export function estimateBMR(rows, profileRmrKcal = null) {
 
   function tryPals(pals) {
     const wts = [], bmrs = [];
-    for (const r of valid) {
-      // Use exerciseCalories when available, fall back to legacy trainingBump
-      const bump = r.exerciseCalories != null ? r.exerciseCalories : (r.trainingBump || 0);
-      const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
+    for (const r of fitSource) {
+      const palKey = nearestPalKey(palKeys, rowExerciseCalories(r));
       const impliedBMR = r.tdee_block / pals[palKey];
       wts.push(r.wt_smooth_lb * C.LB_TO_KG);
       bmrs.push(impliedBMR);
@@ -805,8 +820,7 @@ export function estimateBMR(rows, profileRmrKcal = null) {
 
   const recent = valid.slice(-21);
   const adaptResiduals = recent.map(r => {
-    const bump = r.exerciseCalories != null ? r.exerciseCalories : (r.trainingBump || 0);
-    const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
+    const palKey = nearestPalKey(palKeys, rowExerciseCalories(r));
     const impliedBMR = r.tdee_block / bestPals[palKey];
     const fittedBMR = bestModel.a + bestModel.b * r.wt_smooth_lb * C.LB_TO_KG;
     return impliedBMR - fittedBMR;
@@ -847,6 +861,7 @@ export function estimateBMR(rows, profileRmrKcal = null) {
     observedTdee,
     profilePredictedRmr: profileRmrKcal,
     loggingResidualNote,
+    fittedDataQuality,
     score: bestScore,
     source: 'fitted',
   };
@@ -918,6 +933,10 @@ export function computeConfidence(rows, bmrModel) {
     reasons.push('Using profile-based estimate — not enough data yet for a fitted model.');
   }
 
+  if (bmrModel?.fittedDataQuality === 'mixed') {
+    reasons.push('BMR fit includes some weeks with incomplete calorie logs — vacation or logging gaps may reduce model precision.');
+  }
+
   return { label, score, reasons, daysWithWeight, daysWithLoggedCalories };
 }
 
@@ -952,8 +971,7 @@ export function computeLoggingResidual(rows, bmrModel) {
   const residuals = [];
   for (const r of rows) {
     if (r.tdee_block == null || r.calories == null) continue;
-    const bump = r.trainingBump || 0;
-    const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
+    const palKey = nearestPalKey(palKeys, rowExerciseCalories(r));
     const pal = bmrModel.pals?.[palKey];
     if (!pal) continue;
     const wtKg = r.wt_smooth_lb != null ? r.wt_smooth_lb * C.LB_TO_KG : null;
@@ -1010,8 +1028,7 @@ export function imputeCalories(rows, bmrModel) {
       .filter(fr => fr.weight_lb != null);
     if (futureWeights.length < C.IMPUTE_MIN_FUTURE_WEIGHTS) { r.impute_status = 'pending'; continue; }
 
-    const bump = r.trainingBump || 0;
-    const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
+    const palKey = nearestPalKey(palKeys, rowExerciseCalories(r));
     const pal = bmrModel.pals?.[palKey];
     if (!pal) { r.impute_status = 'insufficient_weight_data'; continue; }
 

--- a/public/tools/CalorieTracker/analysis/engine.js
+++ b/public/tools/CalorieTracker/analysis/engine.js
@@ -56,8 +56,8 @@ export const ANALYSIS_CONFIG = {
   // Default preferred weigh-in window: 6–9 AM (minutes from midnight)
   WEIGH_IN_WINDOW_DEFAULT: { startMin: 360, endMin: 540 },
 
-  // Minimum rest-day blocks needed to compute empirical rest-day expenditure
-  MIN_REST_DAY_BLOCKS: 5,
+  // Maximum per-day water-weight correction magnitude in lb
+  MAX_WATER_CORRECTION_LB: 2.0,
 };
 
 // ==========================================
@@ -109,6 +109,12 @@ function linearRegression(xs, ys) {
 
 function daysBetween(a, b) {
   return Math.round((new Date(b + 'T00:00:00') - new Date(a + 'T00:00:00')) / 86400000);
+}
+
+function dateOffset(dateStr, offsetDays) {
+  const d = new Date(dateStr + 'T00:00:00');
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
 }
 
 /**
@@ -205,6 +211,56 @@ export function selectDailyWeight(readings, preferredWindow = null) {
 }
 
 // ==========================================
+// EXERCISE CALORIES DERIVATION
+// ==========================================
+
+/**
+ * Derive exercise calories from a nutrition entry's exerciseSessions array or
+ * fall back to the legacy trainingBump field.
+ *
+ * Priority per session: manualCalories > wearableCalories > estimatedCalories
+ * If no sessions, falls back to trainingBump.
+ *
+ * @param {object|null} nEntry - nutrition entry (dailyEntries value)
+ * @returns {{ exerciseCalories, exerciseSource, exerciseSessionCount, legacyTrainingBumpUsed }}
+ */
+export function deriveExerciseCalories(nEntry) {
+  const sessions = nEntry?.exerciseSessions;
+  let exerciseCalories = 0;
+  let exerciseSource = 'none';
+  let exerciseSessionCount = 0;
+  let legacyTrainingBumpUsed = false;
+
+  if (Array.isArray(sessions) && sessions.length > 0) {
+    exerciseSessionCount = sessions.length;
+    let totalCals = 0;
+    let dominantSource = 'estimated';
+    for (const s of sessions) {
+      if (s.manualCalories != null && s.manualCalories > 0) {
+        totalCals += s.manualCalories;
+        dominantSource = 'manual';
+      } else if (s.wearableCalories != null && s.wearableCalories > 0) {
+        totalCals += s.wearableCalories;
+        if (dominantSource === 'estimated') dominantSource = 'wearable';
+      } else if (s.estimatedCalories != null && s.estimatedCalories > 0) {
+        totalCals += s.estimatedCalories;
+      }
+    }
+    exerciseCalories = totalCals;
+    exerciseSource = dominantSource;
+  } else {
+    const bump = parseFloat(nEntry?.trainingBump) || 0;
+    if (bump > 0) {
+      exerciseCalories = bump;
+      exerciseSource = 'legacy_bump';
+      legacyTrainingBumpUsed = true;
+    }
+  }
+
+  return { exerciseCalories, exerciseSource, exerciseSessionCount, legacyTrainingBumpUsed };
+}
+
+// ==========================================
 // STEP 1: MERGE weight + nutrition into daily rows
 // ==========================================
 
@@ -251,6 +307,7 @@ export function mergeDailyData(weightEntries, dailyEntries, weightEntriesMulti =
     const wEntry = weightByDate.get(dateStr);
     const nEntry = dailyEntries.get(dateStr);
 
+    const exFields = deriveExerciseCalories(nEntry || null);
     dateMap.set(dateStr, {
       date: dateStr,
       weight_lb: wEntry ? wEntry.weight_lb : null,
@@ -260,6 +317,7 @@ export function mergeDailyData(weightEntries, dailyEntries, weightEntriesMulti =
       carbs: nEntry ? (parseFloat(nEntry.carbs) || null) : null,
       fiber: nEntry ? (parseFloat(nEntry.fiber) || null) : null,
       trainingBump: nEntry ? (parseFloat(nEntry.trainingBump) || 0) : 0,
+      ...exFields,
     });
   }
 
@@ -310,6 +368,7 @@ export function waterCorrect(rows) {
 
   let correctFn = null;   // (row) => correction in lb
   let uncertaintyLb = null;
+  let usedOLS = false;
 
   if (trainRows.length >= C.MIN_DAYS_FOR_WATER_REGRESSION) {
     // Standardise predictors
@@ -346,6 +405,7 @@ export function waterCorrect(rows) {
             + beta[2] * (r.carbs - carbMean) / carbSd
             + (useFiber ? beta[3] * fib : 0);
         };
+        usedOLS = true;
 
         const residAfter = fitRows.map(r => {
           const resid = r.weight_lb - r._baseline;
@@ -391,15 +451,22 @@ export function waterCorrect(rows) {
     }
   }
 
-  // Apply corrections
+  // Apply corrections with per-day cap to prevent over-correction
+  const CAP = C.MAX_WATER_CORRECTION_LB;
   for (const r of result) {
     if (r.weight_lb == null) { r.weight_corr = null; r._waterCorrection = 0; continue; }
-    const corr = correctFn(r);
+    const rawCorr = correctFn(r);
+    const corr = Math.min(Math.max(rawCorr, -CAP), CAP);
     r._waterCorrection = corr;
     r.weight_corr = r.weight_lb - corr;
   }
 
-  return { rows: result, uncertaintyLb: uncertaintyLb ?? null };
+  return {
+    rows: result,
+    uncertaintyLb: uncertaintyLb ?? null,
+    waterCorrectionMethod: usedOLS ? 'ols_regression' : 'median_bucket_adaptive',
+    predictorDays: trainRows.length,
+  };
 }
 
 // ==========================================
@@ -443,7 +510,10 @@ export function estimateTDEE(rows) {
     const tdee = avgIntake - avgStorage;
 
     if (tdee >= C.TDEE_PLAUSIBLE_MIN && tdee <= C.TDEE_PLAUSIBLE_MAX) {
+      const calCoverage = cals.length / blockDays;
       result[i].tdee_block = Math.round(tdee);
+      result[i].calCoverage = +calCoverage.toFixed(2);
+      result[i].tdee_block_quality = calCoverage >= 0.85 ? 'high' : 'medium';
     }
   }
   return result;
@@ -454,31 +524,73 @@ export function estimateTDEE(rows) {
 // ==========================================
 
 /**
- * Compute aggregate TDEE estimates at multiple horizons.
- * Uses the same block logic as estimateTDEE but condenses each horizon
- * into a single point estimate (trimmed mean of all block estimates within
- * that window from the end of the record).
+ * Compute aggregate TDEE estimates at multiple horizons using calendar-date cutoffs.
  *
- * @param {Array} rows - Rows with tdee_block populated
+ * Window = [latestDate - (horizonDays-1), latestDate] — exactly `horizonDays` calendar
+ * days regardless of how many valid block rows fall within it.
+ *
+ * High-quality blocks (calCoverage ≥ 0.85) are preferred when ≥ 5 exist; otherwise
+ * all plausible blocks in the window are used.
+ *
+ * @param {Array} rows - Rows with tdee_block populated (output of estimateTDEE)
  * @returns {object} { 14: {...}, 28: {...}, 42: {...}, 56: {...} }
  */
 export function estimateTDEEByHorizon(rows) {
   const C = ANALYSIS_CONFIG;
   const horizons = C.HORIZONS;
   const result = {};
-  const valid = rows.filter(r => r.tdee_block != null && r.wt_smooth_lb != null);
+
+  const allValid = rows.filter(r => r.tdee_block != null && r.wt_smooth_lb != null);
+  if (allValid.length === 0) {
+    for (const [label, days] of Object.entries(horizons)) {
+      result[days] = {
+        tdee: null, daysUsed: 0, available: false, label,
+        calendarStart: null, calendarEnd: null, blockCount: 0,
+        coveragePct: 0, daysWindow: days, reason: 'no_data',
+      };
+    }
+    return result;
+  }
+
+  const latestDate = allValid[allValid.length - 1].date;
 
   for (const [label, days] of Object.entries(horizons)) {
-    const windowRows = valid.slice(-days);
-    const tdees = windowRows.map(r => r.tdee_block).filter(t => t != null);
+    const cutoffDate = dateOffset(latestDate, -(days - 1));
+    const windowRows = allValid.filter(r => r.date >= cutoffDate);
+
+    const highRows = windowRows.filter(r => r.tdee_block_quality === 'high');
+    const primaryRows = highRows.length >= 5 ? highRows : windowRows;
+    const tdees = primaryRows.map(r => r.tdee_block);
+
+    const calendarStart = windowRows.length > 0 ? windowRows[0].date : cutoffDate;
+    const blockCount = tdees.length;
+    const coveragePct = Math.round(100 * windowRows.length / days);
+
     if (tdees.length < 5) {
-      result[days] = { tdee: null, daysUsed: tdees.length, available: false, label };
+      result[days] = {
+        tdee: null,
+        daysUsed: tdees.length,
+        available: false,
+        label,
+        calendarStart,
+        calendarEnd: latestDate,
+        blockCount,
+        coveragePct,
+        daysWindow: days,
+        reason: 'insufficient_blocks',
+      };
     } else {
       result[days] = {
         tdee: Math.round(trimmedMean(tdees)),
         daysUsed: tdees.length,
         available: true,
         label,
+        calendarStart,
+        calendarEnd: latestDate,
+        blockCount,
+        coveragePct,
+        daysWindow: days,
+        reason: highRows.length >= 5 ? 'high_quality_blocks' : 'mixed_quality_blocks',
       };
     }
   }
@@ -580,32 +692,32 @@ export function estimateBMR(rows, profileRmrKcal = null) {
 
   const valid = rows.filter(r => r.tdee_block != null && r.wt_smooth_lb != null);
 
-  // Observed TDEE across all block estimates (not model-dependent)
-  const allTDEEs = valid.map(r => r.tdee_block).filter(t => t != null);
+  // Observed TDEE: prefer high-quality blocks when enough exist
+  const highQualValid = valid.filter(r => r.tdee_block_quality === 'high');
+  const tdeeSource = highQualValid.length >= 5 ? highQualValid : valid;
+  const allTDEEs = tdeeSource.map(r => r.tdee_block);
   const observedTdee = allTDEEs.length >= 5 ? Math.round(trimmedMean(allTDEEs)) : null;
-
-  // Empirical rest-day expenditure: block estimates on days with trainingBump=0
-  const restValid = valid.filter(r => (r.trainingBump || 0) === 0);
-  const restTDEEs = restValid.map(r => r.tdee_block).filter(t => t != null);
-  const empiricalRestDayExp = restTDEEs.length >= C.MIN_REST_DAY_BLOCKS
-    ? Math.round(trimmedMean(restTDEEs))
-    : null;
 
   if (valid.length < 30) {
     // Not enough data for grid search — use profile RMR as fallback if available
     if (profileRmrKcal && profileRmrKcal > 0) {
       const restPal = 1.30; // conservative rest-day PAL
+      const tdeeRestDay = Math.round(profileRmrKcal * restPal);
       return {
         pals: { 0: restPal, 100: 1.45, 280: 1.58, 400: 1.70 },
         a: 0, b: 0,
+        fittedBmr: profileRmrKcal,
         bmr_current: profileRmrKcal,
         bmr_baseline: profileRmrKcal,
+        modelResidual: 0,
+        modelResidualSd: 0,
+        // Deprecated aliases for backward compat
         adaptation: 0,
         adaptationSD: 0,
-        tdee_current: observedTdee ?? Math.round(profileRmrKcal * restPal),
-        tdee_rest_day: Math.round(profileRmrKcal * restPal),
+        tdee_current: observedTdee ?? tdeeRestDay,
+        tdee_rest_day: tdeeRestDay,
+        modelPredictedRestDayTdee: tdeeRestDay,
         observedTdee,
-        empiricalRestDayExp,
         profilePredictedRmr: profileRmrKcal,
         score: null,
         source: 'profile_prior',
@@ -615,13 +727,11 @@ export function estimateBMR(rows, profileRmrKcal = null) {
     }
     return {
       observedTdee,
-      empiricalRestDayExp,
       profilePredictedRmr: profileRmrKcal,
       error: `Not enough data (need 30+ days with both weight and calorie data; have ${valid.length}).`,
     };
   }
 
-  // Grid search (unchanged from v1)
   const palKeys = Object.keys(C.PAL_RANGES).map(Number).sort((a, b) => a - b);
   const grids = {};
   for (const k of palKeys) {
@@ -635,7 +745,8 @@ export function estimateBMR(rows, profileRmrKcal = null) {
   function tryPals(pals) {
     const wts = [], bmrs = [];
     for (const r of valid) {
-      const bump = r.trainingBump || 0;
+      // Use exerciseCalories when available, fall back to legacy trainingBump
+      const bump = r.exerciseCalories != null ? r.exerciseCalories : (r.trainingBump || 0);
       const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
       const impliedBMR = r.tdee_block / pals[palKey];
       wts.push(r.wt_smooth_lb * C.LB_TO_KG);
@@ -682,34 +793,38 @@ export function estimateBMR(rows, profileRmrKcal = null) {
   }
 
   if (!bestModel.a && bestModel.a !== 0) {
-    return { observedTdee, empiricalRestDayExp, profilePredictedRmr: profileRmrKcal, error: 'BMR model fitting failed.' };
+    return { observedTdee, profilePredictedRmr: profileRmrKcal, error: 'BMR model fitting failed.' };
   }
 
   const lastValid = [...valid].reverse().find(r => r.wt_smooth_lb != null);
   const currentWtKg = lastValid.wt_smooth_lb * C.LB_TO_KG;
   const bmrBase = bestModel.a + bestModel.b * currentWtKg;
 
+  // fittedBmr = pure regression output — no residual folded in
+  const fittedBmr = Math.round(bmrBase);
+
   const recent = valid.slice(-21);
   const adaptResiduals = recent.map(r => {
-    const bump = r.trainingBump || 0;
+    const bump = r.exerciseCalories != null ? r.exerciseCalories : (r.trainingBump || 0);
     const palKey = palKeys.reduce((b, k) => Math.abs(k - bump) < Math.abs(b - bump) ? k : b, palKeys[0]);
     const impliedBMR = r.tdee_block / bestPals[palKey];
     const fittedBMR = bestModel.a + bestModel.b * r.wt_smooth_lb * C.LB_TO_KG;
     return impliedBMR - fittedBMR;
   });
-  const adaptation = Math.round(median(adaptResiduals));
-  const adaptationSD = Math.round(stdDev(adaptResiduals));
+  // modelResidual is the ambiguous gap — could be logging error, water noise, or biology
+  const modelResidual = Math.round(median(adaptResiduals));
+  const modelResidualSd = Math.round(stdDev(adaptResiduals));
 
   const restPal = bestPals[0] || 1.3;
-  const tdeeRestDay = Math.round((bmrBase + adaptation) * restPal);
+  // tdee_rest_day uses pure fittedBmr — not inflated by residual
+  const tdeeRestDay = Math.round(bmrBase * restPal);
 
   const recentTDEEs = valid.slice(-21).map(r => r.tdee_block).filter(t => t != null);
   const tdeeRecent = recentTDEEs.length >= 7 ? Math.round(trimmedMean(recentTDEEs)) : tdeeRestDay;
 
-  // Flag large residuals plainly without claiming "metabolic adaptation"
   let loggingResidualNote = null;
-  if (Math.abs(adaptation) > 150) {
-    loggingResidualNote = Math.abs(adaptation) > 300
+  if (Math.abs(modelResidual) > 150) {
+    loggingResidualNote = Math.abs(modelResidual) > 300
       ? 'Large gap between predicted and observed energy balance — likely reflects logging gaps or water weight noise, not just biology.'
       : 'Moderate gap between predicted and observed balance — could be logging error, activity change, or water noise.';
   }
@@ -718,14 +833,18 @@ export function estimateBMR(rows, profileRmrKcal = null) {
     pals: bestPals,
     a: bestModel.a,
     b: bestModel.b,
-    bmr_current: Math.round(bmrBase + adaptation),
-    bmr_baseline: Math.round(bmrBase),
-    adaptation,
-    adaptationSD,
+    fittedBmr,
+    bmr_current: fittedBmr,
+    bmr_baseline: fittedBmr,
+    modelResidual,
+    modelResidualSd,
+    // Deprecated aliases for backward compat
+    adaptation: modelResidual,
+    adaptationSD: modelResidualSd,
     tdee_current: tdeeRecent,
     tdee_rest_day: tdeeRestDay,
+    modelPredictedRestDayTdee: tdeeRestDay,
     observedTdee,
-    empiricalRestDayExp,
     profilePredictedRmr: profileRmrKcal,
     loggingResidualNote,
     score: bestScore,
@@ -839,7 +958,8 @@ export function computeLoggingResidual(rows, bmrModel) {
     if (!pal) continue;
     const wtKg = r.wt_smooth_lb != null ? r.wt_smooth_lb * C.LB_TO_KG : null;
     if (!wtKg) continue;
-    const predictedTDEE = (bmrModel.a + bmrModel.b * wtKg + (bmrModel.adaptation || 0)) * pal;
+    // Use pure fitted BMR (no residual) — the residual IS the quantity we're measuring here
+    const predictedTDEE = (bmrModel.a + bmrModel.b * wtKg) * pal;
     residuals.push(predictedTDEE - r.tdee_block);
   }
 
@@ -896,7 +1016,8 @@ export function imputeCalories(rows, bmrModel) {
     if (!pal) { r.impute_status = 'insufficient_weight_data'; continue; }
 
     const wtKg = r.wt_smooth_lb * C.LB_TO_KG;
-    const predictedBMR = (bmrModel.a || 0) + (bmrModel.b || 0) * wtKg + (bmrModel.adaptation || 0);
+    // Use pure fitted BMR (no residual) so imputed calories reflect the structural model
+    const predictedBMR = (bmrModel.a || 0) + (bmrModel.b || 0) * wtKg;
     const predictedTDEE = predictedBMR > 0 ? predictedBMR * pal : (bmrModel.tdee_current || 2000);
     const deltaKg = (r.wt_smooth_lb - result[i - 1].wt_smooth_lb) * C.LB_TO_KG;
     const calHat = predictedTDEE + C.ENERGY_DENSITY_KCAL_PER_KG * deltaKg;
@@ -1056,8 +1177,13 @@ export function runAnalysis(weightEntries, dailyEntries, profile = null, weightE
     return { error: 'Not enough data for analysis (need at least 7 days).', rows };
   }
 
-  // Step 2: Water correction (returns {rows, uncertaintyLb})
-  const { rows: correctedRows, uncertaintyLb: waterWeightUncertaintyLb } = waterCorrect(rows);
+  // Step 2: Water correction (returns {rows, uncertaintyLb, waterCorrectionMethod, predictorDays})
+  const {
+    rows: correctedRows,
+    uncertaintyLb: waterWeightUncertaintyLb,
+    waterCorrectionMethod,
+    predictorDays: waterPredictorDays,
+  } = waterCorrect(rows);
   rows = correctedRows;
 
   // Step 3: Smooth
@@ -1103,6 +1229,8 @@ export function runAnalysis(weightEntries, dailyEntries, profile = null, weightE
     plateau,
     tdeeByHorizon,
     waterWeightUncertaintyLb,
+    waterCorrectionMethod,
+    waterPredictorDays,
     loggingResidual,
     confidence,
     profileRmr: profileRmrResult,
@@ -1118,12 +1246,13 @@ export function runAnalysis(weightEntries, dailyEntries, profile = null, weightE
       tdee: bmrModel.error ? null : bmrModel.tdee_current,
       bmr: bmrModel.error ? null : bmrModel.bmr_current,
       observedTdee: bmrModel.observedTdee ?? null,
-      restDayCaloriesOut: bmrModel.empiricalRestDayExp ?? bmrModel.tdee_rest_day ?? null,
+      restDayCaloriesOut: bmrModel.modelPredictedRestDayTdee ?? bmrModel.tdee_rest_day ?? null,
       profilePredictedRmr: profileRmrKcal,
       confidenceLabel: confidence.label,
       confidenceScore: confidence.score,
       confidenceReasons: confidence.reasons,
       waterWeightUncertaintyLb,
+      waterCorrectionMethod,
     },
   };
 }

--- a/public/tools/CalorieTracker/analysis/engine.test.js
+++ b/public/tools/CalorieTracker/analysis/engine.test.js
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   selectDailyWeight,
+  deriveExerciseCalories,
   mergeDailyData,
   waterCorrect,
   smoothWeight,
@@ -34,7 +35,6 @@ function isoDate(baseDate, offsetDays) {
 
 /**
  * Build a Map<docId, entry> weight entries from a daily weight array.
- * Each entry gets a deterministic doc ID.
  */
 function makeWeightEntries(data) {
   const map = new Map();
@@ -51,7 +51,10 @@ function makeWeightEntries(data) {
   return map;
 }
 
-/** Build a Map<date, entry> nutrition entries. */
+/**
+ * Build a Map<date, entry> nutrition entries.
+ * Supports exerciseSessions array (v2 schema).
+ */
 function makeNutritionEntries(data) {
   const map = new Map();
   data.forEach(d => {
@@ -65,6 +68,7 @@ function makeNutritionEntries(data) {
         fiber: d.fiber ?? 25,
         sodium: d.sodium ?? 2200,
         trainingBump: d.trainingBump ?? 0,
+        exerciseSessions: d.exerciseSessions ?? [],
       });
     }
   });
@@ -72,9 +76,7 @@ function makeNutritionEntries(data) {
 }
 
 /**
- * Generate N days of synthetic data starting from START_DATE.
- * @param {number} n - number of days
- * @param {function} dayFn - receives (index, date) and returns { weight_lb, calories, ... }
+ * Generate N days of synthetic data starting from startDate.
  */
 function syntheticDays(n, dayFn, startDate = '2024-01-01') {
   return Array.from({ length: n }, (_, i) => {
@@ -83,7 +85,7 @@ function syntheticDays(n, dayFn, startDate = '2024-01-01') {
   });
 }
 
-// ── Test scenarios ────────────────────────────────────────────────────────────
+// ── selectDailyWeight ─────────────────────────────────────────────────────────
 
 describe('selectDailyWeight', () => {
   it('returns the single reading when only one exists', () => {
@@ -93,8 +95,8 @@ describe('selectDailyWeight', () => {
 
   it('prefers reading inside the preferred window', () => {
     const readings = [
-      { weight_lb: 183, time_min: 900 },  // outside (3 PM)
-      { weight_lb: 181, time_min: 420 },  // inside window (7 AM)
+      { weight_lb: 183, time_min: 900 },
+      { weight_lb: 181, time_min: 420 },
     ];
     const window = { startMin: 360, endMin: 540 };
     expect(selectDailyWeight(readings, window)?.weight_lb).toBe(181);
@@ -106,15 +108,14 @@ describe('selectDailyWeight', () => {
       { weight_lb: 181, time_min: 1200 },
     ];
     const window = { startMin: 360, endMin: 540 };
-    // Both are outside window → pick earliest time_min
     expect(selectDailyWeight(readings, window)?.time_min).toBe(900);
   });
 
   it('uses median of in-window readings for robustness', () => {
     const readings = [
-      { weight_lb: 181, time_min: 400 },  // in window
-      { weight_lb: 182, time_min: 420 },  // in window
-      { weight_lb: 190, time_min: 430 },  // in window but high outlier
+      { weight_lb: 181, time_min: 400 },
+      { weight_lb: 182, time_min: 420 },
+      { weight_lb: 190, time_min: 430 }, // outlier
     ];
     const window = { startMin: 360, endMin: 540 };
     // Sorted in-window: [181, 182, 190] → median at index 1 = 182
@@ -122,13 +123,70 @@ describe('selectDailyWeight', () => {
   });
 });
 
+// ── deriveExerciseCalories ────────────────────────────────────────────────────
+
+describe('deriveExerciseCalories', () => {
+  it('returns zeros and source=none when entry is null', () => {
+    const result = deriveExerciseCalories(null);
+    expect(result.exerciseCalories).toBe(0);
+    expect(result.exerciseSource).toBe('none');
+    expect(result.legacyTrainingBumpUsed).toBe(false);
+  });
+
+  it('falls back to legacy trainingBump when no exerciseSessions', () => {
+    const entry = { trainingBump: 280, exerciseSessions: [] };
+    const result = deriveExerciseCalories(entry);
+    expect(result.exerciseCalories).toBe(280);
+    expect(result.exerciseSource).toBe('legacy_bump');
+    expect(result.legacyTrainingBumpUsed).toBe(true);
+  });
+
+  it('uses manualCalories as highest priority', () => {
+    const entry = {
+      trainingBump: 200,
+      exerciseSessions: [
+        { manualCalories: 350, wearableCalories: 300, estimatedCalories: 250 },
+      ],
+    };
+    const result = deriveExerciseCalories(entry);
+    expect(result.exerciseCalories).toBe(350);
+    expect(result.exerciseSource).toBe('manual');
+    expect(result.legacyTrainingBumpUsed).toBe(false);
+  });
+
+  it('uses wearableCalories when no manualCalories', () => {
+    const entry = {
+      exerciseSessions: [
+        { wearableCalories: 300, estimatedCalories: 200 },
+      ],
+    };
+    const result = deriveExerciseCalories(entry);
+    expect(result.exerciseCalories).toBe(300);
+    expect(result.exerciseSource).toBe('wearable');
+  });
+
+  it('sums calories across multiple sessions', () => {
+    const entry = {
+      exerciseSessions: [
+        { manualCalories: 300 },
+        { manualCalories: 200 },
+      ],
+    };
+    const result = deriveExerciseCalories(entry);
+    expect(result.exerciseCalories).toBe(500);
+    expect(result.exerciseSessionCount).toBe(2);
+  });
+});
+
+// ── Stable maintenance (60 days) ─────────────────────────────────────────────
+
 describe('Stable maintenance (60 days)', () => {
   const DAYS = 60;
   const MAINTENANCE_KCAL = 2200;
   const STABLE_WEIGHT_LB = 180;
 
   const days = syntheticDays(DAYS, (i) => ({
-    weight_lb: STABLE_WEIGHT_LB + (Math.sin(i) * 0.3), // tiny noise
+    weight_lb: STABLE_WEIGHT_LB + (Math.sin(i) * 0.3),
     calories: MAINTENANCE_KCAL,
     trainingBump: 0,
   }));
@@ -141,9 +199,10 @@ describe('Stable maintenance (60 days)', () => {
     expect(r.error).toBeUndefined();
   });
 
-  it('smoothed weight stays near starting weight', () => {
+  it('smoothed weight stays near starting weight (within 3 lb)', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
     const last = r.rows.filter(rw => rw.wt_smooth_lb != null).at(-1);
+    expect(last).toBeDefined();
     expect(Math.abs(last.wt_smooth_lb - STABLE_WEIGHT_LB)).toBeLessThan(3);
   });
 
@@ -164,7 +223,14 @@ describe('Stable maintenance (60 days)', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
     expect(['rough', 'moderate', 'high']).toContain(r.confidence.label);
   });
+
+  it('waterCorrectionMethod is reported', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    expect(['ols_regression', 'median_bucket_adaptive']).toContain(r.waterCorrectionMethod);
+  });
 });
+
+// ── Steady fat loss (60 days) ─────────────────────────────────────────────────
 
 describe('Steady fat loss (60 days, −0.5 lb/week)', () => {
   const DAYS = 60;
@@ -195,7 +261,7 @@ describe('Steady fat loss (60 days, −0.5 lb/week)', () => {
     }
   });
 
-  it('TDEE estimate is above intake (model must infer expenditure > intake)', () => {
+  it('TDEE estimate is above intake', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
     if (r.summary.tdee != null) {
       expect(r.summary.tdee).toBeGreaterThan(INTAKE - 100);
@@ -203,52 +269,326 @@ describe('Steady fat loss (60 days, −0.5 lb/week)', () => {
   });
 });
 
-describe('Under-reported calories (weight drops faster than calories suggest)', () => {
-  const DAYS = 60;
-  const TRUE_TDEE = 2400;
-  const LOGGED_KCAL = 1600;  // logs 600 less than actual
-  const TRUE_DEFICIT = TRUE_TDEE - 2000; // actual intake = 2000, gap = 400
-  const START_WEIGHT = 185;
-  const RATE_LB_PER_DAY = TRUE_DEFICIT / 7700 * 2.2046; // lbs/day
+// ── BMR correctness: no residual folded in ───────────────────────────────────
 
+describe('BMR model correctness (fix 3: no residual in bmr_current)', () => {
+  const DAYS = 60;
   const days = syntheticDays(DAYS, (i) => ({
-    weight_lb: START_WEIGHT - RATE_LB_PER_DAY * i + (Math.sin(i) * 0.15),
-    calories: LOGGED_KCAL, // under-reported
+    weight_lb: 185 - i * 0.03 + Math.sin(i) * 0.2,
+    calories: 2100,
     trainingBump: 0,
   }));
 
   const weightEntries = makeWeightEntries(days);
   const dailyEntries = makeNutritionEntries(days);
 
-  it('returns a non-null loggingResidual', () => {
+  it('bmr_current equals fittedBmr (no residual folded in)', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
-    // Model may or may not converge depending on data, but should not crash
+    const m = r.bmrModel;
+    if (m.error || m.source === 'profile_prior') return;
+    expect(m.bmr_current).toBe(m.fittedBmr);
+  });
+
+  it('modelPredictedRestDayTdee uses fittedBmr * restPal (not inflated)', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    const m = r.bmrModel;
+    if (m.error || m.source === 'profile_prior') return;
+    const restPal = m.pals[0];
+    const expected = Math.round(m.fittedBmr * restPal);
+    // Allow ±1 for rounding
+    expect(Math.abs(m.modelPredictedRestDayTdee - expected)).toBeLessThanOrEqual(1);
+  });
+
+  it('modelResidual is exposed (not hidden inside bmr_current)', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    const m = r.bmrModel;
+    if (m.error || m.source === 'profile_prior') return;
+    // modelResidual exists and is numeric
+    expect(typeof m.modelResidual).toBe('number');
+    // backward-compat alias
+    expect(m.adaptation).toBe(m.modelResidual);
+  });
+
+  it('deprecated adaptation alias still equals modelResidual', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    const m = r.bmrModel;
+    if (m.error) return;
+    expect(m.adaptation).toBe(m.modelResidual);
+    expect(m.adaptationSD).toBe(m.modelResidualSd);
+  });
+});
+
+// ── Horizon windows: calendar cutoffs (fix 4) ────────────────────────────────
+
+describe('estimateTDEEByHorizon: calendar date cutoffs (fix 4)', () => {
+  it('28-day horizon only uses rows within 28 calendar days of latest', () => {
+    const DAYS = 60;
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 180 - i * 0.02,
+      calories: 2100,
+    }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    let rows = mergeDailyData(weMap, nuMap);
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    const horizons = estimateTDEEByHorizon(rows);
+    const h28 = horizons[28];
+    // calendarEnd - calendarStart should be ≤ 27 days (28-day window)
+    if (h28.calendarStart && h28.calendarEnd) {
+      const start = new Date(h28.calendarStart + 'T00:00:00');
+      const end = new Date(h28.calendarEnd + 'T00:00:00');
+      const diffDays = Math.round((end - start) / 86400000);
+      expect(diffDays).toBeLessThanOrEqual(27);
+    }
+  });
+
+  it('horizon metadata includes calendarStart, calendarEnd, blockCount, coveragePct', () => {
+    const DAYS = 50;
+    const days = syntheticDays(DAYS, (i) => ({ weight_lb: 180, calories: 2100 }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    let rows = mergeDailyData(weMap, nuMap);
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    const horizons = estimateTDEEByHorizon(rows);
+    for (const h of Object.values(horizons)) {
+      expect(h).toHaveProperty('calendarEnd');
+      expect(h).toHaveProperty('blockCount');
+      expect(h).toHaveProperty('coveragePct');
+      expect(h).toHaveProperty('daysWindow');
+      expect(h).toHaveProperty('reason');
+    }
+  });
+
+  it('returns null tdee for short windows when insufficient data', () => {
+    const days = syntheticDays(10, () => ({ weight_lb: 180, calories: 2000 }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    let rows = mergeDailyData(weMap, nuMap);
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    const horizons = estimateTDEEByHorizon(rows);
+    Object.values(horizons).forEach(h => {
+      expect(h.available).toBe(false);
+    });
+  });
+
+  it('returns valid tdee for PRIMARY horizon with 40 days', () => {
+    const days = syntheticDays(40, (i) => ({
+      weight_lb: 180 - i * 0.03,
+      calories: 2100,
+    }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    let rows = mergeDailyData(weMap, nuMap);
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    const horizons = estimateTDEEByHorizon(rows);
+    if (horizons[28]?.available) {
+      expect(horizons[28].tdee).toBeGreaterThan(1000);
+      expect(horizons[28].tdee).toBeLessThan(5000);
+    }
+  });
+});
+
+// ── TDEE block quality (fix 5) ────────────────────────────────────────────────
+
+describe('TDEE block quality (fix 5)', () => {
+  it('full-coverage blocks get tdee_block_quality = high', () => {
+    const DAYS = 35;
+    const days = syntheticDays(DAYS, (i) => ({ weight_lb: 180, calories: 2100 }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    let rows = mergeDailyData(weMap, nuMap);
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    const highRows = rows.filter(r => r.tdee_block != null && r.tdee_block_quality === 'high');
+    // With no gaps, all blocks should be high-quality
+    expect(highRows.length).toBeGreaterThan(0);
+    highRows.forEach(r => {
+      expect(r.calCoverage).toBeGreaterThanOrEqual(0.85);
+    });
+  });
+
+  it('vacation-week blocks get medium quality (low calorie coverage)', () => {
+    const DAYS = 40;
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 180 - i * 0.02,
+      calories: (i >= 10 && i <= 16) ? null : 2100, // 7-day gap
+    }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    let rows = mergeDailyData(weMap, nuMap);
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    // Some blocks overlapping the gap should be medium or null
+    const blockRows = rows.filter(r => r.tdee_block != null);
+    // At least some blocks should exist
+    expect(blockRows.length).toBeGreaterThan(0);
+    // Not all should be high-quality (gap degrades some)
+    const highCount = blockRows.filter(r => r.tdee_block_quality === 'high').length;
+    const totalCount = blockRows.length;
+    expect(highCount).toBeLessThan(totalCount);
+  });
+});
+
+// ── Water correction guardrails (fix 6) ──────────────────────────────────────
+
+describe('Water correction guardrails (fix 6)', () => {
+  it('per-day correction is capped at MAX_WATER_CORRECTION_LB', () => {
+    const CAP = ANALYSIS_CONFIG.MAX_WATER_CORRECTION_LB;
+    const DAYS = 40;
+    // Extreme sodium spikes to force large corrections
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 175 + (i % 3 === 0 ? 5 : 0), // 5 lb spike every 3rd day
+      calories: 2000,
+      sodium: i % 3 === 0 ? 8000 : 1500, // very high sodium on spike days
+      carbs: 200,
+    }));
+    const { rows } = waterCorrect(
+      mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days))
+    );
+    rows.forEach(r => {
+      if (r._waterCorrection != null) {
+        expect(Math.abs(r._waterCorrection)).toBeLessThanOrEqual(CAP + 0.001);
+      }
+    });
+  });
+
+  it('waterCorrectionMethod is returned from waterCorrect', () => {
+    const days = syntheticDays(30, (i) => ({
+      weight_lb: 175, calories: 2000, sodium: 2200, carbs: 200,
+    }));
+    const result = waterCorrect(
+      mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days))
+    );
+    expect(['ols_regression', 'median_bucket_adaptive']).toContain(result.waterCorrectionMethod);
+    expect(typeof result.predictorDays).toBe('number');
+  });
+
+  it('waterWeightUncertaintyLb is reported from runAnalysis', () => {
+    const days = syntheticDays(40, (i) => ({
+      weight_lb: 175 + (i === 15 ? 3 : 0),
+      calories: 2000,
+      sodium: i === 15 ? 6000 : 1800,
+      carbs: 200,
+    }));
+    const r = runAnalysis(makeWeightEntries(days), makeNutritionEntries(days));
+    if (r.waterWeightUncertaintyLb != null) {
+      expect(r.waterWeightUncertaintyLb).toBeGreaterThan(0);
+    }
+    expect(r.summary).toHaveProperty('waterCorrectionMethod');
+  });
+
+  it('sodium spike increases uncertainty but does not crash', () => {
+    const days = syntheticDays(35, (i) => ({
+      weight_lb: 175,
+      calories: 2000,
+      sodium: i === 20 ? 10000 : 2000,
+      carbs: 200,
+    }));
+    const r = runAnalysis(makeWeightEntries(days), makeNutritionEntries(days));
+    expect(r).toBeDefined();
+    expect(r.rows.length).toBeGreaterThan(0);
+  });
+});
+
+// ── exerciseSessions integration (fix 2) ─────────────────────────────────────
+
+describe('exerciseSessions integration (fix 2)', () => {
+  it('legacy trainingBump entries still produce a valid model', () => {
+    const DAYS = 60;
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03,
+      calories: 2200 + (i % 7 === 4 ? 280 : 0),
+      trainingBump: i % 7 === 4 ? 280 : 0,
+    }));
+    const r = runAnalysis(makeWeightEntries(days), makeNutritionEntries(days));
+    expect(r.rows.every(rw => rw.exerciseSource != null)).toBe(true);
+    expect(r.rows.every(rw => rw.exerciseCalories != null)).toBe(true);
+  });
+
+  it('exerciseSessions override trainingBump in PAL lookup', () => {
+    const DAYS = 60;
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03,
+      calories: 2100,
+      trainingBump: 100, // legacy bump
+      exerciseSessions: [{ manualCalories: 350 }], // should win
+    }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    const rows = mergeDailyData(weMap, nuMap);
+    // All rows should derive exerciseCalories=350 from sessions, not 100 from bump
+    rows.forEach(r => {
+      expect(r.exerciseCalories).toBe(350);
+      expect(r.exerciseSource).toBe('manual');
+    });
+  });
+
+  it('mixed entries (some with sessions, some with bump) produce consistent rows', () => {
+    const DAYS = 60;
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185,
+      calories: 2100,
+      trainingBump: i % 2 === 0 ? 100 : 0,
+      exerciseSessions: i % 3 === 0 ? [{ wearableCalories: 300 }] : [],
+    }));
+    const rows = mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days));
+    rows.forEach(r => {
+      expect(typeof r.exerciseCalories).toBe('number');
+      expect(r.exerciseCalories).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
+// ── Under-reported calories ───────────────────────────────────────────────────
+
+describe('Under-reported calories (weight drops faster than calories suggest)', () => {
+  const DAYS = 60;
+  const TRUE_TDEE = 2400;
+  const LOGGED_KCAL = 1600;
+  const TRUE_DEFICIT = TRUE_TDEE - 2000;
+  const START_WEIGHT = 185;
+  const RATE_LB_PER_DAY = TRUE_DEFICIT / 7700 * 2.2046;
+
+  const days = syntheticDays(DAYS, (i) => ({
+    weight_lb: START_WEIGHT - RATE_LB_PER_DAY * i + (Math.sin(i) * 0.15),
+    calories: LOGGED_KCAL,
+    trainingBump: 0,
+  }));
+
+  const weightEntries = makeWeightEntries(days);
+  const dailyEntries = makeNutritionEntries(days);
+
+  it('returns a valid result without crashing', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
     expect(r).toBeDefined();
     expect(r.rows.length).toBeGreaterThan(0);
   });
 
   it('model does not over-react to single-day weight changes', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
-    // Smoothed weight should be much less volatile than raw weight
     const smoothVals = r.rows.map(rw => rw.wt_smooth_lb).filter(v => v != null);
     const rawVals = r.rows.map(rw => rw.weight_lb).filter(v => v != null);
     if (smoothVals.length < 2 || rawVals.length < 2) return;
-
     const smoothRange = Math.max(...smoothVals) - Math.min(...smoothVals);
     const rawRange = Math.max(...rawVals) - Math.min(...rawVals);
-    // Smoothed range should be less than or equal to raw range
     expect(smoothRange).toBeLessThanOrEqual(rawRange + 0.5);
   });
 });
+
+// ── High sodium/carb water swing ─────────────────────────────────────────────
 
 describe('High sodium/carb water swing', () => {
   const BASE_DAYS = 30;
   const HIGH_SODIUM_DAY = 15;
 
   const days = syntheticDays(BASE_DAYS, (i) => ({
-    weight_lb: 175 + (i === HIGH_SODIUM_DAY ? 3 : 0), // 3 lb spike on high-sodium day
+    weight_lb: 175 + (i === HIGH_SODIUM_DAY ? 3 : 0),
     calories: 2000,
-    sodium: i === HIGH_SODIUM_DAY ? 6000 : 1800, // very high sodium on day 15
+    sodium: i === HIGH_SODIUM_DAY ? 6000 : 1800,
     carbs: 200,
     trainingBump: 0,
   }));
@@ -260,7 +600,6 @@ describe('High sodium/carb water swing', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
     const spikeRow = r.rows.find(rw => rw.date === days[HIGH_SODIUM_DAY].date);
     if (!spikeRow || spikeRow.wt_smooth_lb == null) return;
-    // Smoothed value should be pulled toward the surrounding 175 lb baseline
     expect(Math.abs(spikeRow.wt_smooth_lb - 175)).toBeLessThan(3);
   });
 
@@ -272,12 +611,14 @@ describe('High sodium/carb water swing', () => {
   });
 });
 
+// ── Missing vacation week ─────────────────────────────────────────────────────
+
 describe('Missing vacation week (days 20–26 no calories)', () => {
   const DAYS = 60;
 
   const days = syntheticDays(DAYS, (i) => ({
     weight_lb: 180 - i * 0.03 + Math.sin(i) * 0.2,
-    calories: (i >= 20 && i <= 26) ? null : 2000, // vacation gap
+    calories: (i >= 20 && i <= 26) ? null : 2000,
     trainingBump: 0,
   }));
 
@@ -289,14 +630,11 @@ describe('Missing vacation week (days 20–26 no calories)', () => {
     expect(r.rows.length).toBe(DAYS);
   });
 
-  it('vacation days have null calories initially (not imputed prematurely)', () => {
+  it('vacation days are marked imputed or pending, not silently set', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
-    // Days 20–26 should not be imputed until 14 days have passed
-    // (they will be 'pending' or 'insufficient_weight_data' depending on data)
     const vacDays = r.rows.filter((rw, i) => i >= 20 && i <= 26);
     vacDays.forEach(rw => {
       if (rw.calories != null) {
-        // If imputed, status should be 'imputed', not silently set
         expect(rw.impute_status).toBe('imputed');
         expect(rw.calories_imputed).toBe(true);
       }
@@ -308,16 +646,17 @@ describe('Missing vacation week (days 20–26 no calories)', () => {
   });
 });
 
+// ── Exercise-heavy weeks ──────────────────────────────────────────────────────
+
 describe('Exercise-heavy weeks (varied training bumps)', () => {
   const DAYS = 60;
-  const BUMPS = [0, 0, 100, 0, 280, 0, 400]; // weekly pattern
+  const BUMPS = [0, 0, 100, 0, 280, 0, 400];
 
   const days = syntheticDays(DAYS, (i) => {
     const bump = BUMPS[i % 7];
-    const calories = 2000 + bump; // intake matches bump
     return {
       weight_lb: 185 - i * 0.05 + Math.sin(i * 0.8) * 0.3,
-      calories,
+      calories: 2000 + bump,
       trainingBump: bump,
     };
   });
@@ -325,26 +664,33 @@ describe('Exercise-heavy weeks (varied training bumps)', () => {
   const weightEntries = makeWeightEntries(days);
   const dailyEntries = makeNutritionEntries(days);
 
-  it('returns a bmrModel when enough data', () => {
+  it('returns a defined bmrModel when enough data', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
-    // With 60 days and varied bumps we should get a fitted model
-    // (may still error if not enough block estimates due to smoothing startup)
     expect(r).toBeDefined();
     if (!r.bmrModel.error) {
       expect(r.bmrModel.pals).toBeDefined();
     }
   });
 
-  it('different PAL values for different bumps (monotonically ordered)', () => {
+  it('PAL values are monotonically ordered with bumps (within tolerance)', () => {
     const r = runAnalysis(weightEntries, dailyEntries);
     if (r.bmrModel.error || r.bmrModel.source === 'profile_prior') return;
     const pals = r.bmrModel.pals;
-    // PAL should increase with training intensity (within numerical tolerance)
     if (pals[0] && pals[400]) {
       expect(pals[400]).toBeGreaterThanOrEqual(pals[0] - 0.05);
     }
   });
+
+  it('each merged row has exerciseCalories field', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    const rowsWithNutrition = r.rows.filter(rw => rw.trainingBump != null);
+    rowsWithNutrition.forEach(rw => {
+      expect(typeof rw.exerciseCalories).toBe('number');
+    });
+  });
 });
+
+// ── estimateProfileRmr ────────────────────────────────────────────────────────
 
 describe('estimateProfileRmr', () => {
   it('returns null when no weight provided', () => {
@@ -355,8 +701,7 @@ describe('estimateProfileRmr', () => {
     const profile = { age: 30, heightValue: 70, heightUnit: 'in', sex: 'male', bodyFatPercent: null };
     const result = estimateProfileRmr(profile, 180);
     expect(result.method).toBe('mifflin_st_jeor');
-    // 180 lb = 81.6 kg; height 70 in = 177.8 cm
-    // MSJ male: 10*81.6 + 6.25*177.8 - 5*30 + 5 = 816 + 1111 - 150 + 5 = 1782
+    // 180 lb = 81.6 kg; 70 in = 177.8 cm; MSJ male = 10*81.6 + 6.25*177.8 - 5*30 + 5 ≈ 1782
     expect(Math.abs(result.rmr - 1782)).toBeLessThan(20);
   });
 
@@ -366,70 +711,82 @@ describe('estimateProfileRmr', () => {
     // 180 lb ≈ 81.6 kg; 21 * 81.6 ≈ 1714
     expect(Math.abs(result.rmr - 1714)).toBeLessThan(30);
   });
+
+  it('uses Cunningham when body fat percent is available', () => {
+    const profile = { bodyFatPercent: '20' }; // 20% BF
+    const result = estimateProfileRmr(profile, 180);
+    expect(result.method).toBe('cunningham');
+    // FFM = 81.6 * 0.8 = 65.3 kg; Cunningham = 500 + 22*65.3 ≈ 1937
+    expect(result.rmr).toBeGreaterThan(1500);
+    expect(result.rmr).toBeLessThan(2500);
+  });
 });
+
+// ── computeConfidence ─────────────────────────────────────────────────────────
 
 describe('computeConfidence', () => {
   it('returns not_enough with only 7 days', () => {
-    const days = syntheticDays(7, (i) => ({ weight_lb: 180, calories: 2000 }));
+    const days = syntheticDays(7, () => ({ weight_lb: 180, calories: 2000 }));
     const rows = [...mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days))];
     const conf = computeConfidence(rows, {});
     expect(conf.label).toBe('not_enough');
+    expect(conf.score).toBe(0);
   });
 
-  it('returns high confidence with 50+ days of weight and calories', () => {
+  it('returns score > 0 with 14+ days', () => {
+    const days = syntheticDays(20, () => ({ weight_lb: 180, calories: 2000 }));
+    const rows = [...mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days))];
+    const conf = computeConfidence(rows, {});
+    expect(conf.score).toBeGreaterThan(0);
+  });
+
+  it('returns high/moderate confidence with 50+ days of weight and calories', () => {
     const days = syntheticDays(55, (i) => ({ weight_lb: 180 - i * 0.05, calories: 2000 }));
     const rows = [...mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days))];
     const conf = computeConfidence(rows, { source: 'fitted', score: 30 });
     expect(['moderate', 'high']).toContain(conf.label);
   });
-});
 
-describe('Multi-horizon TDEE (estimateTDEEByHorizon)', () => {
-  it('returns null tdee for short windows when insufficient data', () => {
-    const days = syntheticDays(10, () => ({ weight_lb: 180, calories: 2000 }));
-    const weMap = makeWeightEntries(days);
-    const nuMap = makeNutritionEntries(days);
-    let rows = mergeDailyData(weMap, nuMap);
-    rows = smoothWeight(waterCorrect(rows).rows);
-    rows = estimateTDEE(rows);
-    const horizons = estimateTDEEByHorizon(rows);
-    // All horizons require at least 5 block estimates — none should be available
-    Object.values(horizons).forEach(h => {
-      expect(h.available).toBe(false);
-    });
-  });
-
-  it('returns valid tdee for PRIMARY horizon with 35 days', () => {
-    const days = syntheticDays(40, (i) => ({
-      weight_lb: 180 - i * 0.03,
-      calories: 2100,
-    }));
-    const weMap = makeWeightEntries(days);
-    const nuMap = makeNutritionEntries(days);
-    let rows = mergeDailyData(weMap, nuMap);
-    rows = smoothWeight(waterCorrect(rows).rows);
-    rows = estimateTDEE(rows);
-    const horizons = estimateTDEEByHorizon(rows);
-    // PRIMARY = 28 days; should have enough block estimates
-    if (horizons[28]?.available) {
-      expect(horizons[28].tdee).toBeGreaterThan(1000);
-      expect(horizons[28].tdee).toBeLessThan(5000);
-    }
+  it('provides reasons array', () => {
+    const days = syntheticDays(30, () => ({ weight_lb: 180, calories: 2000 }));
+    const rows = [...mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days))];
+    const conf = computeConfidence(rows, {});
+    expect(Array.isArray(conf.reasons)).toBe(true);
+    expect(conf.reasons.length).toBeGreaterThan(0);
   });
 });
+
+// ── Profile-based fallback when < 30 days ────────────────────────────────────
 
 describe('Profile-based fallback when < 30 days', () => {
   it('uses profile RMR when not enough data for grid search', () => {
-    const days = syntheticDays(20, (i) => ({ weight_lb: 185, calories: 2200 }));
+    const days = syntheticDays(20, () => ({ weight_lb: 185, calories: 2200 }));
     const weMap = makeWeightEntries(days);
     const nuMap = makeNutritionEntries(days);
     const profile = { age: 35, heightValue: 70, heightUnit: 'in', sex: 'male' };
     const r = runAnalysis(weMap, nuMap, profile);
-    // Should not crash; if model is insufficient it should use profile prior
     expect(r).toBeDefined();
     if (r.bmrModel.source === 'profile_prior') {
       expect(r.bmrModel.bmr_current).toBeGreaterThan(0);
       expect(r.summary.profilePredictedRmr).not.toBeNull();
+      // Profile prior: bmr_current should match the profile RMR input
+      expect(r.bmrModel.bmr_current).toBe(r.summary.profilePredictedRmr);
+      // modelPredictedRestDayTdee should be bmr_current * restPal
+      const restPal = r.bmrModel.pals[0];
+      const expectedRest = Math.round(r.bmrModel.bmr_current * restPal);
+      expect(Math.abs(r.bmrModel.modelPredictedRestDayTdee - expectedRest)).toBeLessThanOrEqual(1);
     }
+  });
+
+  it('restDayCaloriesOut in summary uses modelPredictedRestDayTdee', () => {
+    const days = syntheticDays(60, (i) => ({
+      weight_lb: 185 - i * 0.03,
+      calories: 2100,
+    }));
+    const r = runAnalysis(makeWeightEntries(days), makeNutritionEntries(days));
+    const m = r.bmrModel;
+    if (m.error) return;
+    const expected = m.modelPredictedRestDayTdee ?? m.tdee_rest_day;
+    expect(r.summary.restDayCaloriesOut).toBe(expected);
   });
 });

--- a/public/tools/CalorieTracker/analysis/engine.test.js
+++ b/public/tools/CalorieTracker/analysis/engine.test.js
@@ -1,0 +1,435 @@
+/**
+ * @file analysis/engine.test.js
+ * Vitest tests for the energy analysis engine.
+ *
+ * Uses synthetic data so results are deterministic and verifiable.
+ * Run from repo root: npx vitest run public/tools/CalorieTracker/analysis/engine.test.js
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  selectDailyWeight,
+  mergeDailyData,
+  waterCorrect,
+  smoothWeight,
+  estimateTDEE,
+  estimateTDEEByHorizon,
+  estimateProfileRmr,
+  estimateBMR,
+  computeConfidence,
+  computeLoggingResidual,
+  imputeCalories,
+  detectPlateau,
+  runAnalysis,
+  ANALYSIS_CONFIG,
+} from './engine.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function isoDate(baseDate, offsetDays) {
+  const d = new Date(baseDate + 'T00:00:00');
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Build a Map<docId, entry> weight entries from a daily weight array.
+ * Each entry gets a deterministic doc ID.
+ */
+function makeWeightEntries(data) {
+  const map = new Map();
+  data.forEach((d, i) => {
+    const docId = `w-${i}`;
+    map.set(docId, {
+      date: d.date,
+      weight_lb: d.weight_lb,
+      time_min: d.time_min ?? 480,
+      timestamp: `${d.date}T08:00:00`,
+      source: 'test',
+    });
+  });
+  return map;
+}
+
+/** Build a Map<date, entry> nutrition entries. */
+function makeNutritionEntries(data) {
+  const map = new Map();
+  data.forEach(d => {
+    if (d.calories != null) {
+      map.set(d.date, {
+        date: d.date,
+        calories: d.calories,
+        protein: d.protein ?? 150,
+        carbs: d.carbs ?? 200,
+        fat: d.fat ?? 60,
+        fiber: d.fiber ?? 25,
+        sodium: d.sodium ?? 2200,
+        trainingBump: d.trainingBump ?? 0,
+      });
+    }
+  });
+  return map;
+}
+
+/**
+ * Generate N days of synthetic data starting from START_DATE.
+ * @param {number} n - number of days
+ * @param {function} dayFn - receives (index, date) and returns { weight_lb, calories, ... }
+ */
+function syntheticDays(n, dayFn, startDate = '2024-01-01') {
+  return Array.from({ length: n }, (_, i) => {
+    const date = isoDate(startDate, i);
+    return { date, ...dayFn(i, date) };
+  });
+}
+
+// ── Test scenarios ────────────────────────────────────────────────────────────
+
+describe('selectDailyWeight', () => {
+  it('returns the single reading when only one exists', () => {
+    const r = [{ weight_lb: 180, time_min: 480 }];
+    expect(selectDailyWeight(r, null)?.weight_lb).toBe(180);
+  });
+
+  it('prefers reading inside the preferred window', () => {
+    const readings = [
+      { weight_lb: 183, time_min: 900 },  // outside (3 PM)
+      { weight_lb: 181, time_min: 420 },  // inside window (7 AM)
+    ];
+    const window = { startMin: 360, endMin: 540 };
+    expect(selectDailyWeight(readings, window)?.weight_lb).toBe(181);
+  });
+
+  it('falls back to earliest when none are in the window', () => {
+    const readings = [
+      { weight_lb: 183, time_min: 900 },
+      { weight_lb: 181, time_min: 1200 },
+    ];
+    const window = { startMin: 360, endMin: 540 };
+    // Both are outside window → pick earliest time_min
+    expect(selectDailyWeight(readings, window)?.time_min).toBe(900);
+  });
+
+  it('uses median of in-window readings for robustness', () => {
+    const readings = [
+      { weight_lb: 181, time_min: 400 },  // in window
+      { weight_lb: 182, time_min: 420 },  // in window
+      { weight_lb: 190, time_min: 430 },  // in window but high outlier
+    ];
+    const window = { startMin: 360, endMin: 540 };
+    // Sorted in-window: [181, 182, 190] → median at index 1 = 182
+    expect(selectDailyWeight(readings, window)?.weight_lb).toBe(182);
+  });
+});
+
+describe('Stable maintenance (60 days)', () => {
+  const DAYS = 60;
+  const MAINTENANCE_KCAL = 2200;
+  const STABLE_WEIGHT_LB = 180;
+
+  const days = syntheticDays(DAYS, (i) => ({
+    weight_lb: STABLE_WEIGHT_LB + (Math.sin(i) * 0.3), // tiny noise
+    calories: MAINTENANCE_KCAL,
+    trainingBump: 0,
+  }));
+
+  const weightEntries = makeWeightEntries(days);
+  const dailyEntries = makeNutritionEntries(days);
+
+  it('runAnalysis returns no error', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    expect(r.error).toBeUndefined();
+  });
+
+  it('smoothed weight stays near starting weight', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    const last = r.rows.filter(rw => rw.wt_smooth_lb != null).at(-1);
+    expect(Math.abs(last.wt_smooth_lb - STABLE_WEIGHT_LB)).toBeLessThan(3);
+  });
+
+  it('estimated TDEE is within 200 kcal of maintenance', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    const { tdee } = r.summary;
+    if (tdee != null) {
+      expect(Math.abs(tdee - MAINTENANCE_KCAL)).toBeLessThan(200);
+    }
+  });
+
+  it('plateau is detected', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    expect(r.plateau.isPlateaued).toBe(true);
+  });
+
+  it('confidence is at least rough', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    expect(['rough', 'moderate', 'high']).toContain(r.confidence.label);
+  });
+});
+
+describe('Steady fat loss (60 days, −0.5 lb/week)', () => {
+  const DAYS = 60;
+  const RATE_LB_PER_DAY = 0.5 / 7;
+  const START_WEIGHT = 200;
+  const INTAKE = 1800;
+
+  const days = syntheticDays(DAYS, (i) => ({
+    weight_lb: START_WEIGHT - RATE_LB_PER_DAY * i + (Math.sin(i * 1.3) * 0.2),
+    calories: INTAKE,
+    trainingBump: 0,
+  }));
+
+  const weightEntries = makeWeightEntries(days);
+  const dailyEntries = makeNutritionEntries(days);
+
+  it('detects weight loss trend (negative slope)', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    if (r.plateau.slopeLbPerWeek != null) {
+      expect(r.plateau.slopeLbPerWeek).toBeLessThan(0);
+    }
+  });
+
+  it('total weight change is negative', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    if (r.summary.totalWeightChange != null) {
+      expect(r.summary.totalWeightChange).toBeLessThan(0);
+    }
+  });
+
+  it('TDEE estimate is above intake (model must infer expenditure > intake)', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    if (r.summary.tdee != null) {
+      expect(r.summary.tdee).toBeGreaterThan(INTAKE - 100);
+    }
+  });
+});
+
+describe('Under-reported calories (weight drops faster than calories suggest)', () => {
+  const DAYS = 60;
+  const TRUE_TDEE = 2400;
+  const LOGGED_KCAL = 1600;  // logs 600 less than actual
+  const TRUE_DEFICIT = TRUE_TDEE - 2000; // actual intake = 2000, gap = 400
+  const START_WEIGHT = 185;
+  const RATE_LB_PER_DAY = TRUE_DEFICIT / 7700 * 2.2046; // lbs/day
+
+  const days = syntheticDays(DAYS, (i) => ({
+    weight_lb: START_WEIGHT - RATE_LB_PER_DAY * i + (Math.sin(i) * 0.15),
+    calories: LOGGED_KCAL, // under-reported
+    trainingBump: 0,
+  }));
+
+  const weightEntries = makeWeightEntries(days);
+  const dailyEntries = makeNutritionEntries(days);
+
+  it('returns a non-null loggingResidual', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    // Model may or may not converge depending on data, but should not crash
+    expect(r).toBeDefined();
+    expect(r.rows.length).toBeGreaterThan(0);
+  });
+
+  it('model does not over-react to single-day weight changes', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    // Smoothed weight should be much less volatile than raw weight
+    const smoothVals = r.rows.map(rw => rw.wt_smooth_lb).filter(v => v != null);
+    const rawVals = r.rows.map(rw => rw.weight_lb).filter(v => v != null);
+    if (smoothVals.length < 2 || rawVals.length < 2) return;
+
+    const smoothRange = Math.max(...smoothVals) - Math.min(...smoothVals);
+    const rawRange = Math.max(...rawVals) - Math.min(...rawVals);
+    // Smoothed range should be less than or equal to raw range
+    expect(smoothRange).toBeLessThanOrEqual(rawRange + 0.5);
+  });
+});
+
+describe('High sodium/carb water swing', () => {
+  const BASE_DAYS = 30;
+  const HIGH_SODIUM_DAY = 15;
+
+  const days = syntheticDays(BASE_DAYS, (i) => ({
+    weight_lb: 175 + (i === HIGH_SODIUM_DAY ? 3 : 0), // 3 lb spike on high-sodium day
+    calories: 2000,
+    sodium: i === HIGH_SODIUM_DAY ? 6000 : 1800, // very high sodium on day 15
+    carbs: 200,
+    trainingBump: 0,
+  }));
+
+  const weightEntries = makeWeightEntries(days);
+  const dailyEntries = makeNutritionEntries(days);
+
+  it('smoothed weight is less affected than raw on the spike day', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    const spikeRow = r.rows.find(rw => rw.date === days[HIGH_SODIUM_DAY].date);
+    if (!spikeRow || spikeRow.wt_smooth_lb == null) return;
+    // Smoothed value should be pulled toward the surrounding 175 lb baseline
+    expect(Math.abs(spikeRow.wt_smooth_lb - 175)).toBeLessThan(3);
+  });
+
+  it('waterWeightUncertaintyLb is reported and positive', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    if (r.waterWeightUncertaintyLb != null) {
+      expect(r.waterWeightUncertaintyLb).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('Missing vacation week (days 20–26 no calories)', () => {
+  const DAYS = 60;
+
+  const days = syntheticDays(DAYS, (i) => ({
+    weight_lb: 180 - i * 0.03 + Math.sin(i) * 0.2,
+    calories: (i >= 20 && i <= 26) ? null : 2000, // vacation gap
+    trainingBump: 0,
+  }));
+
+  const weightEntries = makeWeightEntries(days);
+  const dailyEntries = makeNutritionEntries(days);
+
+  it('returns rows for all 60 days', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    expect(r.rows.length).toBe(DAYS);
+  });
+
+  it('vacation days have null calories initially (not imputed prematurely)', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    // Days 20–26 should not be imputed until 14 days have passed
+    // (they will be 'pending' or 'insufficient_weight_data' depending on data)
+    const vacDays = r.rows.filter((rw, i) => i >= 20 && i <= 26);
+    vacDays.forEach(rw => {
+      if (rw.calories != null) {
+        // If imputed, status should be 'imputed', not silently set
+        expect(rw.impute_status).toBe('imputed');
+        expect(rw.calories_imputed).toBe(true);
+      }
+    });
+  });
+
+  it('does not crash with a week-long gap', () => {
+    expect(() => runAnalysis(weightEntries, dailyEntries)).not.toThrow();
+  });
+});
+
+describe('Exercise-heavy weeks (varied training bumps)', () => {
+  const DAYS = 60;
+  const BUMPS = [0, 0, 100, 0, 280, 0, 400]; // weekly pattern
+
+  const days = syntheticDays(DAYS, (i) => {
+    const bump = BUMPS[i % 7];
+    const calories = 2000 + bump; // intake matches bump
+    return {
+      weight_lb: 185 - i * 0.05 + Math.sin(i * 0.8) * 0.3,
+      calories,
+      trainingBump: bump,
+    };
+  });
+
+  const weightEntries = makeWeightEntries(days);
+  const dailyEntries = makeNutritionEntries(days);
+
+  it('returns a bmrModel when enough data', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    // With 60 days and varied bumps we should get a fitted model
+    // (may still error if not enough block estimates due to smoothing startup)
+    expect(r).toBeDefined();
+    if (!r.bmrModel.error) {
+      expect(r.bmrModel.pals).toBeDefined();
+    }
+  });
+
+  it('different PAL values for different bumps (monotonically ordered)', () => {
+    const r = runAnalysis(weightEntries, dailyEntries);
+    if (r.bmrModel.error || r.bmrModel.source === 'profile_prior') return;
+    const pals = r.bmrModel.pals;
+    // PAL should increase with training intensity (within numerical tolerance)
+    if (pals[0] && pals[400]) {
+      expect(pals[400]).toBeGreaterThanOrEqual(pals[0] - 0.05);
+    }
+  });
+});
+
+describe('estimateProfileRmr', () => {
+  it('returns null when no weight provided', () => {
+    expect(estimateProfileRmr(null, null)).toBeNull();
+  });
+
+  it('uses Mifflin-St Jeor when height, age, sex are present', () => {
+    const profile = { age: 30, heightValue: 70, heightUnit: 'in', sex: 'male', bodyFatPercent: null };
+    const result = estimateProfileRmr(profile, 180);
+    expect(result.method).toBe('mifflin_st_jeor');
+    // 180 lb = 81.6 kg; height 70 in = 177.8 cm
+    // MSJ male: 10*81.6 + 6.25*177.8 - 5*30 + 5 = 816 + 1111 - 150 + 5 = 1782
+    expect(Math.abs(result.rmr - 1782)).toBeLessThan(20);
+  });
+
+  it('falls back to weight-only when profile is null', () => {
+    const result = estimateProfileRmr(null, 180);
+    expect(result.method).toBe('weight_only');
+    // 180 lb ≈ 81.6 kg; 21 * 81.6 ≈ 1714
+    expect(Math.abs(result.rmr - 1714)).toBeLessThan(30);
+  });
+});
+
+describe('computeConfidence', () => {
+  it('returns not_enough with only 7 days', () => {
+    const days = syntheticDays(7, (i) => ({ weight_lb: 180, calories: 2000 }));
+    const rows = [...mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days))];
+    const conf = computeConfidence(rows, {});
+    expect(conf.label).toBe('not_enough');
+  });
+
+  it('returns high confidence with 50+ days of weight and calories', () => {
+    const days = syntheticDays(55, (i) => ({ weight_lb: 180 - i * 0.05, calories: 2000 }));
+    const rows = [...mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days))];
+    const conf = computeConfidence(rows, { source: 'fitted', score: 30 });
+    expect(['moderate', 'high']).toContain(conf.label);
+  });
+});
+
+describe('Multi-horizon TDEE (estimateTDEEByHorizon)', () => {
+  it('returns null tdee for short windows when insufficient data', () => {
+    const days = syntheticDays(10, () => ({ weight_lb: 180, calories: 2000 }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    let rows = mergeDailyData(weMap, nuMap);
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    const horizons = estimateTDEEByHorizon(rows);
+    // All horizons require at least 5 block estimates — none should be available
+    Object.values(horizons).forEach(h => {
+      expect(h.available).toBe(false);
+    });
+  });
+
+  it('returns valid tdee for PRIMARY horizon with 35 days', () => {
+    const days = syntheticDays(40, (i) => ({
+      weight_lb: 180 - i * 0.03,
+      calories: 2100,
+    }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    let rows = mergeDailyData(weMap, nuMap);
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    const horizons = estimateTDEEByHorizon(rows);
+    // PRIMARY = 28 days; should have enough block estimates
+    if (horizons[28]?.available) {
+      expect(horizons[28].tdee).toBeGreaterThan(1000);
+      expect(horizons[28].tdee).toBeLessThan(5000);
+    }
+  });
+});
+
+describe('Profile-based fallback when < 30 days', () => {
+  it('uses profile RMR when not enough data for grid search', () => {
+    const days = syntheticDays(20, (i) => ({ weight_lb: 185, calories: 2200 }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    const profile = { age: 35, heightValue: 70, heightUnit: 'in', sex: 'male' };
+    const r = runAnalysis(weMap, nuMap, profile);
+    // Should not crash; if model is insufficient it should use profile prior
+    expect(r).toBeDefined();
+    if (r.bmrModel.source === 'profile_prior') {
+      expect(r.bmrModel.bmr_current).toBeGreaterThan(0);
+      expect(r.summary.profilePredictedRmr).not.toBeNull();
+    }
+  });
+});

--- a/public/tools/CalorieTracker/analysis/engine.test.js
+++ b/public/tools/CalorieTracker/analysis/engine.test.js
@@ -790,3 +790,147 @@ describe('Profile-based fallback when < 30 days', () => {
     expect(r.summary.restDayCaloriesOut).toBe(expected);
   });
 });
+
+// ── calCoverage never exceeds 1.0 (fix: window.length denominator) ────────────
+
+describe('TDEE block calCoverage is always in [0, 1]', () => {
+  it('full-log dataset produces calCoverage === 1.0, not 1.07', () => {
+    const DAYS = 40;
+    const days = syntheticDays(DAYS, () => ({ weight_lb: 180, calories: 2100 }));
+    let rows = mergeDailyData(makeWeightEntries(days), makeNutritionEntries(days));
+    rows = smoothWeight(waterCorrect(rows).rows);
+    rows = estimateTDEE(rows);
+    const blockRows = rows.filter(r => r.tdee_block != null && r.calCoverage != null);
+    expect(blockRows.length).toBeGreaterThan(0);
+    blockRows.forEach(r => {
+      expect(r.calCoverage).toBeLessThanOrEqual(1.0);
+      expect(r.calCoverage).toBeGreaterThan(0);
+    });
+    // With no gaps, every block should reach 1.0 exactly
+    const highCovCount = blockRows.filter(r => r.calCoverage === 1.0).length;
+    expect(highCovCount).toBeGreaterThan(0);
+  });
+});
+
+// ── exerciseCalories used consistently in residual and imputation (fix 1) ─────
+
+describe('exerciseCalories consistent across residual and imputation', () => {
+  it('computeLoggingResidual uses exerciseCalories for PAL lookup', () => {
+    // Build 60 days where exerciseSessions bump is 400 but trainingBump is 0
+    // PAL[400] > PAL[0], so predictedTDEE should be higher → residual shifts
+    const DAYS = 60;
+    const daysNoBump = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03,
+      calories: 2100,
+      trainingBump: 0,
+      exerciseSessions: [],
+    }));
+    const daysWithSessions = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03,
+      calories: 2100,
+      trainingBump: 0,           // bump is 0 — only sessions carry exercise
+      exerciseSessions: [{ manualCalories: 400 }],
+    }));
+
+    let rowsNoBump = mergeDailyData(makeWeightEntries(daysNoBump), makeNutritionEntries(daysNoBump));
+    let rowsWithSessions = mergeDailyData(makeWeightEntries(daysWithSessions), makeNutritionEntries(daysWithSessions));
+
+    // All rows in sessions dataset should have exerciseCalories = 400
+    rowsWithSessions.forEach(r => {
+      expect(r.exerciseCalories).toBe(400);
+    });
+
+    // Rows in no-bump dataset should have exerciseCalories = 0
+    rowsNoBump.forEach(r => {
+      expect(r.exerciseCalories).toBe(0);
+    });
+  });
+
+  it('imputeCalories selects correct PAL bucket from exerciseCalories', () => {
+    const DAYS = 60;
+    // Every other day has a 400-kcal manual session but trainingBump = 0
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03,
+      calories: i % 5 === 0 ? null : 2100, // sparse gaps for imputation
+      trainingBump: 0,
+      exerciseSessions: i % 2 === 0 ? [{ manualCalories: 400 }] : [],
+    }));
+    const weMap = makeWeightEntries(days);
+    const nuMap = makeNutritionEntries(days);
+    const r = runAnalysis(weMap, nuMap);
+    // Should not crash and should produce some imputed days
+    expect(r).toBeDefined();
+    expect(r.rows.length).toBe(DAYS);
+    // Imputed rows should exist (since we have gaps and model should converge)
+    // We only assert no crash here; PAL routing is covered by unit-level row inspection
+  });
+});
+
+// ── fittedDataQuality: vacation gaps don't corrupt fitted BMR ─────────────────
+
+describe('fittedDataQuality: medium blocks excluded from fit when enough high-quality exist', () => {
+  it('fittedDataQuality is high when all data has full coverage', () => {
+    const DAYS = 60;
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03 + Math.sin(i) * 0.2,
+      calories: 2100,
+    }));
+    const r = runAnalysis(makeWeightEntries(days), makeNutritionEntries(days));
+    const m = r.bmrModel;
+    if (m.error || m.source === 'profile_prior') return;
+    expect(m.fittedDataQuality).toBe('high');
+  });
+
+  it('fittedDataQuality is mixed when most blocks have gaps', () => {
+    const DAYS = 60;
+    // Every block overlaps a gap, so almost all blocks will be medium quality
+    const days = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03 + Math.sin(i) * 0.2,
+      calories: i % 4 === 0 ? null : 2100, // 25% missing every 4th day
+    }));
+    const r = runAnalysis(makeWeightEntries(days), makeNutritionEntries(days));
+    const m = r.bmrModel;
+    if (m.error || m.source === 'profile_prior') return;
+    // With 25% gaps, fewer than 20 high-quality blocks → should fall back to mixed
+    if (m.fittedDataQuality === 'mixed') {
+      // Confidence reasons should mention the mixed quality
+      const reason = r.confidence.reasons.some(s => s.includes('incomplete calorie logs'));
+      expect(reason).toBe(true);
+    }
+  });
+
+  it('vacation week does not materially shift fitted BMR when enough high-quality blocks exist', () => {
+    const DAYS = 70;
+    const VACATION_START = 30;
+    const VACATION_END = 36; // 7-day gap
+
+    // Build a clean dataset
+    const daysClean = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03 + Math.sin(i) * 0.15,
+      calories: 2100,
+    }));
+    // Same dataset with a vacation gap
+    const daysWithVacation = syntheticDays(DAYS, (i) => ({
+      weight_lb: 185 - i * 0.03 + Math.sin(i) * 0.15,
+      calories: (i >= VACATION_START && i <= VACATION_END) ? null : 2100,
+    }));
+
+    const rClean = runAnalysis(makeWeightEntries(daysClean), makeNutritionEntries(daysClean));
+    const rVacation = runAnalysis(makeWeightEntries(daysWithVacation), makeNutritionEntries(daysWithVacation));
+
+    const mClean = rClean.bmrModel;
+    const mVacation = rVacation.bmrModel;
+
+    if (mClean.error || mVacation.error ||
+        mClean.source === 'profile_prior' || mVacation.source === 'profile_prior') return;
+
+    // When enough high-quality blocks exist and vacation blocks are excluded from fit,
+    // the fitted BMR should not shift dramatically (within 10% of each other)
+    const bmrClean = mClean.fittedBmr;
+    const bmrVacation = mVacation.fittedBmr;
+    if (bmrClean > 0 && bmrVacation > 0) {
+      const shift = Math.abs(bmrClean - bmrVacation) / bmrClean;
+      expect(shift).toBeLessThan(0.10); // less than 10% shift
+    }
+  });
+});

--- a/public/tools/CalorieTracker/constants.js
+++ b/public/tools/CalorieTracker/constants.js
@@ -221,6 +221,22 @@ export const DEFAULT_GOAL_SETTINGS = {
   manualTargetOverrides: {}, // { [nutrientKey]: number } — sparse, never auto-populated
 };
 
+// Analysis horizons (in days) for multi-window TDEE estimates
+export const ENERGY_HORIZONS = {
+  QUICK: 14,
+  PRIMARY: 28,
+  STABILITY_1: 42,
+  STABILITY_2: 56,
+};
+
+// Data sufficiency labels for confidence reporting
+export const DATA_SUFFICIENCY = {
+  NOT_ENOUGH: 'not_enough',
+  ROUGH: 'rough',
+  MODERATE: 'moderate',
+  HIGH: 'high',
+};
+
 // Helper functions for banking calculations
 export const BankingHelpers = {
   /**

--- a/public/tools/CalorieTracker/package.json
+++ b/public/tools/CalorieTracker/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "serve": "vite --host 0.0.0.0 --port 3000",
-    "test": "../../../node_modules/.bin/vitest run analysis/weightParser.test.js state/schema.test.js targets/targetEngine.test.js"
+    "test": "../../../node_modules/.bin/vitest run analysis/weightParser.test.js state/schema.test.js targets/targetEngine.test.js analysis/engine.test.js"
   },
   "devDependencies": {
     "vite": "^5.0.0"

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -97,6 +97,17 @@ export async function loadUserData() {
     state.baselineTargets = targets;
     state.weightEntries = weightEntries;
 
+    // Build multi-weigh-in map: all readings grouped by calendar date so the
+    // analysis engine can apply preferred-window selection when multiple readings
+    // exist for the same day (e.g. morning + evening scale syncs).
+    const multiMap = new Map();
+    for (const entry of weightEntries.values()) {
+      const d = entry.date;
+      if (!multiMap.has(d)) multiMap.set(d, []);
+      multiMap.get(d).push(entry);
+    }
+    state.weightEntriesMulti = multiMap;
+
     // Normalize every entry at read time so all v2 fields are present in memory.
     // We never write back just because we read — this is a pure in-memory upgrade.
     const normalizedEntries = new Map();

--- a/public/tools/CalorieTracker/state/store.js
+++ b/public/tools/CalorieTracker/state/store.js
@@ -15,9 +15,14 @@ export const state = {
   // A Map to store daily nutrition entries, with date strings as keys.
   dailyEntries: new Map(),
 
-  // A Map to store weight entries, with date strings as keys.
-  // Each value: { weight_lb, time_min, timestamp, source }
+  // A Map to store weight entries, keyed by Firestore document ID.
+  // Each value: { date, weight_lb, time_min, timestamp, source }
   weightEntries: new Map(),
+
+  // Multi-weigh-in map: Map<date-string, Array<{weight_lb, time_min, ...}>>
+  // Built from weightEntries by grouping all readings that share the same date.
+  // Used by the analysis engine to apply preferred-window selection.
+  weightEntriesMulti: new Map(),
 
   // Cached analysis results (recomputed when weight/nutrition data changes).
   analysisResults: null,


### PR DESCRIPTION
- engine.js: multi-horizon TDEE (14/28/42/56-day), OLS water-noise regression
  with uncertainty band, profile-based RMR fallback when <30 days of data,
  separate empiricalRestDayExpenditure and observedTdee outputs, data-sufficiency
  confidence scoring with plain-language reasons, logging residual without
  over-claiming "metabolic adaptation", selectDailyWeight with preferred-window
  support for multiple weigh-ins per day, runAnalysis accepts profile +
  weightEntriesMulti optional params
- analysisUI.js: confidence card with score bar, horizon TDEE table, rest-day
  burn KPI, observed TDEE KPI, model-vs-observed gap section, profile RMR card,
  uncertainty footnote; plain language throughout
- constants.js: ENERGY_HORIZONS and DATA_SUFFICIENCY exports
- state/store.js: weightEntriesMulti field (Map<date, Array>)
- services/data.js: populate weightEntriesMulti by grouping entries by date
- analysis/engine.test.js: 29 synthetic-data tests covering stable maintenance,
  fat loss, under-reporting, water swing, vacation gap, exercise weeks,
  profile fallback, and confidence scoring
- package.json: add engine.test.js to test command; install vitest at root

https://claude.ai/code/session_01DZjfhVwTgBiaFBGjk36xxJ