### PR TITLE
feat(CalorieTracker): build out Nutrients tab with filters, status summary, and chip picker

### DIFF
--- a/public/tools/CalorieTracker/events/wire.js
+++ b/public/tools/CalorieTracker/events/wire.js
@@ -25,6 +25,7 @@ import {
   estimateSessionCalories,
 } from '../exercise/met.js';
 import { getTodayInTimezone } from '../utils/time.js';
+import { resolveWeightKg } from '../ui/nutrientHelpers.js';
 
 /**
  * Main event wiring function - called from main.js after DOM is ready
@@ -441,13 +442,7 @@ function updateExerciseLiveEstimate() {
     manualCalories:   parseFloat(document.getElementById('es-manual-cal')?.value)   || null,
   };
 
-  // Resolve weight
-  const manual   = parseFloat(state.userProfile?.manualWeightOverrideLb);
-  const smoothed = state.analysisResults?.summary?.currentWeight;
-  const weightKg = (!isNaN(manual) && manual > 0) ? manual * 0.45359237
-                 : (smoothed && smoothed > 0)      ? smoothed * 0.45359237
-                 : 80;
-
+  const weightKg = resolveWeightKg();
   const { kcal, source } = estimateSessionCalories(session, weightKg);
   const sourceNote = source === 'manual' ? '(manual override)'
                    : source === 'wearable' ? '(from wearable)'
@@ -488,11 +483,7 @@ async function saveExerciseSession() {
     };
 
     // Compute and store the estimate so the analysis engine can use it
-    const manual   = parseFloat(state.userProfile?.manualWeightOverrideLb);
-    const smoothed = state.analysisResults?.summary?.currentWeight;
-    const weightKg = (!isNaN(manual) && manual > 0) ? manual * 0.45359237
-                   : (smoothed && smoothed > 0)      ? smoothed * 0.45359237
-                   : 80;
+    const weightKg = resolveWeightKg();
     const { kcal, source, met } = estimateSessionCalories(session, weightKg);
     session.estimatedCalories = kcal;
     session.metValue          = met;

--- a/public/tools/CalorieTracker/exercise/met.js
+++ b/public/tools/CalorieTracker/exercise/met.js
@@ -7,6 +7,8 @@
  * Priority per session: manualCalories > wearableCalories > MET estimate
  */
 
+import { DAY_ACTIVITY_LEVELS } from '../constants.js';
+
 // ---------------------------------------------------------------------------
 // Activity type definitions
 // ---------------------------------------------------------------------------
@@ -164,4 +166,39 @@ export function hasHeavyTraining(sessions) {
     ['hard', 'very_hard'].includes(s.intensity) &&
     (parseFloat(s.durationMin) || 0) >= 45
   );
+}
+
+// ---------------------------------------------------------------------------
+// Entry-level exercise calorie helper (shared between dashboard and chart)
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the effective exercise calorie bump for a daily entry.
+ *
+ * Priority:
+ *  1. exerciseSessions (MET / wearable / manual — most accurate)
+ *  2. dayActivityLevel bump (quick-select, no detailed sessions)
+ *  3. Legacy trainingBump (old stored data — preserved exactly)
+ *
+ * Pure function — no DOM or state access.
+ *
+ * @param {object|null} entry    - Daily entry object (may be null/undefined).
+ * @param {number}      weightKg - Body weight for MET calculation (default 80 kg).
+ * @returns {number} Exercise kcal for this day.
+ */
+export function getEntryExerciseKcal(entry, weightKg = 80) {
+  const sessions = entry?.exerciseSessions;
+  if (Array.isArray(sessions) && sessions.length > 0) {
+    return computeSessionTotals(sessions, weightKg).totalKcal;
+  }
+  const level = entry?.dayActivityLevel;
+  const legacyBump = parseFloat(entry?.trainingBump);
+  // Legacy trainingBump stored without a level → use it exactly (backward compat)
+  if (!isNaN(legacyBump) && legacyBump > 0 && !level) {
+    return legacyBump;
+  }
+  if (level && level !== 'rest' && level !== 'custom') {
+    return (DAY_ACTIVITY_LEVELS[level]?.bump) || 0;
+  }
+  return !isNaN(legacyBump) ? legacyBump : 0;
 }

--- a/public/tools/CalorieTracker/exercise/met.js
+++ b/public/tools/CalorieTracker/exercise/met.js
@@ -191,14 +191,18 @@ export function getEntryExerciseKcal(entry, weightKg = 80) {
   if (Array.isArray(sessions) && sessions.length > 0) {
     return computeSessionTotals(sessions, weightKg).totalKcal;
   }
-  const level = entry?.dayActivityLevel;
   const legacyBump = parseFloat(entry?.trainingBump);
-  // Legacy trainingBump stored without a level → use it exactly (backward compat)
-  if (!isNaN(legacyBump) && legacyBump > 0 && !level) {
+  // A positive stored trainingBump is the exact authoritative value for that day.
+  // normalizeEntry() derives dayActivityLevel from it in memory, but the derivation
+  // is lossy (e.g. 280 → medium = 200, 400 → heavy = 350). Prefer the original.
+  // New entries from the quick-select UI do not have trainingBump set, so they
+  // fall through to the dayActivityLevel branch below.
+  if (!isNaN(legacyBump) && legacyBump > 0) {
     return legacyBump;
   }
+  const level = entry?.dayActivityLevel;
   if (level && level !== 'rest' && level !== 'custom') {
     return (DAY_ACTIVITY_LEVELS[level]?.bump) || 0;
   }
-  return !isNaN(legacyBump) ? legacyBump : 0;
+  return 0;
 }

--- a/public/tools/CalorieTracker/exercise/met.test.js
+++ b/public/tools/CalorieTracker/exercise/met.test.js
@@ -10,6 +10,7 @@ import {
   computeSessionTotals,
   hasMeaningfulSweatActivity,
   hasHeavyTraining,
+  getEntryExerciseKcal,
   ACTIVITY_TYPES,
   SWEAT_ACTIVITIES,
 } from './met.js';
@@ -240,6 +241,63 @@ describe('hasHeavyTraining', () => {
   it('returns false for moderate session ≥45 min', () => {
     const sessions = [{ activityType: 'lifting', intensity: 'moderate', durationMin: 60 }];
     expect(hasHeavyTraining(sessions)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEntryExerciseKcal — priority chain
+// ---------------------------------------------------------------------------
+
+describe('getEntryExerciseKcal priority chain', () => {
+  it('uses exerciseSessions when present, ignoring level and trainingBump', () => {
+    const entry = {
+      exerciseSessions: [{ activityType: 'lifting', durationMin: 60, intensity: 'moderate' }],
+      dayActivityLevel: 'heavy',
+      trainingBump: 999,
+    };
+    // lifting moderate 1h × 80kg = 5.0 × 80 × 1 = 400
+    expect(getEntryExerciseKcal(entry, 80)).toBe(400);
+  });
+
+  it('falls through to level/bump when exerciseSessions is empty array', () => {
+    const entry = { exerciseSessions: [], dayActivityLevel: 'medium' };
+    // medium bump = 200
+    expect(getEntryExerciseKcal(entry, 80)).toBe(200);
+  });
+
+  it('uses dayActivityLevel bump when level is set and not rest/custom', () => {
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'heavy' }, 80)).toBe(350);
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'light' }, 80)).toBe(100);
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'medium' }, 80)).toBe(200);
+  });
+
+  it('returns 0 for rest level', () => {
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'rest' }, 80)).toBe(0);
+  });
+
+  it('returns 0 for custom level (sessions provide actual calories)', () => {
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'custom' }, 80)).toBe(0);
+  });
+
+  it('uses legacy trainingBump when no level is set', () => {
+    expect(getEntryExerciseKcal({ trainingBump: 250 }, 80)).toBe(250);
+  });
+
+  it('prefers dayActivityLevel over legacy trainingBump when both present', () => {
+    // level='light'→100, not trainingBump=999
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'light', trainingBump: 999 }, 80)).toBe(100);
+  });
+
+  it('returns 0 for null entry', () => {
+    expect(getEntryExerciseKcal(null, 80)).toBe(0);
+  });
+
+  it('returns 0 for undefined entry', () => {
+    expect(getEntryExerciseKcal(undefined, 80)).toBe(0);
+  });
+
+  it('returns 0 for empty entry object', () => {
+    expect(getEntryExerciseKcal({}, 80)).toBe(0);
   });
 });
 

--- a/public/tools/CalorieTracker/exercise/met.test.js
+++ b/public/tools/CalorieTracker/exercise/met.test.js
@@ -283,9 +283,57 @@ describe('getEntryExerciseKcal priority chain', () => {
     expect(getEntryExerciseKcal({ trainingBump: 250 }, 80)).toBe(250);
   });
 
-  it('prefers dayActivityLevel over legacy trainingBump when both present', () => {
-    // level='light'→100, not trainingBump=999
-    expect(getEntryExerciseKcal({ dayActivityLevel: 'light', trainingBump: 999 }, 80)).toBe(100);
+  it('prefers stored trainingBump over derived dayActivityLevel when both present', () => {
+    // normalizeEntry() derives dayActivityLevel='light' from trainingBump=999 in memory,
+    // but the exact stored value must win
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'light', trainingBump: 999 }, 80)).toBe(999);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEntryExerciseKcal — legacy trainingBump exactness (regression)
+// ---------------------------------------------------------------------------
+
+describe('getEntryExerciseKcal legacy trainingBump exactness', () => {
+  it('exerciseSessions still win over trainingBump and derived level', () => {
+    const entry = {
+      exerciseSessions: [{ activityType: 'lifting', durationMin: 60, intensity: 'moderate' }],
+      dayActivityLevel: 'heavy',
+      trainingBump: 400,
+    };
+    // Sessions: 5.0 MET × 80 kg × 1 h = 400 — same coincidental value, confirms sessions path
+    expect(getEntryExerciseKcal(entry, 80)).toBe(400);
+    // Verify with a different weight to distinguish sessions from trainingBump path
+    expect(getEntryExerciseKcal({ ...entry, trainingBump: 999 }, 70)).toBe(350); // 5.0×70×1
+  });
+
+  it('trainingBump=280 with derived dayActivityLevel=medium returns 280, not 200', () => {
+    // normalizeEntry() maps 280 → 'medium'; DAY_ACTIVITY_LEVELS.medium.bump = 200
+    const entry = { trainingBump: 280, dayActivityLevel: 'medium' };
+    expect(getEntryExerciseKcal(entry, 80)).toBe(280);
+  });
+
+  it('trainingBump=400 with derived dayActivityLevel=heavy returns 400, not 350', () => {
+    // normalizeEntry() maps 400 → 'heavy'; DAY_ACTIVITY_LEVELS.heavy.bump = 350
+    const entry = { trainingBump: 400, dayActivityLevel: 'heavy' };
+    expect(getEntryExerciseKcal(entry, 80)).toBe(400);
+  });
+
+  it('new entry with dayActivityLevel=medium and no trainingBump returns configured bump', () => {
+    // Modern quick-select entries have no trainingBump — level is authoritative
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'medium' }, 80)).toBe(200);
+  });
+
+  it('custom level with no trainingBump returns 0 (sessions will provide calories)', () => {
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'custom' }, 80)).toBe(0);
+  });
+
+  it('rest level with no trainingBump returns 0', () => {
+    expect(getEntryExerciseKcal({ dayActivityLevel: 'rest' }, 80)).toBe(0);
+  });
+
+  it('trainingBump=0 with a level still uses the level (0 is not a stored bump)', () => {
+    expect(getEntryExerciseKcal({ trainingBump: 0, dayActivityLevel: 'medium' }, 80)).toBe(200);
   });
 
   it('returns 0 for null entry', () => {

--- a/public/tools/CalorieTracker/package.json
+++ b/public/tools/CalorieTracker/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "serve": "vite --host 0.0.0.0 --port 3000",
-    "test": "../../../node_modules/.bin/vitest run analysis/weightParser.test.js state/schema.test.js targets/targetEngine.test.js analysis/engine.test.js exercise/met.test.js"
+    "test": "../../../node_modules/.bin/vitest run analysis/weightParser.test.js state/schema.test.js targets/targetEngine.test.js analysis/engine.test.js exercise/met.test.js ui/nutrientHelpers.test.js"
   },
   "devDependencies": {
     "vite": "^5.0.0"

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -27,6 +27,7 @@ import {
   INTENSITY_LABELS,
   estimateSessionCalories,
 } from '../exercise/met.js';
+import { resolveWeightKg } from '../ui/nutrientHelpers.js';
 
 // Re-export so other modules that imported normalize functions from data.js
 // keep working without changes.
@@ -441,18 +442,6 @@ export function getDataSummary() {
 // ---------------------------------------------------------------------------
 // Exercise session helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Resolve the user's current body weight in kg for MET calculations.
- * Prefers smoothed analysis weight, falls back to manual override, then 80 kg.
- */
-function resolveWeightKg() {
-  const manual = parseFloat(state.userProfile?.manualWeightOverrideLb);
-  if (!isNaN(manual) && manual > 0) return manual * 0.45359237;
-  const smoothed = state.analysisResults?.summary?.currentWeight;
-  if (smoothed && smoothed > 0) return smoothed * 0.45359237;
-  return 80; // population fallback
-}
 
 /**
  * Render the compact exercise sessions list into #exercise-sessions-list.

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -618,6 +618,171 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
 }
 
 /* ============================================================
+   CHART CHIP PICKER  (replaces <select multiple> for nutrient selection)
+   ============================================================ */
+.chart-chip-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .375rem;
+}
+
+.chart-chip {
+  padding: .25rem .65rem;
+  font-size: .75rem;
+  line-height: 1.2;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--surface-2));
+  color: hsl(var(--text-3));
+  cursor: pointer;
+  white-space: nowrap;
+  font-family: inherit;
+  transition: border-color .15s, background .15s, color .15s;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.chart-chip:hover {
+  border-color: hsl(var(--accent) / .5);
+  color: hsl(var(--text));
+}
+
+.chart-chip.active {
+  background: hsl(var(--accent) / .15);
+  border-color: hsl(var(--accent));
+  color: hsl(var(--accent));
+  font-weight: 600;
+}
+
+/* ============================================================
+   NUTRIENT FILTER BAR
+   ============================================================ */
+.nutrient-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .375rem;
+}
+
+.nutrient-filter-chip {
+  padding: .25rem .75rem;
+  font-size: .8125rem;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--surface-2));
+  color: hsl(var(--text-2));
+  cursor: pointer;
+  white-space: nowrap;
+  font-family: inherit;
+  transition: border-color .15s, background .15s, color .15s;
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.nutrient-filter-chip:hover {
+  border-color: hsl(var(--accent) / .5);
+  color: hsl(var(--text));
+}
+
+.nutrient-filter-chip.active {
+  background: hsl(var(--accent) / .15);
+  border-color: hsl(var(--accent));
+  color: hsl(var(--accent));
+  font-weight: 600;
+}
+
+/* ============================================================
+   NUTRIENT STATUS SUMMARY GRID
+   ============================================================ */
+.nutrient-status-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: .5rem;
+}
+
+.nutrient-status-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: .625rem .5rem;
+  background: hsl(var(--surface-1));
+  border: 1px solid hsl(var(--border));
+  border-radius: .75rem;
+  text-align: center;
+}
+
+.nutrient-status-icon  { font-size: 1.1rem; margin-bottom: .15rem; }
+.nutrient-status-count { font-size: 1.375rem; font-weight: 700; line-height: 1; }
+.nutrient-status-label { font-size: .6875rem; color: hsl(var(--text-3)); margin-top: .15rem; }
+
+/* ============================================================
+   NUTRIENT INLINE BADGES  (.nt-badge variants)
+   ============================================================ */
+.nt-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: .65rem;
+  padding: .1em .35em;
+  border-radius: .25rem;
+  margin-left: .25rem;
+  vertical-align: middle;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.nt-badge-override { background: hsl(var(--accent) / .15);  color: hsl(var(--accent)); }
+.nt-badge-custom   { background: hsl(var(--info)   / .15);  color: hsl(var(--info)); }
+.nt-badge-scale    { background: hsl(var(--warning) / .15); color: hsl(var(--warning)); }
+.nt-badge-ul       { background: hsl(var(--error)   / .12); color: hsl(var(--warning)); }
+
+.nt-trend {
+  font-size: .8em;
+  margin-left: .2rem;
+  vertical-align: middle;
+}
+
+.nt-avg-label {
+  font-size: .65rem;
+  color: hsl(var(--text-3));
+  margin-left: .2rem;
+  font-weight: 400;
+}
+
+/* Sub-detail line below the KPI bar (today / 3d-avg for averaged nutrients) */
+.nt-sub-detail {
+  grid-column: 1 / -1;
+  font-size: .72rem;
+  color: hsl(var(--text-3));
+  padding-top: .1rem;
+  padding-bottom: .2rem;
+  padding-left: calc(6rem + .75rem);
+}
+
+/* ============================================================
+   NUTRIENT TAGS (shortfall / UL summary lists)
+   ============================================================ */
+.nutrient-tag {
+  display: inline-flex;
+  padding: .15rem .5rem;
+  border-radius: 999px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.nutrient-tag-bad  {
+  background: hsl(var(--error)   / .12);
+  color: hsl(var(--error));
+  border: 1px solid hsl(var(--error)   / .3);
+}
+
+.nutrient-tag-warn {
+  background: hsl(var(--warning) / .12);
+  color: hsl(var(--warning));
+  border: 1px solid hsl(var(--warning) / .3);
+}
+
+/* ============================================================
    MOBILE TWEAKS  (< 480 px)
    ============================================================ */
 @media (max-width: 480px) {
@@ -631,4 +796,11 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
   .settings-panel    { padding: 1rem .75rem; }
   .settings-section  { padding: 1rem .75rem; border-radius: .75rem; }
   .chart-container   { height: 280px; }
+  /* Collapse status grid to 2 cols on small phones */
+  .nutrient-status-grid { grid-template-columns: repeat(2, 1fr); }
+  /* Slightly larger chips for touch targets */
+  .chart-chip        { min-height: 36px; font-size: .8rem; }
+  .nutrient-filter-chip { min-height: 40px; }
+  /* Hide sub-detail on very small screens to save space */
+  .nt-sub-detail     { padding-left: 0; }
 }

--- a/public/tools/CalorieTracker/ui/chart.js
+++ b/public/tools/CalorieTracker/ui/chart.js
@@ -103,58 +103,49 @@ function adjustColor(color, amount) {
 // =========================
 
 /**
- * Initialize chart controls and set up event listeners
+ * Initialize chart controls with chip-based nutrient picker and set up event listeners.
  */
 export function initializeChartControls() {
   try {
     debugLog('init-controls', 'Starting chart controls initialization');
-    
-    const chartNutrients = document.getElementById('chart-nutrients');
+
+    const chipContainer = document.getElementById('chart-nutrient-chips');
     const chartTimeframe = document.getElementById('chart-timeframe');
     const show3DayAvg = document.getElementById('show-3day-avg');
     const show7DayAvg = document.getElementById('show-7day-avg');
 
-    if (!chartNutrients) {
-      debugLog('init-controls', 'Chart nutrients selector not in DOM – skipping init');
+    if (!chipContainer) {
+      debugLog('init-controls', 'chart-nutrient-chips not in DOM – skipping init');
       return;
     }
 
-    // Populate nutrient selector
-    chartNutrients.innerHTML = '';
+    // Populate chip buttons (one per nutrient)
+    chipContainer.innerHTML = '';
     allNutrients.forEach(nutrient => {
-      const option = document.createElement('option');
-      option.value = nutrient;
-      option.textContent = formatNutrientName(nutrient);
-      if (nutrient === CHART_CONFIG.DEFAULT_NUTRIENT) option.selected = true;
-      chartNutrients.appendChild(option);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'chart-chip';
+      btn.dataset.nutrient = nutrient;
+      btn.textContent = formatNutrientName(nutrient);
+      if (nutrient === CHART_CONFIG.DEFAULT_NUTRIENT) btn.classList.add('active');
+      btn.addEventListener('click', () => {
+        btn.classList.toggle('active');
+        try { updateChart(); } catch (err) { handleChartError('chip-click', err); }
+      });
+      chipContainer.appendChild(btn);
     });
 
     // Set default timeframe
-    if (chartTimeframe) {
-      chartTimeframe.value = CHART_CONFIG.DEFAULT_TIMEFRAME;
-    }
+    if (chartTimeframe) chartTimeframe.value = CHART_CONFIG.DEFAULT_TIMEFRAME;
 
-    // Add event listeners with error handling
-    const addEventListenerSafe = (element, event, handler) => {
-      if (element) {
-        element.addEventListener(event, (e) => {
-          try {
-            handler(e);
-          } catch (error) {
-            handleChartError('event-handler', error);
-          }
-        });
-      }
+    const safe = (el, ev, fn) => {
+      if (el) el.addEventListener(ev, e => { try { fn(e); } catch (err) { handleChartError('event-handler', err); } });
     };
-
-    addEventListenerSafe(chartNutrients, 'change', updateChart);
-    addEventListenerSafe(chartTimeframe, 'change', updateChart);
-    addEventListenerSafe(show3DayAvg, 'change', updateChart);
-    addEventListenerSafe(show7DayAvg, 'change', updateChart);
+    safe(chartTimeframe, 'change', updateChart);
+    safe(show3DayAvg,   'change', updateChart);
+    safe(show7DayAvg,   'change', updateChart);
 
     debugLog('init-controls', 'Chart controls initialized successfully');
-
-    // Initial chart render
     updateChart();
 
   } catch (error) {
@@ -394,17 +385,17 @@ export function updateChart() {
       return;
     }
 
-    const chartNutrients = document.getElementById('chart-nutrients');
     const chartTimeframe = document.getElementById('chart-timeframe');
     const show3DayAvg = document.getElementById('show-3day-avg');
     const show7DayAvg = document.getElementById('show-7day-avg');
-    
-    if (!chartNutrients) {
-      debugLog('update-chart', 'Chart nutrients selector not in DOM – skipping update');
+
+    const activeChips = document.querySelectorAll('#chart-nutrient-chips .chart-chip.active');
+    if (!activeChips.length) {
+      debugLog('update-chart', 'chart-nutrient-chips not in DOM – skipping update');
       return;
     }
 
-    const selectedNutrients = Array.from(chartNutrients.selectedOptions).map(o => o.value);
+    const selectedNutrients = Array.from(activeChips).map(c => c.dataset.nutrient);
     const timeframe = chartTimeframe?.value || CHART_CONFIG.DEFAULT_TIMEFRAME;
     const show3Day = show3DayAvg?.checked || false;
     const show7Day = show7DayAvg?.checked || false;

--- a/public/tools/CalorieTracker/ui/chart.js
+++ b/public/tools/CalorieTracker/ui/chart.js
@@ -9,6 +9,7 @@ import { allNutrients, averagedNutrients } from '../constants.js';
 import { formatNutrientName } from '../utils/ui.js';
 import { getPastDate, formatDate } from '../utils/time.js';
 import { getEntryExerciseKcal } from '../exercise/met.js';
+import { resolveWeightKg } from './nutrientHelpers.js';
 
 // =========================
 // CONFIGURATION (Top of file for easy modification)
@@ -56,23 +57,6 @@ const _chartState = {
   show3Day: false,
   show7Day: false,
 };
-
-// ---------------------------------------------------------------------------
-// Weight resolution (approximation for historical chart data)
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve current body weight in kg from state.
- * Used as an approximation for historical exercise calorie calculations.
- * Falls back to 80 kg when no weight data is available.
- */
-function resolveWeightKg() {
-  const manual = parseFloat(state.userProfile?.manualWeightOverrideLb);
-  if (!isNaN(manual) && manual > 0) return manual * 0.45359237;
-  const smoothed = state.analysisResults?.summary?.currentWeight;
-  if (smoothed && smoothed > 0) return smoothed * 0.45359237;
-  return 80;
-}
 
 // =========================
 // HELPER FUNCTIONS
@@ -206,14 +190,9 @@ function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = fals
     
     const endDate = new Date(`${state.dom.dateInput.value}T00:00:00`);
     
-    // Determine number of days to show
     let days = 7;
-    switch (timeframe) {
-      case '3days': days = 3; break;
-      case 'week': days = 7; break;
-      case 'month': days = 30; break;
-      default: days = 7;
-    }
+    if (timeframe === '3days') days = 3;
+    else if (timeframe === 'month') days = 30;
 
     // Get extra days for moving averages
     const maxAvgDays = Math.max(show3Day ? 3 : 0, show7Day ? 7 : 0);
@@ -224,34 +203,24 @@ function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = fals
     const datasets = [];
     const tableData = {};
 
-    // Generate all date labels
     for (let i = totalDaysNeeded - 1; i >= 0; i--) {
-      const date = getPastDate(endDate, i);
-      allLabels.push(formatDate(date));
+      allLabels.push(formatDate(getPastDate(endDate, i)));
     }
-
-    // Generate display labels (the dates we actually show on chart)
     for (let i = days - 1; i >= 0; i--) {
-      const date = getPastDate(endDate, i);
-      const dateStr = formatDate(date);
+      const dateStr = formatDate(getPastDate(endDate, i));
       displayLabels.push(dateStr);
       tableData[dateStr] = {};
     }
 
-    // Create datasets for each selected nutrient
+    // Resolve weight once for all calorie-target calculations (approximation for history)
+    const weightKg = resolveWeightKg();
+
     nutrientKeys.forEach((nutrient, idx) => {
       const color = CONFIG.CHART_COLORS[idx % CONFIG.CHART_COLORS.length];
-
-      // For calories, the target is per-date: base goal + that day's exercise calories.
-      // Uses the full priority chain (sessions > dayActivityLevel > legacy trainingBump)
-      // so the chart matches the rolling-budget panel exactly.
-      // Current weight is used as an approximation for all historical dates.
       const baseTarget = parseFloat(state.baselineTargets[nutrient]) || 1;
-      const weightKg = resolveWeightKg();
       const getDateTarget = (dateStr) => {
         if (nutrient === 'calories') {
-          const entry = state.dailyEntries.get(dateStr) || {};
-          return baseTarget + getEntryExerciseKcal(entry, weightKg);
+          return baseTarget + getEntryExerciseKcal(state.dailyEntries.get(dateStr) || {}, weightKg);
         }
         return baseTarget;
       };
@@ -424,9 +393,23 @@ export function updateChart() {
     const show3DayAvg = document.getElementById('show-3day-avg');
     const show7DayAvg = document.getElementById('show-7day-avg');
 
-    const activeChips = document.querySelectorAll('#chart-nutrient-chips .chart-chip.active');
-    if (!activeChips.length) {
+    const chipContainer = document.getElementById('chart-nutrient-chips');
+    if (!chipContainer) {
       debugLog('update-chart', 'chart-nutrient-chips not in DOM – skipping update');
+      return;
+    }
+
+    const activeChips = chipContainer.querySelectorAll('.chart-chip.active');
+    if (!activeChips.length) {
+      // Empty selection: clear stale chart and show a hint in the table area
+      if (state.chartInstance) {
+        state.chartInstance.destroy();
+        state.chartInstance = null;
+      }
+      const tableContainer = document.getElementById('chart-table');
+      if (tableContainer) {
+        tableContainer.innerHTML = '<p class="text-muted text-center py-4">Select at least one nutrient above to show the chart.</p>';
+      }
       return;
     }
 
@@ -434,11 +417,6 @@ export function updateChart() {
     const timeframe = chartTimeframe?.value || CHART_CONFIG.DEFAULT_TIMEFRAME;
     const show3Day = show3DayAvg?.checked || false;
     const show7Day = show7DayAvg?.checked || false;
-
-    if (selectedNutrients.length === 0) {
-      debugLog('update-chart', 'No nutrients selected');
-      return;
-    }
 
     const { labels, datasets, tableData } = getChartData(selectedNutrients, timeframe, show3Day, show7Day);
     const canvas = document.getElementById('nutrition-chart');

--- a/public/tools/CalorieTracker/ui/chart.js
+++ b/public/tools/CalorieTracker/ui/chart.js
@@ -8,6 +8,7 @@ import { CONFIG } from '../config.js';
 import { allNutrients, averagedNutrients } from '../constants.js';
 import { formatNutrientName } from '../utils/ui.js';
 import { getPastDate, formatDate } from '../utils/time.js';
+import { getEntryExerciseKcal } from '../exercise/met.js';
 
 // =========================
 // CONFIGURATION (Top of file for easy modification)
@@ -45,6 +46,33 @@ const css = getComputedStyle(document.documentElement);
 const borderColor = `hsl(${css.getPropertyValue('--border').trim()})`;
 
 // Chart colors are provided by CONFIG.CHART_COLORS
+
+// ---------------------------------------------------------------------------
+// Module-level chart state — persists across re-renders of the Nutrients tab
+// ---------------------------------------------------------------------------
+const _chartState = {
+  selectedNutrients: new Set([CHART_CONFIG.DEFAULT_NUTRIENT]),
+  timeframe: CHART_CONFIG.DEFAULT_TIMEFRAME,
+  show3Day: false,
+  show7Day: false,
+};
+
+// ---------------------------------------------------------------------------
+// Weight resolution (approximation for historical chart data)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve current body weight in kg from state.
+ * Used as an approximation for historical exercise calorie calculations.
+ * Falls back to 80 kg when no weight data is available.
+ */
+function resolveWeightKg() {
+  const manual = parseFloat(state.userProfile?.manualWeightOverrideLb);
+  if (!isNaN(manual) && manual > 0) return manual * 0.45359237;
+  const smoothed = state.analysisResults?.summary?.currentWeight;
+  if (smoothed && smoothed > 0) return smoothed * 0.45359237;
+  return 80;
+}
 
 // =========================
 // HELPER FUNCTIONS
@@ -119,7 +147,7 @@ export function initializeChartControls() {
       return;
     }
 
-    // Populate chip buttons (one per nutrient)
+    // Populate chip buttons (one per nutrient), restoring prior selection from _chartState
     chipContainer.innerHTML = '';
     allNutrients.forEach(nutrient => {
       const btn = document.createElement('button');
@@ -127,23 +155,30 @@ export function initializeChartControls() {
       btn.className = 'chart-chip';
       btn.dataset.nutrient = nutrient;
       btn.textContent = formatNutrientName(nutrient);
-      if (nutrient === CHART_CONFIG.DEFAULT_NUTRIENT) btn.classList.add('active');
+      if (_chartState.selectedNutrients.has(nutrient)) btn.classList.add('active');
       btn.addEventListener('click', () => {
         btn.classList.toggle('active');
+        if (btn.classList.contains('active')) {
+          _chartState.selectedNutrients.add(nutrient);
+        } else {
+          _chartState.selectedNutrients.delete(nutrient);
+        }
         try { updateChart(); } catch (err) { handleChartError('chip-click', err); }
       });
       chipContainer.appendChild(btn);
     });
 
-    // Set default timeframe
-    if (chartTimeframe) chartTimeframe.value = CHART_CONFIG.DEFAULT_TIMEFRAME;
+    // Restore timeframe and avg toggles from _chartState
+    if (chartTimeframe) chartTimeframe.value = _chartState.timeframe;
+    if (show3DayAvg)   show3DayAvg.checked   = _chartState.show3Day;
+    if (show7DayAvg)   show7DayAvg.checked   = _chartState.show7Day;
 
     const safe = (el, ev, fn) => {
       if (el) el.addEventListener(ev, e => { try { fn(e); } catch (err) { handleChartError('event-handler', err); } });
     };
-    safe(chartTimeframe, 'change', updateChart);
-    safe(show3DayAvg,   'change', updateChart);
-    safe(show7DayAvg,   'change', updateChart);
+    safe(chartTimeframe, 'change', (e) => { _chartState.timeframe = e.target.value; updateChart(); });
+    safe(show3DayAvg,   'change', (e) => { _chartState.show3Day  = e.target.checked; updateChart(); });
+    safe(show7DayAvg,   'change', (e) => { _chartState.show7Day  = e.target.checked; updateChart(); });
 
     debugLog('init-controls', 'Chart controls initialized successfully');
     updateChart();
@@ -207,16 +242,16 @@ function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = fals
     nutrientKeys.forEach((nutrient, idx) => {
       const color = CONFIG.CHART_COLORS[idx % CONFIG.CHART_COLORS.length];
 
-      // For calories, the target is per-date: base goal + that day's training bump.
-      // This mirrors what the daily plan panel shows and the rolling-budget system uses,
-      // so the chart correctly reflects whether the user hit their adjusted target.
-      // For all other nutrients, the baseline target is a fixed value.
+      // For calories, the target is per-date: base goal + that day's exercise calories.
+      // Uses the full priority chain (sessions > dayActivityLevel > legacy trainingBump)
+      // so the chart matches the rolling-budget panel exactly.
+      // Current weight is used as an approximation for all historical dates.
       const baseTarget = parseFloat(state.baselineTargets[nutrient]) || 1;
+      const weightKg = resolveWeightKg();
       const getDateTarget = (dateStr) => {
         if (nutrient === 'calories') {
           const entry = state.dailyEntries.get(dateStr) || {};
-          const bump = parseFloat(entry.trainingBump) || 0;
-          return baseTarget + bump;
+          return baseTarget + getEntryExerciseKcal(entry, weightKg);
         }
         return baseTarget;
       };

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -23,7 +23,7 @@ import {
   hasHeavyTraining,
   getEntryExerciseKcal,
 } from '../exercise/met.js';
-import { computeTrendDirection, classifyTargetSource } from './nutrientHelpers.js';
+import { computeTrendDirection, classifyTargetSource, resolveWeightKg } from './nutrientHelpers.js';
 import { formatNutrientName } from '../utils/ui.js';
 import { getPastDate, formatDate } from '../utils/time.js';
 import { initializeChartControls } from './chart.js';
@@ -106,18 +106,6 @@ function handleError(operation, error, userMessage) {
       `;
     }
   }
-}
-
-/**
- * Resolve current weight in kg from state (for MET estimates and banking).
- * Falls back to 80 kg if no weight data is available.
- */
-function resolveWeightKg() {
-  const manual = parseFloat(state.userProfile?.manualWeightOverrideLb);
-  if (!isNaN(manual) && manual > 0) return manual * 0.45359237;
-  const smoothed = state.analysisResults?.summary?.currentWeight;
-  if (smoothed && smoothed > 0) return smoothed * 0.45359237;
-  return 80;
 }
 
 /**

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -21,7 +21,9 @@ import {
   computeSessionTotals,
   hasMeaningfulSweatActivity,
   hasHeavyTraining,
+  getEntryExerciseKcal,
 } from '../exercise/met.js';
+import { computeTrendDirection, classifyTargetSource } from './nutrientHelpers.js';
 import { formatNutrientName } from '../utils/ui.js';
 import { getPastDate, formatDate } from '../utils/time.js';
 import { initializeChartControls } from './chart.js';
@@ -116,38 +118,6 @@ function resolveWeightKg() {
   const smoothed = state.analysisResults?.summary?.currentWeight;
   if (smoothed && smoothed > 0) return smoothed * 0.45359237;
   return 80;
-}
-
-/**
- * Get the effective exercise calorie bump for a daily entry.
- *
- * Priority:
- *  1. exerciseSessions (with MET / wearable / manual estimate)
- *  2. dayActivityLevel bump (new entries without sessions)
- *  3. Legacy trainingBump (old stored data — preserved exactly)
- *
- * @param {object} entry    - Daily entry from state.dailyEntries.
- * @param {number} weightKg - Body weight for MET calculation.
- * @returns {number} Exercise calories for this day.
- */
-function getEntryExerciseKcal(entry, weightKg) {
-  const sessions = entry?.exerciseSessions;
-  if (Array.isArray(sessions) && sessions.length > 0) {
-    return computeSessionTotals(sessions, weightKg).totalKcal;
-  }
-  // No sessions — check dayActivityLevel (new entries)
-  const level = entry?.dayActivityLevel;
-  const legacyBump = parseFloat(entry?.trainingBump);
-  // If a legacy trainingBump was stored, use it exactly (backward compat)
-  if (!isNaN(legacyBump) && legacyBump > 0 && !level) {
-    return legacyBump;
-  }
-  if (level && level !== 'rest' && level !== 'custom') {
-    return (DAY_ACTIVITY_LEVELS[level]?.bump) || 0;
-  }
-  // For legacy entries that normalizeEntry migrated to dayActivityLevel,
-  // trainingBump is the authoritative stored value; use it.
-  return !isNaN(legacyBump) ? legacyBump : 0;
 }
 
 /**
@@ -404,8 +374,12 @@ export function calculateMicronutrientMetrics(dateStr) {
       let threeDayAvg = 0;
       let status = 'red';
 
+      let trendDirection = 'stable';
+
       if (averagedNutrients.includes(nutrient)) {
+        // Accumulate 7-day window with separate buckets for recent (0-2) and prior (3-6)
         let sum7 = 0, count7 = 0, sum3 = 0, count3 = 0;
+        let sumPrior = 0, nonZeroPriorCount = 0;
         for (let i = 0; i < 7; i++) {
           const pd = getPastDate(targetDate, i);
           const pds = formatDate(pd);
@@ -413,6 +387,7 @@ export function calculateMicronutrientMetrics(dateStr) {
           const intake = pds === dateStr ? todaysIntake : parseFloat(entry[nutrient]) || 0;
           sum7 += intake; count7++;
           if (i < 3) { sum3 += intake; count3++; }
+          else if (intake > 0) { sumPrior += intake; nonZeroPriorCount++; }
         }
         avgIntake = count7 > 0 ? sum7 / count7 : 0;
         threeDayAvg = count3 > 0 ? sum3 / count3 : 0;
@@ -420,38 +395,40 @@ export function calculateMicronutrientMetrics(dateStr) {
         if (avgIntake >= baseTarget * 0.9) status = 'green';
         else if (avgIntake >= baseTarget * 0.7) status = 'amber';
         else status = 'red';
+
+        // Trend: compare recent 3-day avg vs non-overlapping prior window (days 3-6)
+        const priorAvg = nonZeroPriorCount >= 2 ? sumPrior / nonZeroPriorCount : null;
+        trendDirection = computeTrendDirection(threeDayAvg, priorAvg);
       } else {
-        // For daily-floor nutrients, also compute 3-day average for trend
+        // For daily-floor nutrients, also compute the 3-day avg and compare today vs prior 2 days
         let sum3 = 0, count3 = 0;
+        let sumPrior = 0, nonZeroPriorCount = 0;
         for (let i = 0; i < 3; i++) {
           const pd = getPastDate(targetDate, i);
           const pds = formatDate(pd);
           const entry = state.dailyEntries.get(pds) || {};
           const intake = pds === dateStr ? todaysIntake : parseFloat(entry[nutrient]) || 0;
           sum3 += intake; count3++;
+          if (i >= 1 && intake > 0) { sumPrior += intake; nonZeroPriorCount++; }
         }
         threeDayAvg = count3 > 0 ? sum3 / count3 : 0;
 
         if (todaysIntake >= scaledTarget) status = 'green';
         else if (todaysIntake >= scaledTarget * 0.8) status = 'amber';
         else status = 'red';
+
+        // Trend: today vs average of the prior 2 days (non-overlapping)
+        const priorAvg = nonZeroPriorCount >= 1 ? sumPrior / nonZeroPriorCount : null;
+        trendDirection = computeTrendDirection(todaysIntake, priorAvg);
       }
 
-      // Trend: compare 3-day avg to the primary display value
-      const primaryValue = averagedNutrients.includes(nutrient) ? avgIntake : todaysIntake;
-      const trendRatio = primaryValue > 0 ? (threeDayAvg - primaryValue) / primaryValue : 0;
-      const trendDirection = trendRatio > 0.05 ? 'up' : trendRatio < -0.05 ? 'down' : 'stable';
-
-      // Target source
-      let targetSource = 'default';
-      if (state.goalSettings?.manualTargetOverrides?.[nutrient] !== undefined) {
-        targetSource = 'override';
-      } else if (
-        state.baselineTargets[nutrient] !== undefined &&
-        Math.abs((state.baselineTargets[nutrient] ?? 0) - (DEFAULT_TARGETS[nutrient] ?? 0)) > 0.001
-      ) {
-        targetSource = 'custom';
-      }
+      // Target source classification
+      const targetSource = classifyTargetSource(
+        nutrient,
+        state.baselineTargets,
+        DEFAULT_TARGETS,
+        state.goalSettings?.manualTargetOverrides,
+      );
 
       // Upper-limit check (warn at ≥ 80% of UL)
       const ul = UL_TABLE[nutrient] ?? null;
@@ -1360,11 +1337,11 @@ function renderMicronutrientSections(metrics, filter = 'all') {
     const targetValue  = isDailyFloor ? scaledTarget : baseTarget;
     const remaining    = targetValue - displayValue;
 
-    // Source badge
+    // Source badge (no badge for DRI defaults — only call out deviations)
     const sourceBadge = targetSource === 'override'
       ? `<span class="nt-badge nt-badge-override" title="Manually pinned target">📌</span>`
       : targetSource === 'custom'
-      ? `<span class="nt-badge nt-badge-custom" title="Custom target">✏️</span>`
+      ? `<span class="nt-badge nt-badge-custom" title="Custom target (goal-engine or manual setting)">✏️</span>`
       : '';
 
     // Exercise-scaling note
@@ -1385,7 +1362,7 @@ function renderMicronutrientSections(metrics, filter = 'all') {
     // Source label in target span
     const srcLabel = targetSource === 'override' ? ' (pinned)'
                    : targetSource === 'custom'   ? ' (custom)'
-                   : ' (DRI)';
+                   : ' (DRI)'; // 'dri' = matches reference value exactly
 
     // For averaged nutrients show today's value as sub-detail below the bar
     const subDetail = isAveraged

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -27,6 +27,7 @@ import { getPastDate, formatDate } from '../utils/time.js';
 import { initializeChartControls } from './chart.js';
 import { CONFIG } from '../config.js';
 import { renderAnalysisSection, initAnalysisEvents } from '../analysis/analysisUI.js';
+import { UL_TABLE } from '../targets/nutritionReferences.js';
 
 // =========================
 // CONFIGURATION (Top of file for easy modification)
@@ -43,6 +44,9 @@ const DASHBOARD_CONFIG = {
   SHOW_ERRORS_IN_UI: true, // Display errors in the dashboard
   FALLBACK_TO_DEFAULTS: true // Use default values if user settings are invalid
 };
+
+// Module-level filter state for the Nutrients tab (persists across re-renders)
+let _nutrientFilter = 'all';
 
 // =========================
 // MICRONUTRIENT SCALING CONFIGURATION
@@ -371,7 +375,7 @@ export function calculateBankingData(targetDateStr) {
 // =========================
 
 /**
- * Calculate micronutrients with training day scaling
+ * Calculate micronutrients with training day scaling, trend direction, and UL checks.
  * @param {string} dateStr - Date string in YYYY-MM-DD format
  * @returns {Object} Micronutrient metrics
  */
@@ -395,56 +399,87 @@ export function calculateMicronutrientMetrics(dateStr) {
             return sum + q * val;
           }, 0)
         : parseFloat(todayEntry[nutrient]) || 0;
-      
+
       let avgIntake = todaysIntake;
+      let threeDayAvg = 0;
       let status = 'red';
-      
-      // Calculate 7-day average for averaged nutrients
+
       if (averagedNutrients.includes(nutrient)) {
-        let sum = 0;
-        let count = 0;
-        
+        let sum7 = 0, count7 = 0, sum3 = 0, count3 = 0;
         for (let i = 0; i < 7; i++) {
-          const pastDate = getPastDate(targetDate, i);
-          const pastDateStr = formatDate(pastDate);
-          const entry = state.dailyEntries.get(pastDateStr) || {};
-          const intake = pastDateStr === dateStr
-            ? todaysIntake
-            : parseFloat(entry[nutrient]) || 0;
-          sum += intake;
-          count++;
+          const pd = getPastDate(targetDate, i);
+          const pds = formatDate(pd);
+          const entry = state.dailyEntries.get(pds) || {};
+          const intake = pds === dateStr ? todaysIntake : parseFloat(entry[nutrient]) || 0;
+          sum7 += intake; count7++;
+          if (i < 3) { sum3 += intake; count3++; }
         }
-        
-        avgIntake = count > 0 ? sum / count : 0;
-        
-        // Status based on 7-day average vs base target (not scaled)
+        avgIntake = count7 > 0 ? sum7 / count7 : 0;
+        threeDayAvg = count3 > 0 ? sum3 / count3 : 0;
+
         if (avgIntake >= baseTarget * 0.9) status = 'green';
         else if (avgIntake >= baseTarget * 0.7) status = 'amber';
         else status = 'red';
       } else {
-        // Daily nutrients - status based on today's intake vs scaled target
+        // For daily-floor nutrients, also compute 3-day average for trend
+        let sum3 = 0, count3 = 0;
+        for (let i = 0; i < 3; i++) {
+          const pd = getPastDate(targetDate, i);
+          const pds = formatDate(pd);
+          const entry = state.dailyEntries.get(pds) || {};
+          const intake = pds === dateStr ? todaysIntake : parseFloat(entry[nutrient]) || 0;
+          sum3 += intake; count3++;
+        }
+        threeDayAvg = count3 > 0 ? sum3 / count3 : 0;
+
         if (todaysIntake >= scaledTarget) status = 'green';
         else if (todaysIntake >= scaledTarget * 0.8) status = 'amber';
         else status = 'red';
       }
-      
+
+      // Trend: compare 3-day avg to the primary display value
+      const primaryValue = averagedNutrients.includes(nutrient) ? avgIntake : todaysIntake;
+      const trendRatio = primaryValue > 0 ? (threeDayAvg - primaryValue) / primaryValue : 0;
+      const trendDirection = trendRatio > 0.05 ? 'up' : trendRatio < -0.05 ? 'down' : 'stable';
+
+      // Target source
+      let targetSource = 'default';
+      if (state.goalSettings?.manualTargetOverrides?.[nutrient] !== undefined) {
+        targetSource = 'override';
+      } else if (
+        state.baselineTargets[nutrient] !== undefined &&
+        Math.abs((state.baselineTargets[nutrient] ?? 0) - (DEFAULT_TARGETS[nutrient] ?? 0)) > 0.001
+      ) {
+        targetSource = 'custom';
+      }
+
+      // Upper-limit check (warn at ≥ 80% of UL)
+      const ul = UL_TABLE[nutrient] ?? null;
+      const checkValue = averagedNutrients.includes(nutrient) ? avgIntake : todaysIntake;
+      const isUlExceeded = ul !== null && checkValue >= ul * 0.8;
+
       metrics[nutrient] = {
         name: nutrient,
         baseTarget,
         scaledTarget,
         todaysIntake,
         avgIntake,
+        threeDayAvg,
         status,
         isDailyFloor: dailyTrackedNutrients.includes(nutrient),
         isAveraged: averagedNutrients.includes(nutrient),
         isScaled: scaledTarget !== baseTarget,
         scaleSuggested: suggested,
         scaleReason: reason,
+        targetSource,
+        trendDirection,
+        ul,
+        isUlExceeded,
       };
     });
-    
+
     return metrics;
-    
+
   } catch (error) {
     handleError('calculate-micronutrients', error, 'Failed to calculate micronutrient metrics');
     return {};
@@ -590,10 +625,97 @@ function renderNutrientsOutput() {
   const dateStr = state.dom.dateInput?.value;
   if (!dateStr) return;
 
-  const micronutrientMetrics = calculateMicronutrientMetrics(dateStr);
-  container.innerHTML = renderChartSection() + renderMicronutrientSections(micronutrientMetrics);
+  const metrics = calculateMicronutrientMetrics(dateStr);
+
+  container.innerHTML =
+    renderNutrientSummaryCards(metrics) +
+    renderChartSection() +
+    renderNutrientFilterBar(_nutrientFilter) +
+    `<div id="nutrient-sections-container">${renderMicronutrientSections(metrics, _nutrientFilter)}</div>`;
 
   initializeChartControls();
+  initializeNutrientFilterBar(metrics);
+}
+
+/**
+ * Render status summary cards at the top of the Nutrients tab.
+ */
+function renderNutrientSummaryCards(metrics) {
+  const vals = Object.values(metrics);
+  const red  = vals.filter(m => m.status === 'red');
+  const amber = vals.filter(m => m.status === 'amber');
+  const green = vals.filter(m => m.status === 'green');
+  const ulWarn = vals.filter(m => m.isUlExceeded);
+
+  const card = (icon, count, label, colorClass) => `
+    <div class="nutrient-status-card">
+      <span class="nutrient-status-icon">${icon}</span>
+      <span class="nutrient-status-count ${colorClass}">${count}</span>
+      <span class="nutrient-status-label">${label}</span>
+    </div>`;
+
+  const shortfallList = red.length > 0 ? `
+    <div class="mb-3 p-3 surface-2 rounded-lg border">
+      <p class="text-sm font-semibold text-negative mb-2">⬇️ Common Shortfalls</p>
+      <div class="flex flex-wrap gap-1">
+        ${red.map(m => `<span class="nutrient-tag nutrient-tag-bad">${formatNutrientName(m.name)}</span>`).join('')}
+      </div>
+    </div>` : '';
+
+  const ulList = ulWarn.length > 0 ? `
+    <div class="mb-3 p-3 surface-2 rounded-lg border">
+      <p class="text-sm font-semibold text-warning mb-2">⚠️ Near Upper Limit</p>
+      <div class="flex flex-wrap gap-1">
+        ${ulWarn.map(m => `<span class="nutrient-tag nutrient-tag-warn" title="UL: ${m.ul}">${formatNutrientName(m.name)}</span>`).join('')}
+      </div>
+    </div>` : '';
+
+  return `
+    <div class="mb-6">
+      <div class="nutrient-status-grid mb-3">
+        ${card('🔴', red.length,   'Low',        'text-negative')}
+        ${card('🟡', amber.length, 'Near Target', 'text-warning')}
+        ${card('🟢', green.length, 'On Target',   'text-positive')}
+        ${card('⚠️', ulWarn.length,'Near UL',     'text-warning')}
+      </div>
+      ${shortfallList}${ulList}
+    </div>`;
+}
+
+/**
+ * Render the filter chip bar for the nutrient list.
+ */
+function renderNutrientFilterBar(activeFilter) {
+  const filters = [
+    { id: 'all',      label: 'All' },
+    { id: 'low',      label: '🔴 Low' },
+    { id: 'near',     label: '🟡 Near Target' },
+    { id: 'above',    label: '🟢 On Target' },
+    { id: 'override', label: '📌 Overridden' },
+  ];
+  return `
+    <div id="nutrient-filter-bar" class="nutrient-filter-bar mb-4" role="group" aria-label="Filter nutrients">
+      ${filters.map(f =>
+        `<button type="button" class="nutrient-filter-chip${f.id === activeFilter ? ' active' : ''}" data-filter="${f.id}">${f.label}</button>`
+      ).join('')}
+    </div>`;
+}
+
+/**
+ * Wire up click handlers on filter chips; re-renders the nutrient list only.
+ */
+function initializeNutrientFilterBar(metrics) {
+  const bar = document.getElementById('nutrient-filter-bar');
+  if (!bar) return;
+  bar.querySelectorAll('.nutrient-filter-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      _nutrientFilter = chip.dataset.filter;
+      bar.querySelectorAll('.nutrient-filter-chip').forEach(c =>
+        c.classList.toggle('active', c.dataset.filter === _nutrientFilter));
+      const sc = document.getElementById('nutrient-sections-container');
+      if (sc) sc.innerHTML = renderMicronutrientSections(metrics, _nutrientFilter);
+    });
+  });
 }
 
 /**
@@ -1170,39 +1292,39 @@ function renderTodaysPlanPanel(bankingData, todaysEntry) {
 }
 
 /**
- * Render chart section
+ * Render chart section — uses chip-based nutrient picker for mobile-friendly selection.
  */
 function renderChartSection() {
   return `
     <div class="mb-8 card p-6 shadow-lg">
       <h3 class="text-responsive-2xl font-bold text-secondary mb-4">📊 Nutrition Progress Chart</h3>
-      <div class="mb-4 grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div>
-          <label for="chart-nutrients" class="block text-sm font-medium text-primary mb-1">Select Nutrients</label>
-          <select id="chart-nutrients" multiple class="w-full p-2 border rounded-md shadow-sm focus:ring-accent-600 focus:border-accent-600" size="4"></select>
-        </div>
-        <div>
+
+      <div class="mb-3">
+        <p class="text-sm font-medium text-primary mb-2">Select Nutrients <span class="text-xs text-muted font-normal">(tap to toggle)</span></p>
+        <div id="chart-nutrient-chips" class="chart-chip-picker" role="group" aria-label="Select nutrients for chart"></div>
+      </div>
+
+      <div class="mb-4 flex flex-wrap gap-4 items-end">
+        <div class="flex-1">
           <label for="chart-timeframe" class="block text-sm font-medium text-primary mb-1">Time Frame</label>
-          <select id="chart-timeframe" class="w-full p-2 border rounded-md shadow-sm focus:ring-accent-600 focus:border-accent-600">
+          <select id="chart-timeframe">
             <option value="3days">Last 3 Days</option>
             <option value="week">Last Week</option>
             <option value="month">Last Month</option>
           </select>
         </div>
-        <div>
-          <label class="block text-sm font-medium text-primary mb-1">Trend Lines</label>
-          <div class="space-y-2 mt-2">
-            <div class="flex items-center">
-              <input type="checkbox" id="show-3day-avg" class="mr-2 h-4 w-4 text-accent border rounded focus:ring-accent-600">
-              <label for="show-3day-avg" class="text-sm text-primary">3-day average</label>
-            </div>
-            <div class="flex items-center">
-              <input type="checkbox" id="show-7day-avg" class="mr-2 h-4 w-4 text-accent border rounded focus:ring-accent-600">
-              <label for="show-7day-avg" class="text-sm text-primary">7-day average</label>
-            </div>
-          </div>
+        <div class="flex gap-4 items-center flex-wrap">
+          <label class="flex items-center gap-2 cursor-pointer text-sm text-primary">
+            <input type="checkbox" id="show-3day-avg" class="h-4 w-4">
+            <span>3-day avg</span>
+          </label>
+          <label class="flex items-center gap-2 cursor-pointer text-sm text-primary">
+            <input type="checkbox" id="show-7day-avg" class="h-4 w-4">
+            <span>7-day avg</span>
+          </label>
         </div>
       </div>
+
       <div class="chart-container"><canvas id="nutrition-chart"></canvas></div>
       <div id="chart-table" class="mt-6"></div>
     </div>
@@ -1210,84 +1332,117 @@ function renderChartSection() {
 }
 
 /**
- * Render micronutrient sections with training day scaling
+ * Render micronutrient sections with filter support and enhanced per-nutrient detail.
+ * @param {Object} metrics - Output of calculateMicronutrientMetrics()
+ * @param {string} filter  - 'all'|'low'|'near'|'above'|'override'
  */
-function renderMicronutrientSections(metrics) {
+function renderMicronutrientSections(metrics, filter = 'all') {
+  const filterFn = (data) => {
+    switch (filter) {
+      case 'low':      return data.status === 'red';
+      case 'near':     return data.status === 'amber';
+      case 'above':    return data.status === 'green';
+      case 'override': return data.targetSource === 'override';
+      default:         return true;
+    }
+  };
+
   const renderNutrientRow = (nutrient, data) => {
-    const { baseTarget, scaledTarget, todaysIntake, avgIntake, isDailyFloor, isAveraged, scaleSuggested, scaleReason } = data;
+    if (!filterFn(data)) return '';
+
+    const {
+      baseTarget, scaledTarget, todaysIntake, avgIntake, threeDayAvg,
+      isDailyFloor, isAveraged, scaleSuggested, scaleReason,
+      targetSource, trendDirection, ul, isUlExceeded,
+    } = data;
 
     const displayValue = isAveraged ? avgIntake : todaysIntake;
     const targetValue  = isDailyFloor ? scaledTarget : baseTarget;
     const remaining    = targetValue - displayValue;
 
-    const suggestedNote = scaleSuggested && scaledTarget !== baseTarget
-      ? `<span class="text-xs text-muted ml-1" title="Optional suggestion (${scaleReason})">(+${Math.round((scaledTarget - baseTarget))} suggested)</span>`
+    // Source badge
+    const sourceBadge = targetSource === 'override'
+      ? `<span class="nt-badge nt-badge-override" title="Manually pinned target">📌</span>`
+      : targetSource === 'custom'
+      ? `<span class="nt-badge nt-badge-custom" title="Custom target">✏️</span>`
+      : '';
+
+    // Exercise-scaling note
+    const scaleBadge = scaleSuggested && scaledTarget !== baseTarget
+      ? `<span class="nt-badge nt-badge-scale" title="Exercise scaling: ${scaleReason}">⚡+${Math.round(scaledTarget - baseTarget)}</span>`
+      : '';
+
+    // Trend indicator
+    const trendMap = { up: ['↑', 'text-positive'], down: ['↓', 'text-negative'], stable: ['→', 'text-muted'] };
+    const [trendIcon, trendCls] = trendMap[trendDirection] || trendMap.stable;
+    const trendBadge = `<span class="${trendCls} nt-trend" title="Recent trend">${trendIcon}</span>`;
+
+    // UL warning
+    const ulBadge = isUlExceeded
+      ? `<span class="nt-badge nt-badge-ul" title="Near/above upper limit (UL: ${ul})">⚠️</span>`
+      : '';
+
+    // Source label in target span
+    const srcLabel = targetSource === 'override' ? ' (pinned)'
+                   : targetSource === 'custom'   ? ' (custom)'
+                   : ' (DRI)';
+
+    // For averaged nutrients show today's value as sub-detail below the bar
+    const subDetail = isAveraged
+      ? `<div class="nt-sub-detail">Today: ${todaysIntake.toFixed(1)} · 3d avg: ${threeDayAvg.toFixed(1)}</div>`
       : '';
 
     return `
       <div class="kpi-row">
         <div class="meta">
-          <span class="label">${formatNutrientName(nutrient)}${suggestedNote}</span>
-          <span class="current">${displayValue.toFixed(1)}</span>
-          <span class="target">target ${targetValue.toFixed(1)}</span>
+          <span class="label">${formatNutrientName(nutrient)}${sourceBadge}${scaleBadge}${trendBadge}${ulBadge}</span>
+          <span class="current">${displayValue.toFixed(1)}${isAveraged ? '<span class="nt-avg-label">avg</span>' : ''}</span>
+          <span class="target">target ${targetValue.toFixed(1)}${srcLabel}</span>
           <span class="remain ${remainClass(remaining)}">${remaining > 0 ? `${remaining.toFixed(1)} left` : remaining < 0 ? `${Math.abs(remaining).toFixed(1)} over` : '0 left'}</span>
         </div>
         <div class="hbar">
           <div class="hbar-fill ${pctClass(displayValue, targetValue)}" style="width:${pctWidth(displayValue, targetValue)}"></div>
           <div class="hbar-marker" style="left:${markerLeft}"></div>
         </div>
-      </div>
-    `;
+        ${subDetail}
+      </div>`;
   };
 
   const renderSection = (title, nutrientKeys, description) => {
     const rows = nutrientKeys
-      .filter(nutrient => metrics[nutrient])
-      .map(nutrient => renderNutrientRow(nutrient, metrics[nutrient]))
+      .filter(n => metrics[n] && filterFn(metrics[n]))
+      .map(n => renderNutrientRow(n, metrics[n]))
+      .filter(Boolean)
       .join('');
-
     if (!rows) return '';
-
     return `
       <div class="mb-8">
-        <div class="mb-4">
+        <div class="mb-3">
           <h3 class="text-responsive-2xl font-bold text-secondary">${title}</h3>
           <p class="text-sm text-muted">${description}</p>
         </div>
-        <div class="divide-y">
-          ${rows}
-        </div>
-      </div>
-    `;
+        <div class="divide-y">${rows}</div>
+      </div>`;
   };
 
-  return [
-    renderSection(
-      '💧 Daily Electrolytes & Essentials',
-      nutrients.dailyFloors,
-      'Scale with training intensity - must meet daily targets'
-    ),
-    renderSection(
-      '🧪 Daily Vitamins',
-      nutrients.dailyVitamins,
-      'Water-soluble - daily targets, some scale with intense training'
-    ),
-    renderSection(
-      '🟡 Fat-Soluble Vitamins',
-      nutrients.avgVitamins,
-      '7-day rolling average - stored in body fat, no training scaling'
-    ),
-    renderSection(
-      '⚡ Stored Minerals',
-      nutrients.avgMinerals,
-      '7-day rolling average - stored in tissues, no training scaling'
-    ),
-    renderSection(
-      '🔄 Optional Nutrients',
-      nutrients.optional,
-      '7-day rolling average targets'
-    )
+  const sections = [
+    renderSection('💧 Daily Electrolytes & Essentials', nutrients.dailyFloors,
+      'Must meet daily targets — electrolytes scale with training intensity'),
+    renderSection('🧪 Daily Vitamins', nutrients.dailyVitamins,
+      'Water-soluble — daily targets'),
+    renderSection('🟡 Fat-Soluble Vitamins', nutrients.avgVitamins,
+      '7-day rolling average — stored in body fat, no training scaling'),
+    renderSection('⚡ Stored Minerals', nutrients.avgMinerals,
+      '7-day rolling average — stored in tissues, no training scaling'),
+    renderSection('🔄 Optional Nutrients', nutrients.optional,
+      '7-day rolling average targets'),
   ].join('');
+
+  if (!sections.trim()) {
+    const labels = { low: 'Low', near: 'Near Target', above: 'On Target', override: 'Overridden' };
+    return `<p class="text-muted text-center py-8">No nutrients match the "${labels[filter] || filter}" filter.</p>`;
+  }
+  return sections;
 }
 
 // =========================

--- a/public/tools/CalorieTracker/ui/nutrientHelpers.js
+++ b/public/tools/CalorieTracker/ui/nutrientHelpers.js
@@ -1,8 +1,33 @@
 /**
  * @file ui/nutrientHelpers.js
- * Pure helper functions for nutrient display logic.
- * No DOM, Firebase, or state access — safe to import anywhere and to unit-test.
+ * Shared helper functions for nutrient display logic and weight resolution.
+ * No DOM or Firebase access. resolveWeightKg reads from state (not pure),
+ * but computeTrendDirection and classifyTargetSource are fully pure.
  */
+
+import { state } from '../state/store.js';
+
+// ---------------------------------------------------------------------------
+// Weight resolution (shared by dashboard, chart, and data service)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the user's current body weight in kg from state.
+ * Prefers manual override, then smoothed analysis weight, then falls back to 80 kg.
+ *
+ * Used as an approximation for historical MET-based exercise calorie calculations.
+ */
+export function resolveWeightKg() {
+  const manual = parseFloat(state.userProfile?.manualWeightOverrideLb);
+  if (!isNaN(manual) && manual > 0) return manual * 0.45359237;
+  const smoothed = state.analysisResults?.summary?.currentWeight;
+  if (smoothed && smoothed > 0) return smoothed * 0.45359237;
+  return 80;
+}
+
+// ---------------------------------------------------------------------------
+// Trend and target-source helpers (pure)
+// ---------------------------------------------------------------------------
 
 /**
  * Compute trend direction by comparing a recent window to a prior window.

--- a/public/tools/CalorieTracker/ui/nutrientHelpers.js
+++ b/public/tools/CalorieTracker/ui/nutrientHelpers.js
@@ -1,0 +1,45 @@
+/**
+ * @file ui/nutrientHelpers.js
+ * Pure helper functions for nutrient display logic.
+ * No DOM, Firebase, or state access — safe to import anywhere and to unit-test.
+ */
+
+/**
+ * Compute trend direction by comparing a recent window to a prior window.
+ *
+ * Suppresses the trend arrow when either value is zero or the prior window
+ * is null (insufficient data).
+ *
+ * @param {number}      recentVal - Average intake for the recent window (e.g. days 0-2).
+ * @param {number|null} priorVal  - Average intake for the prior window (e.g. days 3-6).
+ *                                  Pass null to suppress the arrow (not enough history).
+ * @returns {'up'|'down'|'stable'}
+ */
+export function computeTrendDirection(recentVal, priorVal) {
+  if (priorVal === null || priorVal === 0 || recentVal === 0) return 'stable';
+  const ratio = (recentVal - priorVal) / priorVal;
+  return ratio > 0.05 ? 'up' : ratio < -0.05 ? 'down' : 'stable';
+}
+
+/**
+ * Classify the source of a nutrient target.
+ *
+ * Returns one of:
+ *  - 'override' — user explicitly pinned this nutrient via manualTargetOverrides
+ *  - 'custom'   — target differs from the DRI/default (goal-engine or manual settings)
+ *  - 'dri'      — target exactly matches the DRI/default value
+ *
+ * @param {string} nutrient
+ * @param {object} baselineTargets   - state.baselineTargets
+ * @param {object} defaultTargets    - DEFAULT_TARGETS (reference values)
+ * @param {object} manualOverrides   - state.goalSettings?.manualTargetOverrides (may be undefined)
+ * @returns {'override'|'custom'|'dri'}
+ */
+export function classifyTargetSource(nutrient, baselineTargets, defaultTargets, manualOverrides) {
+  if (manualOverrides?.[nutrient] !== undefined) return 'override';
+  if (
+    baselineTargets[nutrient] !== undefined &&
+    Math.abs((baselineTargets[nutrient] ?? 0) - (defaultTargets[nutrient] ?? 0)) > 0.001
+  ) return 'custom';
+  return 'dri';
+}

--- a/public/tools/CalorieTracker/ui/nutrientHelpers.test.js
+++ b/public/tools/CalorieTracker/ui/nutrientHelpers.test.js
@@ -1,0 +1,96 @@
+/**
+ * @file ui/nutrientHelpers.test.js
+ * Unit tests for pure nutrient-display helpers.
+ * No DOM, Firebase, or state access.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeTrendDirection, classifyTargetSource } from './nutrientHelpers.js';
+
+// ---------------------------------------------------------------------------
+// computeTrendDirection
+// ---------------------------------------------------------------------------
+
+describe('computeTrendDirection', () => {
+  it('returns stable when priorVal is null (insufficient history)', () => {
+    expect(computeTrendDirection(100, null)).toBe('stable');
+  });
+
+  it('returns stable when priorVal is 0 (avoid divide-by-zero)', () => {
+    expect(computeTrendDirection(100, 0)).toBe('stable');
+  });
+
+  it('returns stable when recentVal is 0 (no recent data)', () => {
+    expect(computeTrendDirection(0, 100)).toBe('stable');
+  });
+
+  it('returns up when recent is >5% above prior', () => {
+    // +10% above prior → up
+    expect(computeTrendDirection(110, 100)).toBe('up');
+  });
+
+  it('returns down when recent is >5% below prior', () => {
+    // -10% below prior → down
+    expect(computeTrendDirection(90, 100)).toBe('down');
+  });
+
+  it('returns stable when difference is within ±5%', () => {
+    expect(computeTrendDirection(103, 100)).toBe('stable'); // +3%
+    expect(computeTrendDirection(97, 100)).toBe('stable');  // -3%
+  });
+
+  it('returns stable at exactly 5% threshold', () => {
+    // Exactly 5% — the threshold is strict (> not >=)
+    expect(computeTrendDirection(105, 100)).toBe('stable');
+    expect(computeTrendDirection(95, 100)).toBe('stable');
+  });
+
+  it('returns up just above 5% threshold', () => {
+    expect(computeTrendDirection(105.1, 100)).toBe('up');
+  });
+
+  it('returns down just below -5% threshold', () => {
+    expect(computeTrendDirection(94.9, 100)).toBe('down');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyTargetSource
+// ---------------------------------------------------------------------------
+
+describe('classifyTargetSource', () => {
+  const defaults = { vitaminC: 90, zinc: 11 };
+
+  it('returns override when nutrient is in manualTargetOverrides', () => {
+    // Even if baseline matches default, explicit override wins
+    expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, { vitaminC: 75 })).toBe('override');
+  });
+
+  it('returns override regardless of baseline value', () => {
+    expect(classifyTargetSource('zinc', { zinc: 20 }, defaults, { zinc: 15 })).toBe('override');
+  });
+
+  it('returns dri when baseline matches default exactly', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, {})).toBe('dri');
+  });
+
+  it('returns dri when baseline is absent (not yet set)', () => {
+    expect(classifyTargetSource('vitaminC', {}, defaults, {})).toBe('dri');
+  });
+
+  it('returns custom when baseline differs from default', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 120 }, defaults, {})).toBe('custom');
+  });
+
+  it('returns custom when baseline is zero but default is non-zero', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 0 }, defaults, {})).toBe('custom');
+  });
+
+  it('returns dri when manualOverrides is undefined', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, undefined)).toBe('dri');
+  });
+
+  it('returns dri when manualOverrides is null', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, null)).toBe('dri');
+  });
+});


### PR DESCRIPTION
- Nutrients tab now owns all micronutrient sections; Today tab stays
  clean with only Calories / Protein / Fat / Carbs
- Enhanced calculateMicronutrientMetrics() with trend direction (3-day
  vs 7-day avg), target source (DRI default / custom / pinned override),
  3-day rolling average, and upper-limit (UL) checks at 80% threshold
- Status summary grid at top of Nutrients tab shows counts for Low /
  Near Target / On Target / Near UL, plus named shortfall and UL lists
- Filter bar (All / Low / Near Target / On Target / Overridden) updates
  the nutrient list without a full page re-render; filter state is
  preserved across data refreshes
- Per-nutrient rows now show: source badge (📌 pinned / ✏️ custom),
  exercise-scaling badge (⚡ +Xmg), trend arrow (↑ ↓ →), UL warning
  badge; averaged nutrients also display today's intake and 3-day avg
  as a sub-detail line below the bar
- Replaced cramped <select multiple> with chip-based nutrient picker
  (chart-chip-picker) that wraps naturally on mobile; tap to toggle;
  chart.js updated to read active chips instead of selectedOptions
- CSS: chart-chip-picker, nutrient-filter-bar, nutrient-status-grid,
  .nt-badge variants, .nt-sub-detail, .nutrient-tag variants; mobile
  breakpoint collapses status grid to 2 cols and sizes chips for touch
- All 269 unit tests pass; Next.js lint and build clean

https://claude.ai/code/session_0163e5WbjpMoUGMxcxr2CL88