### PR TITLE
fix(CalorieTracker): Auto Goal no longer uses rolling bank — prevents crash targets

### DIFF
--- a/public/tools/CalorieTracker/constants.js
+++ b/public/tools/CalorieTracker/constants.js
@@ -30,7 +30,16 @@ export const BANKING_CONFIG = {
     LIGHT_LIFT: 100, // 25-40g carbs * 4 kcal/g = 100-160 kcal
     HARD_LIFT: 280, // 50-90g carbs * 4 kcal/g = 200-360 kcal
     HIIT_ENDURANCE: 400 // 60-120g carbs * 4 kcal/g = 240-480 kcal
-  }
+  },
+
+  // Auto Goal schedule adjustment caps (kcal/day downward)
+  // Soft cap: normal maximum correction per day in Auto Goal mode
+  MAX_SCHEDULE_ADJ_SOFT: 150,
+  // Hard cap: absolute maximum correction — goal date may need adjustment
+  MAX_SCHEDULE_ADJ_HARD: 250,
+
+  // Safe daily calorie floor — NIDDK Body Weight Planner public lower bound
+  MIN_DAILY_CALORIES: 1000,
 };
 
 // Groups nutrients by tracking behavior (daily floors vs 7-day averages)

--- a/public/tools/CalorieTracker/services/firebase.js
+++ b/public/tools/CalorieTracker/services/firebase.js
@@ -374,7 +374,7 @@ export async function saveUserProfile(incoming) {
     const toSave = prepareProfileForSave(incoming, state.userProfile);
     await setDoc(doc(db, `artifacts/${appId}/users/${state.userId}/profile/userProfile`), toSave);
     state.userProfile = normalizeUserProfile(toSave);
-    showMessage('Profile saved!');
+    if (!opts?.silent) showMessage('Profile saved!');
     debugLog('firebase-save', 'User profile saved');
   } catch (e) {
     handleError('profile-save', e, 'Failed to save profile.');
@@ -418,7 +418,7 @@ export async function saveGoalSettings(incoming, opts = {}) {
     const toSave = prepareGoalSettingsForSave(incoming, state.goalSettings, opts);
     await setDoc(doc(db, `artifacts/${appId}/users/${state.userId}/goals/goalSettings`), toSave);
     state.goalSettings = normalizeGoalSettings(toSave);
-    showMessage('Goals saved!');
+    if (!opts?.silent) showMessage('Goals saved!');
     debugLog('firebase-save', 'Goal settings saved');
   } catch (e) {
     handleError('goals-save', e, 'Failed to save goal settings.');

--- a/public/tools/CalorieTracker/services/firebase.js
+++ b/public/tools/CalorieTracker/services/firebase.js
@@ -366,7 +366,7 @@ export async function fetchUserProfile() {
  * Saves the user's profile document to Firestore and updates state.userProfile.
  * @param {object} profile - The normalized profile object to persist.
  */
-export async function saveUserProfile(incoming) {
+export async function saveUserProfile(incoming, opts = {}) {
   if (!state.userId) return showMessage('Cannot save profile. Not authenticated.', true);
   try {
     // Merge: defaults → current state → incoming, then force schemaVersion.

--- a/public/tools/CalorieTracker/targets/targetEngine.js
+++ b/public/tools/CalorieTracker/targets/targetEngine.js
@@ -644,6 +644,7 @@ export function generateTargets(profile, goals, analysisResults = null, rawLates
       tdeeValue: tdeeResult.tdee,
       tdeeSource: tdeeResult.source,
       goalType,
+      calorieFloor: calResult.calorieFloor,
     },
   };
 }
@@ -728,6 +729,7 @@ export function resolveDailyBaseTargets(dateStr, stateLike) {
       targets: { ...stateLike.baselineTargets },
       source: 'manual',
       warnings: [],
+      calorieFloor: 1000,
     };
   }
 
@@ -747,6 +749,7 @@ export function resolveDailyBaseTargets(dateStr, stateLike) {
       targets: { ...stateLike.baselineTargets },
       source: 'manual_fallback',
       warnings: [`Auto-goal targets unavailable (${reason}); falling back to manual baseline.`],
+      calorieFloor: 1000,
     };
   }
 
@@ -755,6 +758,7 @@ export function resolveDailyBaseTargets(dateStr, stateLike) {
     targets: finalTargets,
     source: 'autoGoal',
     warnings: result.warnings,
+    calorieFloor: result.meta?.calorieFloor ?? 1000,
   };
 }
 

--- a/public/tools/CalorieTracker/targets/targetEngine.test.js
+++ b/public/tools/CalorieTracker/targets/targetEngine.test.js
@@ -1326,3 +1326,107 @@ describe('buildEatingPatternTargetSeries', () => {
     expect(typeof targetData[0]).toBe('number');
   });
 });
+
+// ── Auto Goal: 177 lb → 170 lb by 2026-07-31 scenario ───────────────────────
+
+describe('Auto Goal: 177→170 lb by 2026-07-31', () => {
+  const PROFILE_177 = makeProfile({
+    sex: 'male', age: 35,
+    heightValue: 70, heightUnit: 'in',
+    manualWeightOverrideLb: 177,
+    baselineActivityLevel: 'moderate',
+  });
+  const GOALS_TO_170 = makeGoals({
+    goalType: 'fatLoss',
+    targetWeightLb: 170,
+    targetDate: '2026-07-31',
+    targetMode: 'autoGoal',
+    manualTargetOverrides: {},
+  });
+  // Approx days from today (2026-05-18) to 2026-07-31 ≈ 74 days
+  const AS_OF = '2026-05-18';
+
+  it('produces a mild deficit, not a crash target', () => {
+    const { targets, meta } = generateTargets(PROFILE_177, GOALS_TO_170, null, null, AS_OF);
+    expect(targets).not.toBeNull();
+    // 177 lb → 170 lb in ~74 days: delta_lb=7; delta_kg≈3.17; deficit = 3.17×7700/74 ≈ 330 kcal
+    // TDEE formula moderate ≈ 2700; target ≈ 2700−330 ≈ 2370 — reasonable, not below 1000
+    expect(targets.calories).toBeGreaterThan(1500);
+    expect(targets.calories).toBeLessThan(3000);
+    expect(meta.weightLb).toBe(177);
+  });
+
+  it('calorie target is above safe floor (1000 kcal)', () => {
+    const { targets } = generateTargets(PROFILE_177, GOALS_TO_170, null, null, AS_OF);
+    expect(targets.calories).toBeGreaterThanOrEqual(1000);
+  });
+
+  it('moving target date later increases calories (gentler deficit)', () => {
+    const goalsEarlier = { ...GOALS_TO_170, targetDate: '2026-06-30' };
+    const goalsLater   = { ...GOALS_TO_170, targetDate: '2026-10-31' };
+    const { targets: tE } = generateTargets(PROFILE_177, goalsEarlier, null, null, AS_OF);
+    const { targets: tL } = generateTargets(PROFILE_177, goalsLater,   null, null, AS_OF);
+    expect(tL.calories).toBeGreaterThanOrEqual(tE.calories);
+  });
+
+  it('moving target date earlier decreases calories (steeper deficit)', () => {
+    const goalsFar  = { ...GOALS_TO_170, targetDate: '2026-11-30' };
+    const goalsNear = { ...GOALS_TO_170, targetDate: '2026-07-01' };
+    const { targets: tF } = generateTargets(PROFILE_177, goalsFar,  null, null, AS_OF);
+    const { targets: tN } = generateTargets(PROFILE_177, goalsNear, null, null, AS_OF);
+    expect(tN.calories).toBeLessThanOrEqual(tF.calories);
+  });
+
+  it('if target date would require unsafe deficit, calories are floored and explanation notes it', () => {
+    // 7 lb loss in 3 days is absurd — should hit bmr_floor clamp
+    const extremeGoals = { ...GOALS_TO_170, targetDate: '2026-05-21' }; // 3 days out
+    const { targets, explanation } = generateTargets(PROFILE_177, extremeGoals, null, null, AS_OF);
+    // target_invalid or bmr_floor clamp; calories should still be >= 1000
+    expect(targets.calories).toBeGreaterThanOrEqual(1000);
+    // The explanation may note the clamp
+    if (explanation?.deficitClamped) {
+      expect(explanation.deficitClamped).toMatch(/date|cap|clamp|750|invalid/i);
+    }
+  });
+
+  it('resolveDailyBaseTargets produces reasonable auto goal for 177→170 scenario', () => {
+    const s = {
+      baselineTargets: { calories: 2000, protein: 150, fat: 60, carbs: 200 },
+      goalSettings: { ...GOALS_TO_170, targetMode: 'autoGoal' },
+      userProfile: PROFILE_177,
+      analysisResults: null,
+      weightEntries: new Map(),
+    };
+    const { targets, source } = resolveDailyBaseTargets(AS_OF, s);
+    expect(source).toBe('autoGoal');
+    expect(targets.calories).toBeGreaterThan(1500);
+    expect(targets.calories).toBeLessThan(3000);
+  });
+});
+
+// ── Auto Goal calorie floor: base target never below 1000 ────────────────────
+
+describe('Auto Goal calorie floor', () => {
+  it('computeCalorieTarget always returns calories >= 1000 for fat loss', () => {
+    // TDEE 1050, BMR 1200 → minSafeFloor = max(1000, round(1200×0.85)=1020) = 1020
+    const { calories } = computeCalorieTarget('fatLoss', 1050, 1200, makeGoals(), 100);
+    expect(calories).toBeGreaterThanOrEqual(1000);
+  });
+
+  it('calorieFloor is max(1000, round(0.85 × BMR))', () => {
+    // BMR 1800 → floor = max(1000, 1530) = 1530
+    const { calorieFloor } = computeCalorieTarget('fatLoss', 2400, 1800, makeGoals(), 185);
+    expect(calorieFloor).toBe(Math.max(1000, Math.round(1800 * 0.85)));
+  });
+
+  it('generateTargets never returns calories below 1000 for any goal type', () => {
+    const profile = makeProfile({ manualWeightOverrideLb: 90, sex: 'female', age: 70 });
+    for (const goalType of ['fatLoss', 'maintenance', 'recomp', 'muscleGain', 'performance']) {
+      const goals = makeGoals({ goalType, targetWeightLb: goalType === 'fatLoss' ? 85 : null, targetDate: '2027-12-31' });
+      const { targets } = generateTargets(profile, goals, null, null, '2026-05-18');
+      if (targets) {
+        expect(targets.calories, `${goalType} calories below 1000`).toBeGreaterThanOrEqual(1000);
+      }
+    }
+  });
+});

--- a/public/tools/CalorieTracker/targets/targetUI.js
+++ b/public/tools/CalorieTracker/targets/targetUI.js
@@ -339,12 +339,19 @@ function _setAutosaveStatus(status) {
 async function _doAutosave() {
   _setAutosaveStatus('saving');
   try {
-    await saveUserProfile(readProfileFromForm());
-    await saveGoalSettings(readGoalsFromForm());
+    await saveUserProfile(readProfileFromForm(), { silent: true });
+    await saveGoalSettings(readGoalsFromForm(), { silent: true });
     updateWeightDisplay();
     _setAutosaveStatus('saved');
     // Fade back to blank after 3 s
     setTimeout(() => _setAutosaveStatus(''), 3000);
+    // Refresh Today tab and chart so profile changes are immediately reflected
+    try {
+      const { updateDashboard } = await import('../ui/dashboard.js');
+      const { updateChart } = await import('../ui/chart.js');
+      updateDashboard();
+      updateChart();
+    } catch (_) {}
   } catch (err) {
     _setAutosaveStatus('error');
     handleError('autosave-profile', err, 'Failed to autosave profile.');
@@ -572,7 +579,7 @@ export function wireProfileTab() {
 
   const autoFields = [
     'profile-manual-weight', 'profile-birthdate', 'profile-age',
-    'profile-height', 'profile-bodyfat', 'profile-goal-type',
+    'profile-height', 'profile-height-unit', 'profile-bodyfat', 'profile-goal-type',
     'profile-target-weight', 'profile-target-date', 'profile-protein-basis',
   ];
   for (const id of autoFields) {

--- a/public/tools/CalorieTracker/targets/targetUI.js
+++ b/public/tools/CalorieTracker/targets/targetUI.js
@@ -345,6 +345,9 @@ async function _doAutosave() {
     _setAutosaveStatus('saved');
     // Fade back to blank after 3 s
     setTimeout(() => _setAutosaveStatus(''), 3000);
+    // Invalidate cached analysis so profile changes (BF%, weight, age, sex, height)
+    // are reflected immediately rather than using stale TDEE/targets.
+    state.analysisResults = null;
     // Refresh Today tab and chart so profile changes are immediately reflected
     try {
       const { updateDashboard } = await import('../ui/dashboard.js');
@@ -482,6 +485,7 @@ async function handleSaveProfile() {
     await saveUserProfile(readProfileFromForm());
     await saveGoalSettings(readGoalsFromForm());
     updateWeightDisplay();
+    state.analysisResults = null;
     _setAutosaveStatus('saved');
     setTimeout(() => _setAutosaveStatus(''), 3000);
     showMessage('Profile and goals saved!');
@@ -525,6 +529,8 @@ async function handleApplyTargets() {
     const finalTargets = applyManualOverrides(result.targets, manualOverrides);
     await saveTargets(finalTargets);
 
+    // Invalidate cached analysis so the new profile/goals take effect immediately.
+    state.analysisResults = null;
     // Refresh all visible tracker UI
     const { populateSettingsForm, updateDashboard } = await import('../ui/dashboard.js');
     const { updateChart } = await import('../ui/chart.js');

--- a/public/tools/CalorieTracker/targets/targetUI.js
+++ b/public/tools/CalorieTracker/targets/targetUI.js
@@ -489,6 +489,12 @@ async function handleSaveProfile() {
     _setAutosaveStatus('saved');
     setTimeout(() => _setAutosaveStatus(''), 3000);
     showMessage('Profile and goals saved!');
+    try {
+      const { updateDashboard } = await import('../ui/dashboard.js');
+      const { updateChart } = await import('../ui/chart.js');
+      updateDashboard();
+      updateChart();
+    } catch (_) {}
   } catch (err) {
     _setAutosaveStatus('error');
     handleError('save-profile', err, 'Failed to save profile.');

--- a/public/tools/CalorieTracker/ui/banking.test.js
+++ b/public/tools/CalorieTracker/ui/banking.test.js
@@ -193,3 +193,211 @@ describe('rolling bank — blank days are neutral, not zero', () => {
     expect(unknownDays).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Pure helpers mirrored from dashboard.js — Auto Goal schedule adjustment
+// ---------------------------------------------------------------------------
+
+const MIN_DAILY_CALORIES = 1000;
+const MAX_SCHEDULE_ADJ_SOFT = 150;
+const MAX_SCHEDULE_ADJ_HARD = 250;
+
+/**
+ * Auto Goal banking: base target + exercise + soft schedule correction.
+ * The full rolling bank is NOT applied; overages are spread over remaining days.
+ */
+function calcBankingAutoGoal(targetDateStr, dailyEntries, baseKcal, goalTargetDate = null) {
+  const targetDate = new Date(`${targetDateStr}T00:00:00`);
+  const WINDOW = 7;
+
+  let sumPastActual = 0;
+  const unknownDays = [];
+
+  for (let i = 1; i < WINDOW; i++) {
+    const d = new Date(targetDate);
+    d.setDate(d.getDate() - i);
+    const dateStr = d.toISOString().slice(0, 10);
+    const entry   = dailyEntries.get(dateStr) ?? {};
+    const trusted = hasTrustedCalories(entry);
+    const actualKcal = trusted ? parseFloat(entry.calories) : baseKcal;
+    if (!trusted) unknownDays.push(dateStr);
+    sumPastActual += actualKcal;
+  }
+
+  // rawBankBalance = sum(past targets) - sum(past actual)
+  const rawBankBalance = Math.round(baseKcal * (WINDOW - 1) - sumPastActual);
+  const cumulativeDebt = Math.max(0, -rawBankBalance);
+
+  let scheduleAdjustment = 0;
+  let scheduleCapped = false;
+
+  if (cumulativeDebt > 0 && goalTargetDate) {
+    const targetMs    = new Date(`${goalTargetDate}T00:00:00`).getTime();
+    const todayMs     = new Date(`${targetDateStr}T00:00:00`).getTime();
+    const remainingDays = Math.round((targetMs - todayMs) / 86400000);
+    if (remainingDays > 1) {
+      const rawAdj = -cumulativeDebt / remainingDays;
+      scheduleAdjustment = Math.round(Math.max(-MAX_SCHEDULE_ADJ_HARD, rawAdj));
+      if (rawAdj < -MAX_SCHEDULE_ADJ_SOFT) scheduleCapped = true;
+    }
+  }
+
+  const rawTarget = baseKcal + scheduleAdjustment; // exercise = 0 in tests
+  let todayKcalTarget = Math.round(rawTarget / 25) * 25;
+  const targetFloorApplied = todayKcalTarget < MIN_DAILY_CALORIES;
+  if (targetFloorApplied) todayKcalTarget = MIN_DAILY_CALORIES;
+
+  return {
+    todayKcalTarget,
+    rawBankBalance,
+    scheduleAdjustment,
+    targetFloorApplied,
+    scheduleCapped,
+    bankIncomplete: unknownDays.length > 0,
+    unknownDays,
+    bankMode: 'autoGoalSchedule',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Auto Goal banking tests
+// ---------------------------------------------------------------------------
+
+describe('Auto Goal mode — schedule adjustment, not full rolling bank', () => {
+  it('zero past data → no adjustment, target equals baseKcal', () => {
+    const { todayKcalTarget, scheduleAdjustment } =
+      calcBankingAutoGoal(TODAY, new Map(), 2000);
+    expect(scheduleAdjustment).toBe(0);
+    expect(todayKcalTarget).toBe(2000);
+  });
+
+  it('six days of big overages with far goal date → small schedule correction, not crash', () => {
+    // 6 days × 2800 kcal vs 2000 target = 4800 kcal debt
+    // goal date 74 days out → 4800/74 ≈ 65 kcal/day correction → target ≈ 1935
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 2800])
+    ));
+    const goalDate = new Date('2025-06-15T00:00:00');
+    goalDate.setDate(goalDate.getDate() + 74);
+    const goalDateStr = goalDate.toISOString().slice(0, 10);
+
+    const { todayKcalTarget, scheduleAdjustment } =
+      calcBankingAutoGoal(TODAY, entries, 2000, goalDateStr);
+
+    expect(todayKcalTarget).toBeGreaterThan(1000);  // not a crash target
+    expect(todayKcalTarget).toBeLessThan(2100);      // but genuinely adjusted
+    expect(scheduleAdjustment).toBeLessThan(0);      // downward correction
+    expect(scheduleAdjustment).toBeGreaterThanOrEqual(-MAX_SCHEDULE_ADJ_HARD);
+  });
+
+  it('large overage with no goal date → no schedule adjustment', () => {
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 3500])
+    ));
+    const { scheduleAdjustment } = calcBankingAutoGoal(TODAY, entries, 2000, null);
+    expect(scheduleAdjustment).toBe(0);
+  });
+
+  it('schedule adjustment does not exceed soft cap (150 kcal/day) for moderate debt', () => {
+    // 6 × 2150 vs 2000 = 900 kcal debt; 30 days → 30 kcal/day (well within soft cap)
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 2150])
+    ));
+    const near = new Date('2025-06-15T00:00:00');
+    near.setDate(near.getDate() + 30);
+    const { scheduleAdjustment, scheduleCapped } =
+      calcBankingAutoGoal(TODAY, entries, 2000, near.toISOString().slice(0, 10));
+    expect(Math.abs(scheduleAdjustment)).toBeLessThanOrEqual(MAX_SCHEDULE_ADJ_SOFT);
+    expect(scheduleCapped).toBe(false);
+  });
+
+  it('massive overage with close goal date triggers soft-cap flag', () => {
+    // 6 × 3500 vs 2000 = 9000 kcal debt; 10 days → 900 kcal/day (exceeds hard cap)
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 3500])
+    ));
+    const near = new Date('2025-06-15T00:00:00');
+    near.setDate(near.getDate() + 10);
+    const { scheduleAdjustment, scheduleCapped } =
+      calcBankingAutoGoal(TODAY, entries, 2000, near.toISOString().slice(0, 10));
+    expect(Math.abs(scheduleAdjustment)).toBeLessThanOrEqual(MAX_SCHEDULE_ADJ_HARD);
+    expect(scheduleCapped).toBe(true);
+  });
+
+  it('target never goes below MIN_DAILY_CALORIES (1000) even with huge debt', () => {
+    // Artificially low base + big debt to test floor
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 3000])
+    ));
+    const near = new Date('2025-06-15T00:00:00');
+    near.setDate(near.getDate() + 3); // extremely close goal → huge required correction
+    const { todayKcalTarget, targetFloorApplied } =
+      calcBankingAutoGoal(TODAY, entries, 1100, near.toISOString().slice(0, 10));
+    expect(todayKcalTarget).toBeGreaterThanOrEqual(MIN_DAILY_CALORIES);
+    if (targetFloorApplied) expect(todayKcalTarget).toBe(MIN_DAILY_CALORIES);
+  });
+
+  it('under-eating in auto goal mode produces zero schedule adjustment (no bonus calories)', () => {
+    // 6 × 1600 vs 2000 = +2400 kcal credit → rawBankBalance > 0 → no schedule adjustment
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 1600])
+    ));
+    const far = new Date('2025-06-15T00:00:00');
+    far.setDate(far.getDate() + 60);
+    const { scheduleAdjustment, rawBankBalance } =
+      calcBankingAutoGoal(TODAY, entries, 2000, far.toISOString().slice(0, 10));
+    expect(rawBankBalance).toBeGreaterThan(0);
+    expect(scheduleAdjustment).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manual mode floor enforcement
+// ---------------------------------------------------------------------------
+
+describe('manual mode — rolling bank floor at 1000 kcal', () => {
+  it('massive overage in manual mode floors today target at 1000 kcal', () => {
+    // 6 × 4000 vs 2000 → rolling target = 7×2000 − 6×4000 = 14000 − 24000 = −10000 → floor
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 4000])
+    ));
+    // Mirror manual-mode rolling bank logic with floor applied
+    const { rollingTarget } = calcBanking(TODAY, entries, 2000);
+    const floored = Math.max(Math.round(rollingTarget / 25) * 25, MIN_DAILY_CALORIES);
+    expect(floored).toBeGreaterThanOrEqual(MIN_DAILY_CALORIES);
+  });
+
+  it('small overage in manual mode does not hit floor', () => {
+    // 6 × 2100 vs 2000 (100 kcal/day over) → rolling = 7×2000 − 6×2100 = 14000−12600 = 1400 → above 1000
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 2100])
+    ));
+    const { rollingTarget } = calcBanking(TODAY, entries, 2000);
+    const floored = Math.max(Math.round(rollingTarget / 25) * 25, MIN_DAILY_CALORIES);
+    expect(floored).toBeGreaterThan(1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mode isolation: manual uses rolling bank, auto goal uses schedule adjustment
+// ---------------------------------------------------------------------------
+
+describe('mode isolation: manual vs Auto Goal banking behavior', () => {
+  it('same overage history → manual crashes, auto goal does not', () => {
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 2800])
+    ));
+    const baseKcal = 2000;
+
+    // Manual mode: rolling target = 7×2000 − 6×2800 = 14000−16800 = -2800 (before floor)
+    const { rollingTarget: manualRolling } = calcBanking(TODAY, entries, baseKcal);
+    expect(manualRolling).toBeLessThan(baseKcal); // would be negative without floor
+
+    // Auto Goal mode: target = baseKcal + small schedule correction
+    const far = new Date('2025-06-15T00:00:00');
+    far.setDate(far.getDate() + 74);
+    const { todayKcalTarget: autoTarget } =
+      calcBankingAutoGoal(TODAY, entries, baseKcal, far.toISOString().slice(0, 10));
+    expect(autoTarget).toBeGreaterThan(1500); // no crash
+  });
+});

--- a/public/tools/CalorieTracker/ui/banking.test.js
+++ b/public/tools/CalorieTracker/ui/banking.test.js
@@ -540,3 +540,63 @@ describe('calcBankingCore — 177→170 lb scenario (regression)', () => {
     expect(r.targetFloorApplied).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// calcBankingCore — banking off (renderBankingPanel / renderCalcDetailsPanel)
+// These tests confirm that banking-off mode never crashes and produces the
+// right shape so the UI panels can render without ReferenceErrors.
+// ---------------------------------------------------------------------------
+
+describe('calcBankingCore — banking off UI safety', () => {
+  const BASE = 2000;
+
+  it('returns bankMode "off" when useRollingBanking is false', () => {
+    const r = calcBankingCore(makeCore({ useRollingBanking: false }));
+    expect(r.bankMode).toBe('off');
+  });
+
+  it('target = base + exercise, ignoring history', () => {
+    // 6 days of large overage — should have zero effect on target
+    const r = calcBankingCore(makeCore({
+      useRollingBanking: false,
+      todayBaseCalories: BASE,
+      todaysTrainingBump: 300,
+      sumPast6Actual: 6 * 3000,   // big overage — irrelevant
+    }));
+    expect(r.todayKcalTarget).toBe(Math.round((BASE + 300) / 25) * 25);
+    expect(r.bankBalance).toBe(0);
+    expect(r.bankAdjustmentApplied).toBe(0);
+  });
+
+  it('large undereating history has no effect on target', () => {
+    const r = calcBankingCore(makeCore({
+      useRollingBanking: false,
+      todayBaseCalories: BASE,
+      sumPast6Actual: 0,          // extreme under-eating — irrelevant
+    }));
+    expect(r.todayKcalTarget).toBe(BASE);
+    expect(r.bankBalance).toBe(0);
+  });
+
+  it('floor still applies when base + exercise is below effectiveFloor', () => {
+    const r = calcBankingCore(makeCore({
+      useRollingBanking: false,
+      todayBaseCalories: 500,
+      todaysTrainingBump: 0,
+      effectiveFloor: 1000,
+    }));
+    expect(r.todayKcalTarget).toBe(1000);
+    expect(r.targetFloorApplied).toBe(true);
+  });
+
+  it('all required output fields are present and numeric', () => {
+    const r = calcBankingCore(makeCore({ useRollingBanking: false }));
+    for (const key of ['bankMode', 'bankBalance', 'bankAdjustmentApplied',
+                        'scheduleAdjustment', 'rawBankBalance',
+                        'todayKcalTarget', 'targetFloorApplied', 'scheduleCapped']) {
+      expect(r).toHaveProperty(key);
+    }
+    expect(typeof r.todayKcalTarget).toBe('number');
+    expect(typeof r.bankBalance).toBe('number');
+  });
+});

--- a/public/tools/CalorieTracker/ui/banking.test.js
+++ b/public/tools/CalorieTracker/ui/banking.test.js
@@ -9,9 +9,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { calcBankingCore } from './bankingEngine.js';
 
 // ---------------------------------------------------------------------------
-// Pure helpers mirrored from dashboard.js
+// Pure helpers mirrored from dashboard.js (kept for existing test coverage)
 // ---------------------------------------------------------------------------
 
 function hasTrustedCalories(entry) {
@@ -399,5 +400,143 @@ describe('mode isolation: manual vs Auto Goal banking behavior', () => {
     const { todayKcalTarget: autoTarget } =
       calcBankingAutoGoal(TODAY, entries, baseKcal, far.toISOString().slice(0, 10));
     expect(autoTarget).toBeGreaterThan(1500); // no crash
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calcBankingCore — tests that use the real exported pure function
+// ---------------------------------------------------------------------------
+
+function makeCore(overrides = {}) {
+  return {
+    todayBaseCalories: 2000,
+    todaysTrainingBump: 0,
+    sumPastBaseTargets: 6 * 2000,
+    sumPastTrainingBumps: 0,
+    sumPast6Actual: 6 * 2000,
+    windowBudget: 7 * 2000,
+    targetMode: 'manual',
+    useRollingBanking: true,
+    goalTargetDate: null,
+    targetDateStr: TODAY,
+    effectiveFloor: 1000,
+    ...overrides,
+  };
+}
+
+describe('calcBankingCore — manual rolling bank', () => {
+  it('on-target past 6 days → zero bank balance, target = baseKcal', () => {
+    const r = calcBankingCore(makeCore());
+    expect(r.bankBalance).toBe(0);
+    expect(r.todayKcalTarget).toBe(2000);
+    expect(r.bankMode).toBe('manualRolling');
+  });
+
+  it('under-eating past 6 days → positive bank, higher today target', () => {
+    const r = calcBankingCore(makeCore({ sumPast6Actual: 6 * 1500 }));
+    expect(r.bankBalance).toBeGreaterThan(0);
+    expect(r.todayKcalTarget).toBeGreaterThan(2000);
+  });
+
+  it('large overage → target floored at effectiveFloor', () => {
+    const r = calcBankingCore(makeCore({ sumPast6Actual: 6 * 4000 }));
+    expect(r.targetFloorApplied).toBe(true);
+    expect(r.todayKcalTarget).toBe(1000);
+  });
+
+  it('floor of 1200 (BMR-based) is used when provided', () => {
+    const r = calcBankingCore(makeCore({ sumPast6Actual: 6 * 4000, effectiveFloor: 1200 }));
+    expect(r.todayKcalTarget).toBe(1200);
+  });
+});
+
+describe('calcBankingCore — banking off (useRollingBanking: false)', () => {
+  it('bankMode is "off" when useRollingBanking=false', () => {
+    const r = calcBankingCore(makeCore({ useRollingBanking: false }));
+    expect(r.bankMode).toBe('off');
+  });
+
+  it('target = base + exercise, unaffected by past overage', () => {
+    // 6 days of big overages but banking is off
+    const r = calcBankingCore(makeCore({
+      useRollingBanking: false,
+      sumPast6Actual: 6 * 3500,
+      todaysTrainingBump: 200,
+    }));
+    expect(r.todayKcalTarget).toBe(2200); // 2000 + 200, no penalty
+    expect(r.bankBalance).toBe(0);
+    expect(r.bankAdjustmentApplied).toBe(0);
+  });
+
+  it('under-eating past week does not inflate target when banking is off', () => {
+    const r = calcBankingCore(makeCore({
+      useRollingBanking: false,
+      sumPast6Actual: 6 * 500,
+    }));
+    expect(r.todayKcalTarget).toBe(2000);
+  });
+
+  it('floor still applies in banking-off mode', () => {
+    const r = calcBankingCore(makeCore({
+      useRollingBanking: false,
+      todayBaseCalories: 800,
+      effectiveFloor: 1000,
+    }));
+    expect(r.targetFloorApplied).toBe(true);
+    expect(r.todayKcalTarget).toBe(1000);
+  });
+});
+
+describe('calcBankingCore — Auto Goal schedule adjustment', () => {
+  it('no past overage → zero schedule adjustment, target = base', () => {
+    const r = calcBankingCore(makeCore({
+      targetMode: 'autoGoal',
+      goalTargetDate: '2025-09-01',
+    }));
+    expect(r.scheduleAdjustment).toBe(0);
+    expect(r.todayKcalTarget).toBe(2000);
+    expect(r.bankMode).toBe('autoGoalSchedule');
+  });
+
+  it('overage + far goal date → small negative schedule adjustment', () => {
+    const far = new Date(TODAY); far.setDate(far.getDate() + 74);
+    const r = calcBankingCore(makeCore({
+      targetMode: 'autoGoal',
+      sumPast6Actual: 6 * 2800, // 4800 kcal debt
+      goalTargetDate: far.toISOString().slice(0, 10),
+    }));
+    expect(r.scheduleAdjustment).toBeLessThan(0);
+    expect(r.todayKcalTarget).toBeGreaterThan(1000);
+    expect(r.todayKcalTarget).toBeLessThan(2100);
+  });
+
+  it('rawBankBalance returned as informational (not schedule adjustment)', () => {
+    const far = new Date(TODAY); far.setDate(far.getDate() + 74);
+    const r = calcBankingCore(makeCore({
+      targetMode: 'autoGoal',
+      sumPast6Actual: 6 * 2800,
+      goalTargetDate: far.toISOString().slice(0, 10),
+    }));
+    expect(r.rawBankBalance).toBeLessThan(0); // has debt
+    expect(r.bankBalance).toBe(r.rawBankBalance); // bankBalance = informational rawBankBalance
+    expect(Math.abs(r.scheduleAdjustment)).toBeLessThan(Math.abs(r.rawBankBalance)); // gentle spread
+  });
+});
+
+describe('calcBankingCore — 177→170 lb scenario (regression)', () => {
+  it('big overage history in auto goal mode does not produce crash target', () => {
+    // Simulate user who ate 2800 kcal/day vs 1935 kcal base for 6 days
+    const far = new Date(TODAY); far.setDate(far.getDate() + 74);
+    const r = calcBankingCore(makeCore({
+      targetMode: 'autoGoal',
+      todayBaseCalories: 1935,
+      sumPastBaseTargets: 6 * 1935,
+      sumPast6Actual: 6 * 2800,
+      goalTargetDate: far.toISOString().slice(0, 10),
+      effectiveFloor: 1000,
+    }));
+    expect(r.todayKcalTarget).toBeGreaterThan(1000);
+    expect(r.todayKcalTarget).toBeLessThan(2200);
+    expect(r.targetFloorApplied).toBe(false);
   });
 });

--- a/public/tools/CalorieTracker/ui/bankingEngine.js
+++ b/public/tools/CalorieTracker/ui/bankingEngine.js
@@ -1,0 +1,99 @@
+/**
+ * @file ui/bankingEngine.js
+ * Pure banking math — no state, no DOM, no Firebase.
+ * Imported by calculateBankingData() in dashboard.js and by unit tests.
+ */
+
+import { BANKING_CONFIG, BankingHelpers } from '../constants.js';
+
+/**
+ * Core banking calculation — given summarized inputs, produce today's calorie target.
+ *
+ * @param {object}      p
+ * @param {number}      p.todayBaseCalories    - Auto-goal or baseline daily calorie target
+ * @param {number}      p.todaysTrainingBump   - Exercise kcal for today
+ * @param {number}      p.sumPastBaseTargets   - Sum of past 6 days' base calorie targets
+ * @param {number}      p.sumPastTrainingBumps - Sum of past 6 days' exercise bumps
+ * @param {number}      p.sumPast6Actual       - Sum of past 6 days' actual intake
+ * @param {number}      p.windowBudget         - Full 7-day window budget (for manual rolling mode display)
+ * @param {string}      p.targetMode           - 'manual' | 'autoGoal'
+ * @param {boolean}     [p.useRollingBanking]  - Whether rolling bank is enabled (manual mode only); default true
+ * @param {string|null} [p.goalTargetDate]     - Goal target date 'YYYY-MM-DD' or null (auto goal only)
+ * @param {string}      p.targetDateStr        - Today's date 'YYYY-MM-DD'
+ * @param {number}      p.effectiveFloor       - Minimum daily calories (BMR-based ≥ 1000 or fixed 1000)
+ * @returns {{ bankMode, bankBalance, bankAdjustmentApplied, scheduleAdjustment, rawBankBalance, todayKcalTarget, targetFloorApplied, scheduleCapped }}
+ */
+export function calcBankingCore(p) {
+  const {
+    todayBaseCalories,
+    todaysTrainingBump,
+    sumPastBaseTargets,
+    sumPastTrainingBumps,
+    sumPast6Actual,
+    windowBudget,
+    targetMode,
+    useRollingBanking = true,
+    goalTargetDate = null,
+    targetDateStr,
+    effectiveFloor,
+  } = p;
+
+  const SOFT_CAP = -(BANKING_CONFIG.MAX_SCHEDULE_ADJ_SOFT ?? 150);
+  const HARD_CAP = -(BANKING_CONFIG.MAX_SCHEDULE_ADJ_HARD ?? 250);
+
+  // rawBankBalance: positive = under-ate (credit), negative = over-ate (debt)
+  const rawBankBalance = Math.round(sumPastBaseTargets + sumPastTrainingBumps - sumPast6Actual);
+
+  let bankMode, bankBalance, bankAdjustmentApplied, scheduleAdjustment, scheduleCapped, todayKcalTarget;
+  scheduleAdjustment = 0;
+  scheduleCapped = false;
+
+  if (targetMode === 'autoGoal') {
+    // AUTO GOAL: base + exercise + soft schedule correction.
+    // Full rolling bank NOT applied — only spread overages gently.
+    const cumulativeDebt = Math.max(0, -rawBankBalance);
+    if (cumulativeDebt > 0 && goalTargetDate) {
+      const targetMs = new Date(`${goalTargetDate}T00:00:00`).getTime();
+      const todayMs  = new Date(`${targetDateStr}T00:00:00`).getTime();
+      const remainingDays = Math.round((targetMs - todayMs) / 86400000);
+      if (remainingDays > 1) {
+        const rawAdj = -cumulativeDebt / remainingDays;
+        scheduleAdjustment = Math.round(Math.max(HARD_CAP, rawAdj));
+        if (rawAdj < SOFT_CAP) scheduleCapped = true;
+      }
+    }
+    bankMode = 'autoGoalSchedule';
+    bankAdjustmentApplied = scheduleAdjustment;
+    bankBalance = rawBankBalance; // informational — not directly applied
+    todayKcalTarget = BankingHelpers.roundToNearest25(todayBaseCalories + todaysTrainingBump + scheduleAdjustment);
+
+  } else if (!useRollingBanking) {
+    // MANUAL + banking off: fixed base + exercise, no week-level adjustment.
+    bankMode = 'off';
+    bankBalance = 0;
+    bankAdjustmentApplied = 0;
+    todayKcalTarget = BankingHelpers.roundToNearest25(todayBaseCalories + todaysTrainingBump);
+
+  } else {
+    // MANUAL rolling bank: window budget adjusts today's target up/down.
+    bankMode = 'manualRolling';
+    const rollingTarget = windowBudget - sumPast6Actual;
+    bankBalance = Math.round(rollingTarget - todayBaseCalories - todaysTrainingBump);
+    bankAdjustmentApplied = bankBalance;
+    todayKcalTarget = BankingHelpers.roundToNearest25(rollingTarget);
+  }
+
+  const targetFloorApplied = todayKcalTarget < effectiveFloor;
+  if (targetFloorApplied) todayKcalTarget = effectiveFloor;
+
+  return {
+    bankMode,
+    bankBalance: Math.round(bankBalance),
+    bankAdjustmentApplied,
+    scheduleAdjustment,
+    rawBankBalance,
+    todayKcalTarget,
+    targetFloorApplied,
+    scheduleCapped,
+  };
+}

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -701,7 +701,7 @@ function renderTodayMacroHeader(bankingData) {
   const el = document.getElementById('today-macro-header');
   if (!el) return;
 
-  const { todayKcalTarget, displayProteinG, displayFatG, displayCarbsG } = bankingData;
+  const { todayKcalTarget, finalProteinG, finalFatG, finalCarbsG } = bankingData;
 
   const totals = state.dailyFoodItems.reduce((acc, item) => {
     const q = parseFloat(item.quantity ?? 0) || 0;
@@ -724,10 +724,10 @@ function renderTodayMacroHeader(bankingData) {
   };
 
   el.innerHTML =
-    cell('Cal',     totals.cal,  todayKcalTarget)  +
-    cell('Protein', totals.pro,  displayProteinG)  +
-    cell('Fat',     totals.fat,  displayFatG)      +
-    cell('Carbs',   totals.carb, displayCarbsG);
+    cell('Cal',     totals.cal,  todayKcalTarget) +
+    cell('Protein', totals.pro,  finalProteinG)   +
+    cell('Fat',     totals.fat,  finalFatG)        +
+    cell('Carbs',   totals.carb, finalCarbsG);
 }
 
 /**
@@ -872,7 +872,7 @@ function renderCalcDetailsPanel(bankingData) {
   const {
     todayBaseCalories, todaysTrainingBump, bankBalance, targetMode, bankMode,
     sumPast6Actual, sumPastTargets, windowBudget, todayKcalTarget,
-    scheduleAdjustment, rawBankBalance, targetFloorApplied, minDailyCalories,
+    scheduleAdjustment, rawBankBalance, targetFloorApplied, effectiveFloor, floorSource,
   } = bankingData;
 
   if (bankMode === 'autoGoalSchedule') {
@@ -899,8 +899,8 @@ function renderCalcDetailsPanel(bankingData) {
           ` : ''}
           ${targetFloorApplied ? `
             <div class="flex justify-between items-center p-2 surface-1 rounded border text-warning">
-              <span>Minimum daily floor applied:</span>
-              <span class="font-medium">${minDailyCalories} kcal</span>
+              <span>Minimum daily floor applied${floorSource === 'bmr_floor' ? ' (BMR-based)' : ''}:</span>
+              <span class="font-medium">${effectiveFloor} kcal</span>
             </div>
           ` : ''}
           <div class="mt-2 pt-2 border-t border text-xs text-muted space-y-1">
@@ -957,9 +957,9 @@ function renderCalcDetailsPanel(bankingData) {
  */
 function renderTodayCompact(bankingData) {
   const {
-    todayKcalTarget, displayProteinG, displayFatG, displayCarbsG,
+    todayKcalTarget, finalProteinG, finalFatG, finalCarbsG,
     todayBaseCalories, todaysTrainingBump, bankBalance, bankIncomplete, unknownDays, targetMode,
-    bankMode, scheduleAdjustment, rawBankBalance, targetFloorApplied, minDailyCalories, scheduleCapped,
+    bankMode, scheduleAdjustment, rawBankBalance, targetFloorApplied, effectiveFloor, floorSource, scheduleCapped,
   } = bankingData;
 
   const totals = state.dailyFoodItems.reduce((acc, item) => {
@@ -1027,7 +1027,7 @@ function renderTodayCompact(bankingData) {
     : '';
 
   const floorNote = targetFloorApplied
-    ? `<div class="text-xs text-warning mt-1">⚠ Target was floored at ${minDailyCalories} kcal. Goal date may need adjustment or recent overage is being carried forward.</div>`
+    ? `<div class="text-xs text-warning mt-1">⚠ Target was floored at ${effectiveFloor} kcal${floorSource === 'bmr_floor' ? ' (BMR-based minimum)' : ''}. Goal date may need adjustment or recent overage is being carried forward.</div>`
     : '';
 
   const capNote = scheduleCapped
@@ -1057,9 +1057,9 @@ function renderTodayCompact(bankingData) {
       </div>
     </div>
     <div class="divide-y">
-      ${macroRow('Protein', totals.protein, displayProteinG)}
-      ${macroRow('Fat (min)', totals.fat, displayFatG)}
-      ${macroRow('Carbs', totals.carbs, displayCarbsG)}
+      ${macroRow('Protein', totals.protein, finalProteinG)}
+      ${macroRow('Fat (min)', totals.fat, finalFatG)}
+      ${macroRow('Carbs', totals.carbs, finalCarbsG)}
     </div>
   `;
 }
@@ -1332,7 +1332,7 @@ function renderBankingPanel(bankingData) {
   const {
     bankBalance, rawBankBalance, pastDays, sumPast6Actual, sumPastTargets,
     windowBudget, todayBaseCalories, targetMode, bankMode, scheduleAdjustment,
-    targetFloorApplied, minDailyCalories, scheduleCapped, todayKcalTarget,
+    targetFloorApplied, effectiveFloor, floorSource, scheduleCapped, todayKcalTarget,
   } = bankingData;
 
   const contributionRows = pastDays.map(d => `
@@ -1409,7 +1409,7 @@ function renderBankingPanel(bankingData) {
 
         ${targetFloorApplied ? `
           <div class="mb-3 p-3 surface-2 rounded-lg border text-sm text-warning">
-            ⚠ Target was floored at ${minDailyCalories} kcal. Goal date may need adjustment or the recent overage is large relative to remaining time.
+            ⚠ Target was floored at ${effectiveFloor} kcal${floorSource === 'bmr_floor' ? ' (BMR-based minimum)' : ''}. Goal date may need adjustment or the recent overage is large relative to remaining time.
           </div>` : ''}
 
         ${scheduleCapped ? `
@@ -1453,7 +1453,7 @@ function renderBankingPanel(bankingData) {
 
       ${targetFloorApplied ? `
         <div class="mt-3 p-3 surface-2 rounded-lg border text-sm text-warning">
-          ⚠ Target was floored at ${minDailyCalories} kcal. The rolling bank pulled today's budget below the minimum safe daily intake.
+          ⚠ Target was floored at ${effectiveFloor} kcal${floorSource === 'bmr_floor' ? ' (BMR-based minimum)' : ''}. The rolling bank pulled today's budget below the minimum safe daily intake.
         </div>` : ''}
 
       ${pastDaysTable}

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -10,7 +10,6 @@ import {
   dailyTrackedNutrients,
   averagedNutrients,
   BANKING_CONFIG,
-  BankingHelpers,
   DEFAULT_TARGETS,
   DAY_ACTIVITY_LEVELS,
 } from '../constants.js';
@@ -399,6 +398,10 @@ export function calculateBankingData(targetDateStr) {
       finalFatG: displayFatG,
       finalCarbsG: carbsG,
 
+      // Macro feasibility: protein+fat floors exceed calorie target → carbs forced to 0
+      macroFloorExceedsCalories: (displayProteinG * 4 + displayFatG * 9) > todayKcalTarget,
+      macroFloorCalories: displayProteinG * 4 + displayFatG * 9,
+
       // Today's resolved base calorie target
       todayBaseCalories,
       resolvedTargetSource,
@@ -447,6 +450,8 @@ export function calculateBankingData(targetDateStr) {
       finalProteinG: BANKING_CONFIG.PROTEIN_G,
       finalFatG: BANKING_CONFIG.FAT_FLOOR_G,
       finalCarbsG: 0,
+      macroFloorExceedsCalories: false,
+      macroFloorCalories: BANKING_CONFIG.PROTEIN_G * 4 + BANKING_CONFIG.FAT_FLOOR_G * 9,
       todayBaseCalories: BANKING_CONFIG.BASE_KCAL,
       resolvedTargetSource: 'manual',
       bankIncomplete: false,
@@ -960,6 +965,7 @@ function renderTodayCompact(bankingData) {
     todayKcalTarget, finalProteinG, finalFatG, finalCarbsG,
     todayBaseCalories, todaysTrainingBump, bankBalance, bankIncomplete, unknownDays, targetMode,
     bankMode, scheduleAdjustment, rawBankBalance, targetFloorApplied, effectiveFloor, floorSource, scheduleCapped,
+    macroFloorExceedsCalories,
   } = bankingData;
 
   const totals = state.dailyFoodItems.reduce((acc, item) => {
@@ -1038,6 +1044,10 @@ function renderTodayCompact(bankingData) {
     ? `<div class="text-xs text-muted mt-0.5 italic" style="font-size:0.7rem">Profile &amp; Goals only changes Today after "Apply to Baseline Targets" or switching to Auto Goal mode.</div>`
     : '';
 
+  const macroFeasibilityNote = macroFloorExceedsCalories
+    ? `<div class="text-xs text-warning mt-1">⚠ Protein + fat floors exceed today's calorie target — carbs set to 0. Consider relaxing the target or adjusting macro floors.</div>`
+    : '';
+
   return `
     <div class="mb-4 p-4 surface-2 rounded-lg border text-center">
       <div class="text-xs text-muted uppercase tracking-wide mb-1">${remainLabel}</div>
@@ -1048,6 +1058,7 @@ function renderTodayCompact(bankingData) {
       </div>
       ${rawBankNote}
       ${floorNote}
+      ${macroFeasibilityNote}
       ${capNote}
       ${bankNote}
       ${profileNote}
@@ -1422,6 +1433,33 @@ function renderBankingPanel(bankingData) {
     `;
   }
 
+  // Banking-off mode — fixed base + exercise, no week-level adjustment
+  if (bankMode === 'off') {
+    return `
+      <div class="section-card p-4">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-responsive-xl font-bold text-secondary">📋 Manual — Banking Off</h3>
+          <button id="recent-days-toggle" class="btn-subtle">
+            <i class="fas fa-chevron-down"></i>
+            <span class="toggle-text">Show Past 6 Days</span>
+          </button>
+        </div>
+
+        <div class="p-3 rounded-lg border surface-2 mb-3 text-sm text-muted">
+          <p>Banking is disabled. Today's target is your base target${todaysTrainingBump > 0 ? ` plus today's exercise (+${todaysTrainingBump} kcal)` : ''} — past intake does not adjust it.</p>
+          <p class="mt-1 text-xs">Past 6 days are shown below for context only.</p>
+        </div>
+
+        ${targetFloorApplied ? `
+          <div class="mb-3 p-3 surface-2 rounded-lg border text-sm text-warning">
+            ⚠ Target was floored at ${effectiveFloor} kcal${floorSource === 'bmr_floor' ? ' (BMR-based minimum)' : ''}.
+          </div>` : ''}
+
+        ${pastDaysTable}
+      </div>
+    `;
+  }
+
   // Manual mode — rolling bank panel
   const bankExplanation = bankBalance > 0
     ? `You have ${bankBalance} kcal banked from under-eating — today's target is higher to use it.`
@@ -1462,146 +1500,6 @@ function renderBankingPanel(bankingData) {
         <p><strong>How it works:</strong> Your 7-day calorie budget is ${budgetExplain}</p>
         <p>You've consumed ${sumPast6Actual} kcal over the last 6 days against a target of ${sumPastTargets} kcal.</p>
         <p>${tomorrowNote}</p>
-      </div>
-    </div>
-  `;
-}
-
-
-/**
- * Render today's plan with collapsible calculation details
- */
-function renderTodaysPlanPanel(bankingData, todaysEntry) {
-  const {
-    baseKcal,
-    todaysTrainingBump,
-    bankBalance,
-    sumPast6Actual,
-    sumPastTargets,
-    windowBudget,
-    todayKcalTarget,
-    proteinG,
-    fatG,
-    carbsG,
-    trainingIntensity
-  } = bankingData;
-
-  // Derive today's actuals from state with quantity awareness
-  const todaysTotals = state.dailyFoodItems.reduce((acc, item) => {
-    const q = parseFloat(item.quantity ?? 0) || 0;
-    const cals = parseFloat(item.calories) || 0;
-    const p = parseFloat(item.protein) || 0;
-    const f = parseFloat(item.fat) || 0;
-    const c = parseFloat(item.carbs) || 0;
-    acc.calories += q * cals;
-    acc.protein += q * p;
-    acc.fat += q * f;
-    acc.carbs += q * c;
-    return acc;
-  }, { calories: 0, protein: 0, fat: 0, carbs: 0 });
-
-  const todaysCalories = todaysTotals.calories;
-  const todaysProtein = todaysTotals.protein;
-  const todaysFat = todaysTotals.fat;
-  const todaysCarbs = todaysTotals.carbs;
-
-  const remainingCalories = todayKcalTarget - todaysCalories;
-
-  const remainingCaloriesColor = remainingCalories >= 0 ? 'text-muted' : 'text-negative';
-
-  const renderMacroRow = (label, current, target) => {
-    const remaining = target - current;
-    return `
-      <div class="kpi-row">
-        <div class="meta">
-          <span class="label">${label}</span>
-          <span class="current">${Math.round(current)}g</span>
-          <span class="target">target ${Math.round(target)}g</span>
-          <span class="remain ${remainClass(remaining)}">
-            ${remaining > 0 ? `${Math.round(remaining)}g left` : remaining < 0 ? `${Math.abs(Math.round(remaining))}g over` : '0g left'}
-          </span>
-        </div>
-        <div class="hbar">
-          <div class="hbar-fill ${pctClass(current, target)}" style="width:${pctWidth(current, target)}"></div>
-          <div class="hbar-marker" style="left:${markerLeft}"></div>
-        </div>
-      </div>
-    `;
-  };
-
-  const macroRows = [
-    renderMacroRow('Protein', todaysProtein, proteinG),
-    renderMacroRow('Fat (minimum)', todaysFat, fatG),
-    renderMacroRow('Carbs (flexible)', todaysCarbs, carbsG)
-  ].join('');
-
-  return `
-    <div class="mb-6 card p-6 shadow-lg">
-      <h3 class="text-responsive-xl font-bold text-secondary mb-4">🍽️ Today's Nutrition Plan</h3>
-
-      <!-- Summary Section -->
-      <div class="mb-4 p-4 surface-2 rounded-lg border">
-        <div class="flex justify-between items-center text-lg font-semibold">
-          <span>Today's Calorie Target:</span>
-          <span class="text-accent">${todayKcalTarget} kcal</span>
-        </div>
-        <div class="flex justify-between items-center text-sm mt-1">
-          <span class="text-primary">Remaining:</span>
-          <span class="font-medium ${remainingCaloriesColor}">${remainingCalories.toFixed(0)} kcal</span>
-        </div>
-
-        <!-- Collapsible Details Button -->
-        <button id="bank-details-toggle" class="mt-3 btn-subtle">
-          <i class="fas fa-chevron-down"></i>
-          <span class="toggle-text">Show How We Calculated This</span>
-        </button>
-
-        <!-- Collapsible Calculation Details -->
-        <div id="bank-details-content" class="${DASHBOARD_CONFIG.DEFAULT_COLLAPSED_DETAILS ? 'hidden' : ''} mt-4 space-y-2 text-sm">
-          <div class="grid grid-cols-1 gap-2">
-            <div class="flex justify-between items-center p-2 surface-1 rounded border">
-              <span>7-day window budget:</span>
-              <span class="font-medium">${windowBudget} kcal</span>
-            </div>
-            <div class="flex justify-between items-center p-2 surface-1 rounded border">
-              <span>Past 6 days target:</span>
-              <span class="font-medium">${sumPastTargets} kcal (base + training)</span>
-            </div>
-            <div class="flex justify-between items-center p-2 surface-1 rounded border">
-              <span>Past 6 days consumed:</span>
-              <span class="font-medium">${sumPast6Actual} kcal</span>
-            </div>
-            <div class="flex justify-between items-center p-2 surface-1 rounded border">
-              <span>Remaining for today:</span>
-              <span class="font-medium">${windowBudget - sumPast6Actual} kcal</span>
-            </div>
-            ${todaysTrainingBump > 0 ? `
-              <p class="text-xs text-muted px-2 italic">Exercise calories included in today's budget (+${todaysTrainingBump} kcal)</p>
-            ` : ''}
-            ${bankBalance !== 0 ? `
-              <div class="flex justify-between items-center p-2 rounded border surface-2">
-                <span>Rolling balance adjustment:</span>
-                <span class="font-medium ${bankBalance > 0 ? 'text-positive' : 'text-negative'}">${bankBalance > 0 ? '+' : ''}${bankBalance} kcal</span>
-              </div>
-            ` : ''}
-            <div class="mt-2 pt-2 border-t border">
-              <div class="text-xs text-muted space-y-1">
-                <div>Final target: ${windowBudget} − ${sumPast6Actual} = <strong>${todayKcalTarget} kcal</strong></div>
-                <div>If you eat exactly this, tomorrow's target will be ${todayBaseCalories ?? baseKcal} kcal (on a rest day).</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <!-- Macro Breakdown -->
-        <div class="md:col-span-3">
-          <h4 class="font-semibold text-secondary mb-3">Your Macro Targets</h4>
-          <div class="divide-y">
-            ${macroRows}
-          </div>
-        </div>
       </div>
     </div>
   `;

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -921,7 +921,38 @@ function renderCalcDetailsPanel(bankingData) {
     `;
   }
 
-  // Manual mode
+  // Manual — banking off: fixed base + exercise only
+  if (bankMode === 'off') {
+    return `
+      <div class="section-card p-4 mb-6">
+        <h3 class="text-responsive-xl font-bold text-secondary mb-3">🧮 How Today's Target Was Calculated</h3>
+        <div class="grid grid-cols-1 gap-2 text-sm">
+          <div class="flex justify-between items-center p-2 surface-1 rounded border">
+            <span>Manual base target:</span>
+            <span class="font-medium">${todayBaseCalories} kcal</span>
+          </div>
+          ${todaysTrainingBump > 0 ? `
+            <div class="flex justify-between items-center p-2 surface-1 rounded border">
+              <span>Exercise:</span>
+              <span class="font-medium text-accent">+${todaysTrainingBump} kcal</span>
+            </div>
+          ` : ''}
+          ${targetFloorApplied ? `
+            <div class="flex justify-between items-center p-2 surface-1 rounded border text-warning">
+              <span>Minimum daily floor applied${floorSource === 'bmr_floor' ? ' (BMR-based)' : ''}:</span>
+              <span class="font-medium">${effectiveFloor} kcal</span>
+            </div>
+          ` : ''}
+          <div class="mt-2 pt-2 border-t border text-xs text-muted space-y-1">
+            <div>${todayBaseCalories}${todaysTrainingBump > 0 ? ` + ${todaysTrainingBump}` : ''} = <strong>${todayKcalTarget} kcal today</strong></div>
+            <div>Banking is off — past days do not alter today's target.</div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // Manual mode — rolling bank
   const tomorrowNote = `Hit this target and tomorrow resets to ${todayBaseCalories} kcal (rest day).`;
   return `
     <div class="section-card p-4 mb-6">
@@ -1322,6 +1353,19 @@ function renderInfoBox() {
     `;
   }
 
+  if (state.goalSettings?.useRollingBanking === false) {
+    return `
+      <div class="mb-6 p-4 surface-2 rounded-lg border">
+        <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How This Works</h3>
+        <div class="text-sm text-muted space-y-1">
+          <p><strong>Fixed Daily Target:</strong> Banking is off. Your target each day is your manual baseline plus any exercise calories — past intake has no effect on today's number.</p>
+          <p><strong>Past 6 Days:</strong> Shown as context only and do not roll into the current target.</p>
+          <p><strong>Training Days:</strong> Select your workout type above — this adds calories and scales electrolytes appropriately.</p>
+        </div>
+      </div>
+    `;
+  }
+
   return `
     <div class="mb-6 p-4 surface-2 rounded-lg border">
       <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How This Works</h3>
@@ -1342,7 +1386,7 @@ function renderInfoBox() {
 function renderBankingPanel(bankingData) {
   const {
     bankBalance, rawBankBalance, pastDays, sumPast6Actual, sumPastTargets,
-    windowBudget, todayBaseCalories, targetMode, bankMode, scheduleAdjustment,
+    windowBudget, todayBaseCalories, todaysTrainingBump, targetMode, bankMode, scheduleAdjustment,
     targetFloorApplied, effectiveFloor, floorSource, scheduleCapped, todayKcalTarget,
   } = bankingData;
 

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -281,38 +281,87 @@ export function calculateBankingData(targetDateStr) {
     const todaysTrainingBump  = getEntryExerciseKcal(todaysEntry, weightKg);
     const todayBaseCalories   = resolveDayCalorieTarget(targetDateStr);
 
-    // The full 7-day window budget uses each day's own base target
-    // PLUS training bumps for every day (past and today).
+    // The full 7-day window budget (for display and manual-mode calc).
     const windowBudget = sumPastBaseTargets + todayBaseCalories + sumPastTrainingBumps + todaysTrainingBump;
 
-    // Rolling target = how much of the window budget remains for today.
-    const rollingTarget = windowBudget - sumPast6Actual;
+    // rawBankBalance: cumulative credit (+) or debt (-) from the past 6 days.
+    // Positive = under-ate relative to targets. Negative = over-ate.
+    const rawBankBalance = Math.round(sumPastBaseTargets + sumPastTrainingBumps - sumPast6Actual);
 
-    // Bank balance = how much today's target differs from a plain rest-day goal.
-    // Positive = you under-ate relative to targets = more room today.
-    // Negative = you over-ate relative to targets = less room today.
-    // When bankIncomplete, the balance is a lower-bound estimate (unknown days neutral).
-    const bankBalance = rollingTarget - todayBaseCalories - todaysTrainingBump;
+    // Sum of all past day targets (for display in the table footer)
+    const sumPastTargets = sumPastBaseTargets + sumPastTrainingBumps;
 
-    // Round to nearest 25 for display friendliness
-    const todayKcalTarget = BankingHelpers.roundToNearest25(rollingTarget);
+    // ── Mode-specific target resolution ──────────────────────────────────────
+    const MIN_DAILY_CALORIES = BANKING_CONFIG.MIN_DAILY_CALORIES ?? 1000;
+    let bankMode, bankBalance, bankAdjustmentApplied, scheduleAdjustment, targetFloorApplied;
+    let scheduleCapped = false;
+    let todayKcalTarget;
 
-    // Protein floor does not scale with exercise; carbs absorb the extra calories.
+    if (targetMode === 'autoGoal') {
+      // AUTO GOAL: today's target = base (from goal engine) + exercise + soft schedule correction.
+      // The full rolling bank is NOT applied — that caused extreme negative targets when a few
+      // high-calorie days exhausted the 7-day window budget.
+      scheduleAdjustment = 0;
+
+      const cumulativeDebt = Math.max(0, -rawBankBalance); // how much over target this week
+
+      if (cumulativeDebt > 0) {
+        const goalTargetDate = state.goalSettings?.targetDate;
+        if (goalTargetDate) {
+          const targetMs   = new Date(`${goalTargetDate}T00:00:00`).getTime();
+          const todayMs    = new Date(`${targetDateStr}T00:00:00`).getTime();
+          const remainingDays = Math.round((targetMs - todayMs) / 86400000);
+
+          if (remainingDays > 1) {
+            const rawAdj   = -cumulativeDebt / remainingDays;
+            const SOFT_CAP = -(BANKING_CONFIG.MAX_SCHEDULE_ADJ_SOFT ?? 150);
+            const HARD_CAP = -(BANKING_CONFIG.MAX_SCHEDULE_ADJ_HARD ?? 250);
+            // Apply hard cap; flag if soft cap was also exceeded
+            scheduleAdjustment = Math.round(Math.max(HARD_CAP, rawAdj));
+            if (rawAdj < SOFT_CAP) scheduleCapped = true;
+          }
+        }
+      }
+
+      bankMode             = 'autoGoalSchedule';
+      bankAdjustmentApplied = scheduleAdjustment;
+      bankBalance          = rawBankBalance; // informational (not directly applied)
+
+      const rawTarget = todayBaseCalories + todaysTrainingBump + scheduleAdjustment;
+      todayKcalTarget = BankingHelpers.roundToNearest25(rawTarget);
+
+      targetFloorApplied = todayKcalTarget < MIN_DAILY_CALORIES;
+      if (targetFloorApplied) todayKcalTarget = MIN_DAILY_CALORIES;
+
+    } else {
+      // MANUAL: rolling bank logic — the window budget adjusts today's target up/down.
+      bankMode = 'manualRolling';
+      scheduleAdjustment = 0;
+
+      const rollingTarget = windowBudget - sumPast6Actual;
+      bankBalance          = Math.round(rollingTarget - todayBaseCalories - todaysTrainingBump);
+      bankAdjustmentApplied = bankBalance;
+
+      todayKcalTarget = BankingHelpers.roundToNearest25(rollingTarget);
+
+      targetFloorApplied = todayKcalTarget < MIN_DAILY_CALORIES;
+      if (targetFloorApplied) todayKcalTarget = MIN_DAILY_CALORIES;
+    }
+
+    // Macro split using today's final target.
     const scaledProteinG = proteinG;
     const proteinKcal    = scaledProteinG * 4;
     const fatKcal        = fatFloorG * 9;
     const remainingKcal  = Math.max(0, todayKcalTarget - proteinKcal - fatKcal);
     const carbsG         = Math.round(remainingKcal / 4);
 
-    // Resolve today's base macro targets for display.
-    // carbsG above can be 0 when the rolling target < protein+fat budget (e.g. after over-eating);
-    // macro progress bars should show the stable daily base targets instead.
-    // Also capture the resolution source so display labels can be mode-accurate.
-    let resolvedTargetSource = targetMode;  // 'manual' or 'autoGoal'
+    // Resolve today's stable base macro targets for progress bars.
+    // carbsG above can be 0 when rolling target < protein+fat budget — show stable targets instead.
+    let resolvedTargetSource = targetMode;
     const displayBaseTargets = targetMode === 'autoGoal'
       ? (() => {
         const r = resolveDailyBaseTargets(targetDateStr, state);
-        resolvedTargetSource = r.source;   // may be 'manual_fallback' if weight unavailable
+        resolvedTargetSource = r.source;
         return r.targets || {};
       })()
       : state.baselineTargets;
@@ -325,19 +374,13 @@ export function calculateBankingData(targetDateStr) {
       return Math.round(Math.max(0, (calBudget - displayProteinG * 4 - displayFatG * 9) / 4));
     })();
 
-    // Sum of all past day targets (for display in the table footer)
-    const sumPastTargets = sumPastBaseTargets + sumPastTrainingBumps;
-
     debugLog('calculation-summary', {
-      windowBudget,
+      targetMode, bankMode,
+      rawBankBalance, scheduleAdjustment, bankBalance,
+      todayBaseCalories, todaysTrainingBump,
+      todayKcalTarget, targetFloorApplied, scheduleCapped,
       sumPast6Actual: Math.round(sumPast6Actual),
-      sumPastTrainingBumps,
-      todaysTrainingBump,
-      rollingTarget: Math.round(rollingTarget),
-      bankBalance: Math.round(bankBalance),
-      todayKcalTarget,
-      bankIncomplete,
-      unknownDays,
+      bankIncomplete, unknownDays,
     });
 
     if (DASHBOARD_CONFIG.LOG_CALCULATION_STEPS && pastDays.length > 0) {
@@ -352,7 +395,7 @@ export function calculateBankingData(targetDateStr) {
     }
 
     return {
-      // Core rolling balance values
+      // Core balance values
       bankBalance: Math.round(bankBalance),
       pastDays,
       sumPast6Actual: Math.round(sumPast6Actual),
@@ -369,12 +412,12 @@ export function calculateBankingData(targetDateStr) {
       fatG: Math.round(fatFloorG),
       carbsG,
 
-      // Base macro targets for display (stable; not reduced by rolling deficit)
+      // Stable display macros (not reduced by bank/schedule)
       displayProteinG,
       displayFatG,
       displayCarbsG,
 
-      // Today's resolved base calorie target (may differ from baseKcal in autoGoal mode)
+      // Today's resolved base calorie target
       todayBaseCalories,
       resolvedTargetSource,
 
@@ -382,8 +425,15 @@ export function calculateBankingData(targetDateStr) {
       bankIncomplete,
       unknownDays,
 
-      // Display meta
+      // Mode / adjustment metadata
       targetMode,
+      bankMode,            // 'manualRolling' | 'autoGoalSchedule'
+      bankAdjustmentApplied,
+      rawBankBalance,      // cumulative 6-day credit/debt (informational in autoGoal mode)
+      scheduleAdjustment,  // auto goal only: spread overage over remaining days
+      targetFloorApplied,  // true when MIN_DAILY_CALORIES floor was applied
+      minDailyCalories: MIN_DAILY_CALORIES,
+      scheduleCapped,      // true if soft cap (150 kcal/day) was hit
 
       // Config
       config: { windowDays }
@@ -412,7 +462,13 @@ export function calculateBankingData(targetDateStr) {
       bankIncomplete: false,
       unknownDays: [],
       targetMode: 'manual',
-      trainingIntensity: 'rest',
+      bankMode: 'manualRolling',
+      bankAdjustmentApplied: 0,
+      rawBankBalance: 0,
+      scheduleAdjustment: 0,
+      targetFloorApplied: false,
+      minDailyCalories: BANKING_CONFIG.MIN_DAILY_CALORIES ?? 1000,
+      scheduleCapped: false,
       config: { windowDays: BANKING_CONFIG.ROLLING_WINDOW_DAYS }
     };
   }
@@ -432,12 +488,18 @@ export function calculateMicronutrientMetrics(dateStr) {
     const targetDate = new Date(`${dateStr}T00:00:00`);
     const todayEntry = state.dailyEntries.get(dateStr) || {};
 
+    // In autoGoal mode resolve targets once so Nutrients tab matches Today/Charts.
+    const targetMode = state.goalSettings?.targetMode ?? 'manual';
+    const effectiveTargets = targetMode === 'autoGoal'
+      ? (resolveDailyBaseTargets(dateStr, state).targets ?? state.baselineTargets)
+      : state.baselineTargets;
+
     const metrics = {};
 
     allNutrients.forEach(nutrient => {
       if (nutrients.macros.includes(nutrient)) return; // Skip macros
 
-      const baseTarget = parseFloat(state.baselineTargets[nutrient]) || DEFAULT_TARGETS[nutrient] || 0;
+      const baseTarget = parseFloat(effectiveTargets[nutrient]) || DEFAULT_TARGETS[nutrient] || 0;
       const { factor, suggested, reason } = getElectrolyteScale(nutrient, todayEntry);
       const scaledTarget = baseTarget * factor;
       const todaysIntake = dateStr === state.dom.dateInput.value
@@ -500,10 +562,10 @@ export function calculateMicronutrientMetrics(dateStr) {
         trendDirection = computeTrendDirection(todaysIntake, priorAvg);
       }
 
-      // Target source classification
+      // Target source classification (use effectiveTargets so auto-goal values are classified correctly)
       const targetSource = classifyTargetSource(
         nutrient,
-        state.baselineTargets,
+        effectiveTargets,
         DEFAULT_TARGETS,
         state.goalSettings?.manualTargetOverrides,
       );
@@ -811,17 +873,58 @@ function renderEnergyOutput() {
 }
 
 /**
- * Render the calculation formula panel for Energy tab.
+ * Render the calculation formula panel for Energy tab (mode-aware).
  */
 function renderCalcDetailsPanel(bankingData) {
   const {
-    todayBaseCalories, todaysTrainingBump, bankBalance, targetMode,
-    sumPast6Actual, sumPastTargets, windowBudget, todayKcalTarget, trainingIntensity
+    todayBaseCalories, todaysTrainingBump, bankBalance, targetMode, bankMode,
+    sumPast6Actual, sumPastTargets, windowBudget, todayKcalTarget,
+    scheduleAdjustment, rawBankBalance, targetFloorApplied, minDailyCalories,
   } = bankingData;
-  const tomorrowNote = targetMode === 'autoGoal'
-    ? 'Hit this target and tomorrow recalculates from Auto Goal mode.'
-    : `Hit this target and tomorrow resets to ${todayBaseCalories} kcal (rest day).`;
 
+  if (bankMode === 'autoGoalSchedule') {
+    const tomorrowNote = 'Hit this target and tomorrow recalculates from Auto Goal mode.';
+    return `
+      <div class="section-card p-4 mb-6">
+        <h3 class="text-responsive-xl font-bold text-secondary mb-3">🧮 How Today's Target Was Calculated</h3>
+        <div class="grid grid-cols-1 gap-2 text-sm">
+          <div class="flex justify-between items-center p-2 surface-1 rounded border">
+            <span>Auto Goal base target (from weight &amp; goal):</span>
+            <span class="font-medium">${todayBaseCalories} kcal</span>
+          </div>
+          ${todaysTrainingBump > 0 ? `
+            <div class="flex justify-between items-center p-2 surface-1 rounded border">
+              <span>Exercise:</span>
+              <span class="font-medium text-accent">+${todaysTrainingBump} kcal</span>
+            </div>
+          ` : ''}
+          ${scheduleAdjustment !== 0 ? `
+            <div class="flex justify-between items-center p-2 surface-1 rounded border">
+              <span>Schedule correction (overage spread over goal window):</span>
+              <span class="font-medium ${scheduleAdjustment > 0 ? 'text-positive' : 'text-negative'}">${scheduleAdjustment > 0 ? '+' : ''}${scheduleAdjustment} kcal</span>
+            </div>
+          ` : ''}
+          ${targetFloorApplied ? `
+            <div class="flex justify-between items-center p-2 surface-1 rounded border text-warning">
+              <span>Minimum daily floor applied:</span>
+              <span class="font-medium">${minDailyCalories} kcal</span>
+            </div>
+          ` : ''}
+          <div class="mt-2 pt-2 border-t border text-xs text-muted space-y-1">
+            <div>${todayBaseCalories} + ${todaysTrainingBump} + ${scheduleAdjustment} = <strong>${todayKcalTarget} kcal today</strong></div>
+            ${rawBankBalance !== 0 ? `
+              <div class="italic">7-day raw balance: ${rawBankBalance > 0 ? '+' : ''}${rawBankBalance} kcal (${rawBankBalance < 0 ? 'overage spread over remaining goal days — not applied as a single crash day' : 'credit — not added to today\'s target in Auto Goal mode'}).</div>
+            ` : ''}
+            <div>${tomorrowNote}</div>
+            <div>In Auto Goal mode: overages are spread gently, not concentrated. The base target recalculates as your weight changes.</div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // Manual mode
+  const tomorrowNote = `Hit this target and tomorrow resets to ${todayBaseCalories} kcal (rest day).`;
   return `
     <div class="section-card p-4 mb-6">
       <h3 class="text-responsive-xl font-bold text-secondary mb-3">🧮 How Today's Target Was Calculated</h3>
@@ -863,6 +966,7 @@ function renderTodayCompact(bankingData) {
   const {
     todayKcalTarget, displayProteinG, displayFatG, displayCarbsG,
     todayBaseCalories, todaysTrainingBump, bankBalance, bankIncomplete, unknownDays, targetMode,
+    bankMode, scheduleAdjustment, rawBankBalance, targetFloorApplied, minDailyCalories, scheduleCapped,
   } = bankingData;
 
   const totals = state.dailyFoodItems.reduce((acc, item) => {
@@ -874,8 +978,11 @@ function renderTodayCompact(bankingData) {
     return acc;
   }, { calories: 0, protein: 0, fat: 0, carbs: 0 });
 
-  const remaining  = todayKcalTarget - totals.calories;
+  const remaining   = todayKcalTarget - totals.calories;
   const remainColor = remaining >= 0 ? 'text-positive' : 'text-negative';
+  // Label changes when over target so the large number isn't mistaken for a negative calorie target
+  const remainLabel = remaining >= 0 ? 'Calories Remaining' : 'Calories Over Target';
+  const remainDisplay = Math.abs(Math.round(remaining));
 
   const macroRow = (label, actual, target) => {
     const rem = target - actual;
@@ -900,8 +1007,38 @@ function renderTodayCompact(bankingData) {
     ? `<span class="text-xs font-medium text-accent ml-1">Auto Goal</span>`
     : `<span class="text-xs text-muted ml-1">Manual Baseline</span>`;
 
+  // Build the adjustment segment of the formula line.
+  let adjSegment = '';
+  if (bankMode === 'autoGoalSchedule') {
+    if (scheduleAdjustment !== 0) {
+      adjSegment = ` + Schedule: ${scheduleAdjustment > 0 ? '+' : ''}${scheduleAdjustment}`;
+    }
+  } else {
+    // Manual mode — rolling bank
+    if (bankBalance !== 0) {
+      adjSegment = ` + Bank: ${bankBalance > 0 ? '+' : ''}${bankBalance}`;
+    }
+  }
+  const exerciseSegment = todaysTrainingBump > 0 ? ` + Exercise: +${todaysTrainingBump}` : '';
+
+  // Informational raw-bank line for Auto Goal mode
+  const rawBankNote = bankMode === 'autoGoalSchedule' && rawBankBalance !== 0
+    ? `<div class="text-xs text-muted mt-0.5">
+        7-day raw ${rawBankBalance < 0 ? 'overage' : 'credit'}: ${Math.abs(rawBankBalance)} kcal
+        ${rawBankBalance < 0 && scheduleAdjustment !== 0 ? '— spread over goal window' : ''}
+       </div>`
+    : '';
+
   const bankNote = bankIncomplete
-    ? `<div class="text-xs text-warning mt-1">⚠ Rolling bank incomplete — missing data for: ${unknownDays.join(', ')}. Unknown days treated as on-target.</div>`
+    ? `<div class="text-xs text-warning mt-1">⚠ ${bankMode === 'autoGoalSchedule' ? 'Schedule context' : 'Rolling bank'} incomplete — missing data for: ${unknownDays.join(', ')}. Unknown days treated as on-target.</div>`
+    : '';
+
+  const floorNote = targetFloorApplied
+    ? `<div class="text-xs text-warning mt-1">⚠ Target was floored at ${minDailyCalories} kcal. Goal date may need adjustment or recent overage is being carried forward.</div>`
+    : '';
+
+  const capNote = scheduleCapped
+    ? `<div class="text-xs text-warning mt-0.5">Schedule correction capped at ${scheduleAdjustment} kcal/day (daily limit). Goal date may benefit from extension.</div>`
     : '';
 
   const profileNote = targetMode !== 'autoGoal'
@@ -910,12 +1047,15 @@ function renderTodayCompact(bankingData) {
 
   return `
     <div class="mb-4 p-4 surface-2 rounded-lg border text-center">
-      <div class="text-xs text-muted uppercase tracking-wide mb-1">Calories Remaining</div>
-      <div class="text-4xl font-bold ${remainColor}">${Math.round(remaining)}</div>
+      <div class="text-xs text-muted uppercase tracking-wide mb-1">${remainLabel}</div>
+      <div class="text-4xl font-bold ${remainColor}">${remainDisplay}</div>
       <div class="text-xs text-muted mt-1">${Math.round(totals.calories)} eaten · ${todayKcalTarget} target</div>
       <div class="text-xs text-muted mt-1">
-        Target: ${modeBadge} · Base: ${todayBaseCalories}${todaysTrainingBump > 0 ? ` + Exercise: +${todaysTrainingBump}` : ''}${bankBalance !== 0 ? ` + Bank: ${bankBalance > 0 ? '+' : ''}${bankBalance}` : ''} = ${todayKcalTarget} kcal
+        Target: ${modeBadge} · Base: ${todayBaseCalories}${exerciseSegment}${adjSegment} = ${todayKcalTarget} kcal
       </div>
+      ${rawBankNote}
+      ${floorNote}
+      ${capNote}
       ${bankNote}
       ${profileNote}
       <div class="hbar mt-2">
@@ -1147,9 +1287,26 @@ function setupCollapsibleHandlers() {
 // =========================
 
 /**
- * Render info box with explanations
+ * Render info box with explanations (mode-aware).
  */
 function renderInfoBox() {
+  const targetMode = state.goalSettings?.targetMode ?? 'manual';
+
+  if (targetMode === 'autoGoal') {
+    const softCap = BANKING_CONFIG.MAX_SCHEDULE_ADJ_SOFT ?? 150;
+    return `
+      <div class="mb-6 p-4 surface-2 rounded-lg border">
+        <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How Auto Goal Works</h3>
+        <div class="text-sm text-muted space-y-1">
+          <p><strong>Daily Target:</strong> Recalculated from your current weight, goal, and target date — adapts as your weight changes. The base calorie target never comes from a fixed 7-day window.</p>
+          <p><strong>Schedule Correction:</strong> If you've eaten over target this week, a small correction (max ${softCap} kcal/day) is spread across the remaining goal days — never concentrated into a single crash day.</p>
+          <p><strong>Training Days:</strong> Select your workout type above — this adds calories and scales electrolytes appropriately.</p>
+          <p><strong>7-Day Raw Balance:</strong> Shown as informational context only. In Auto Goal mode it does not directly set today's target.</p>
+        </div>
+      </div>
+    `;
+  }
+
   return `
     <div class="mb-6 p-4 surface-2 rounded-lg border">
       <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How This Works</h3>
@@ -1163,16 +1320,16 @@ function renderInfoBox() {
 }
 
 /**
- * Render banking panel showing rolling 7-day balance
+ * Render banking/adjustment panel showing 7-day balance context.
+ * Auto Goal mode: shows raw balance as informational + schedule adjustment.
+ * Manual mode: shows rolling bank balance as usual.
  */
 function renderBankingPanel(bankingData) {
-  const { bankBalance, pastDays, sumPast6Actual, sumPastTargets, windowBudget, todayBaseCalories, targetMode } = bankingData;
-  const budgetExplain = targetMode === 'autoGoal'
-    ? `${windowBudget} kcal (per-day auto-goal targets + training bumps).`
-    : `${windowBudget} kcal (${todayBaseCalories}/day × 7 + training bumps).`;
-  const tomorrowNote = targetMode === 'autoGoal'
-    ? 'Hit this target and tomorrow recalculates from Auto Goal mode.'
-    : `If you hit today's target, tomorrow's target resets to exactly ${todayBaseCalories} kcal (on a rest day).`;
+  const {
+    bankBalance, rawBankBalance, pastDays, sumPast6Actual, sumPastTargets,
+    windowBudget, todayBaseCalories, targetMode, bankMode, scheduleAdjustment,
+    targetFloorApplied, minDailyCalories, scheduleCapped, todayKcalTarget,
+  } = bankingData;
 
   const contributionRows = pastDays.map(d => `
     <tr${d.unknown ? ' class="opacity-60"' : ''}>
@@ -1185,19 +1342,99 @@ function renderBankingPanel(bankingData) {
     </tr>
   `).join('');
 
+  const pastDaysTable = `
+    <div id="recent-days-content" class="hidden">
+      <div class="overflow-x-auto mt-3">
+        <table class="w-full border rounded-lg">
+          <thead class="surface-2">
+            <tr>
+              <th class="px-3 py-2 text-left text-xs font-medium text-secondary uppercase">Day</th>
+              <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Actual</th>
+              <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Goal</th>
+              <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Over/Under</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${contributionRows}
+            <tr class="surface-2 border-t-2 border">
+              <td class="px-3 py-2 text-sm font-medium">Total (6 days)</td>
+              <td class="px-3 py-2 text-sm text-center font-bold">${sumPast6Actual}</td>
+              <td class="px-3 py-2 text-sm text-center font-bold">${sumPastTargets}</td>
+              <td class="px-3 py-2 text-sm text-center font-bold ${rawBankBalance > 0 ? 'text-positive' : rawBankBalance < 0 ? 'text-negative' : 'text-muted'}">
+                ${rawBankBalance > 0 ? '+' : ''}${rawBankBalance}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>`;
+
+  if (bankMode === 'autoGoalSchedule') {
+    const cumulativeDebt = Math.max(0, -rawBankBalance);
+    let statusText;
+    if (rawBankBalance < 0) {
+      statusText = `Over budget by ${cumulativeDebt} kcal this week.`;
+      if (scheduleAdjustment !== 0) {
+        statusText += ` Spreading correction over remaining goal window (${scheduleAdjustment} kcal/day today).`;
+      }
+    } else if (rawBankBalance > 0) {
+      statusText = `Under budget by ${rawBankBalance} kcal this week — no upward adjustment applied.`;
+    } else {
+      statusText = `On track this week — no adjustment needed.`;
+    }
+
+    return `
+      <div class="section-card p-4">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-responsive-xl font-bold text-secondary">📊 Auto Goal — 7-Day Context</h3>
+          <button id="recent-days-toggle" class="btn-subtle">
+            <i class="fas fa-chevron-down"></i>
+            <span class="toggle-text">Show Past 6 Days</span>
+          </button>
+        </div>
+
+        <div class="p-3 rounded-lg border surface-2 mb-3">
+          <div class="text-center">
+            <div class="text-xs text-muted mb-1">7-Day Raw Balance (informational)</div>
+            <div class="text-responsive-2xl font-bold ${rawBankBalance > 0 ? 'text-positive' : rawBankBalance < 0 ? 'text-negative' : 'text-muted'}">
+              ${rawBankBalance > 0 ? '+' : ''}${rawBankBalance} kcal
+            </div>
+            <p class="text-sm text-muted mt-1">${statusText}</p>
+          </div>
+        </div>
+
+        ${targetFloorApplied ? `
+          <div class="mb-3 p-3 surface-2 rounded-lg border text-sm text-warning">
+            ⚠ Target was floored at ${minDailyCalories} kcal. Goal date may need adjustment or the recent overage is large relative to remaining time.
+          </div>` : ''}
+
+        ${scheduleCapped ? `
+          <div class="mb-3 p-3 surface-2 rounded-lg border text-sm text-warning">
+            Schedule correction capped at ${scheduleAdjustment} kcal/day. Extending your goal date would allow a gentler adjustment.
+          </div>` : ''}
+
+        ${pastDaysTable}
+      </div>
+    `;
+  }
+
+  // Manual mode — rolling bank panel
   const bankExplanation = bankBalance > 0
     ? `You have ${bankBalance} kcal banked from under-eating — today's target is higher to use it.`
     : bankBalance < 0
     ? `You're ${Math.abs(bankBalance)} kcal over budget — today's target is lower to balance it out.`
     : "You're perfectly on track — no adjustment needed!";
 
+  const budgetExplain = `${windowBudget} kcal (${todayBaseCalories}/day × 7 + training bumps).`;
+  const tomorrowNote  = `If you hit today's target (${todayKcalTarget} kcal), tomorrow's target resets to ${todayBaseCalories} kcal (on a rest day).`;
+
   return `
     <div class="section-card p-4">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-responsive-xl font-bold text-secondary">🏦 Rolling 7-Day Balance</h3>
         <button id="recent-days-toggle" class="btn-subtle">
-            <i class="fas fa-chevron-down"></i>
-            <span class="toggle-text">Show Past 6 Days</span>
+          <i class="fas fa-chevron-down"></i>
+          <span class="toggle-text">Show Past 6 Days</span>
         </button>
       </div>
 
@@ -1210,36 +1447,17 @@ function renderBankingPanel(bankingData) {
         </div>
       </div>
 
-      <div id="recent-days-content" class="hidden">
-        <div class="overflow-x-auto">
-          <table class="w-full border rounded-lg">
-            <thead class="surface-2">
-              <tr>
-                <th class="px-3 py-2 text-left text-xs font-medium text-secondary uppercase">Day</th>
-                <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Actual</th>
-                <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Goal</th>
-                <th class="px-3 py-2 text-center text-xs font-medium text-secondary uppercase">Over/Under</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${contributionRows}
-              <tr class="surface-2 border-t-2 border">
-                <td class="px-3 py-2 text-sm font-medium">Total (6 days)</td>
-                <td class="px-3 py-2 text-sm text-center font-bold">${sumPast6Actual}</td>
-                <td class="px-3 py-2 text-sm text-center font-bold">${sumPastTargets}</td>
-                <td class="px-3 py-2 text-sm text-center font-bold ${bankBalance > 0 ? 'text-positive' : bankBalance < 0 ? 'text-negative' : 'text-muted'}">
-                  ${bankBalance > 0 ? '+' : ''}${bankBalance}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+      ${targetFloorApplied ? `
+        <div class="mt-3 p-3 surface-2 rounded-lg border text-sm text-warning">
+          ⚠ Target was floored at ${minDailyCalories} kcal. The rolling bank pulled today's budget below the minimum safe daily intake.
+        </div>` : ''}
 
-        <div class="mt-3 p-3 surface-2 rounded-lg text-xs text-muted space-y-1">
-          <p><strong>How it works:</strong> Your 7-day calorie budget is ${budgetExplain}</p>
-          <p>You've consumed ${sumPast6Actual} kcal over the last 6 days against a target of ${sumPastTargets} kcal.</p>
-          <p>${tomorrowNote}</p>
-        </div>
+      ${pastDaysTable}
+
+      <div class="mt-3 p-3 surface-2 rounded-lg text-xs text-muted space-y-1">
+        <p><strong>How it works:</strong> Your 7-day calorie budget is ${budgetExplain}</p>
+        <p>You've consumed ${sumPast6Actual} kcal over the last 6 days against a target of ${sumPastTargets} kcal.</p>
+        <p>${tomorrowNote}</p>
       </div>
     </div>
   `;

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -31,6 +31,9 @@ import { CONFIG } from '../config.js';
 import { renderAnalysisSection, initAnalysisEvents } from '../analysis/analysisUI.js';
 import { UL_TABLE } from '../targets/nutritionReferences.js';
 import { resolveDailyBaseTargets } from '../targets/dailyTargetResolver.js';
+import { runAnalysis } from '../analysis/engine.js';
+import { computeBMR, resolveCurrentWeightLb, latestWeightLbFromEntries } from '../targets/targetEngine.js';
+import { calcBankingCore } from './bankingEngine.js';
 
 // =========================
 // CONFIGURATION (Top of file for easy modification)
@@ -284,69 +287,38 @@ export function calculateBankingData(targetDateStr) {
     // The full 7-day window budget (for display and manual-mode calc).
     const windowBudget = sumPastBaseTargets + todayBaseCalories + sumPastTrainingBumps + todaysTrainingBump;
 
-    // rawBankBalance: cumulative credit (+) or debt (-) from the past 6 days.
-    // Positive = under-ate relative to targets. Negative = over-ate.
-    const rawBankBalance = Math.round(sumPastBaseTargets + sumPastTrainingBumps - sumPast6Actual);
-
     // Sum of all past day targets (for display in the table footer)
     const sumPastTargets = sumPastBaseTargets + sumPastTrainingBumps;
 
-    // ── Mode-specific target resolution ──────────────────────────────────────
+    // ── Effective calorie floor (BMR-based or 1000 kcal minimum) ─────────────
     const MIN_DAILY_CALORIES = BANKING_CONFIG.MIN_DAILY_CALORIES ?? 1000;
-    let bankMode, bankBalance, bankAdjustmentApplied, scheduleAdjustment, targetFloorApplied;
-    let scheduleCapped = false;
-    let todayKcalTarget;
-
-    if (targetMode === 'autoGoal') {
-      // AUTO GOAL: today's target = base (from goal engine) + exercise + soft schedule correction.
-      // The full rolling bank is NOT applied — that caused extreme negative targets when a few
-      // high-calorie days exhausted the 7-day window budget.
-      scheduleAdjustment = 0;
-
-      const cumulativeDebt = Math.max(0, -rawBankBalance); // how much over target this week
-
-      if (cumulativeDebt > 0) {
-        const goalTargetDate = state.goalSettings?.targetDate;
-        if (goalTargetDate) {
-          const targetMs   = new Date(`${goalTargetDate}T00:00:00`).getTime();
-          const todayMs    = new Date(`${targetDateStr}T00:00:00`).getTime();
-          const remainingDays = Math.round((targetMs - todayMs) / 86400000);
-
-          if (remainingDays > 1) {
-            const rawAdj   = -cumulativeDebt / remainingDays;
-            const SOFT_CAP = -(BANKING_CONFIG.MAX_SCHEDULE_ADJ_SOFT ?? 150);
-            const HARD_CAP = -(BANKING_CONFIG.MAX_SCHEDULE_ADJ_HARD ?? 250);
-            // Apply hard cap; flag if soft cap was also exceeded
-            scheduleAdjustment = Math.round(Math.max(HARD_CAP, rawAdj));
-            if (rawAdj < SOFT_CAP) scheduleCapped = true;
-          }
-        }
-      }
-
-      bankMode             = 'autoGoalSchedule';
-      bankAdjustmentApplied = scheduleAdjustment;
-      bankBalance          = rawBankBalance; // informational (not directly applied)
-
-      const rawTarget = todayBaseCalories + todaysTrainingBump + scheduleAdjustment;
-      todayKcalTarget = BankingHelpers.roundToNearest25(rawTarget);
-
-      targetFloorApplied = todayKcalTarget < MIN_DAILY_CALORIES;
-      if (targetFloorApplied) todayKcalTarget = MIN_DAILY_CALORIES;
-
-    } else {
-      // MANUAL: rolling bank logic — the window budget adjusts today's target up/down.
-      bankMode = 'manualRolling';
-      scheduleAdjustment = 0;
-
-      const rollingTarget = windowBudget - sumPast6Actual;
-      bankBalance          = Math.round(rollingTarget - todayBaseCalories - todaysTrainingBump);
-      bankAdjustmentApplied = bankBalance;
-
-      todayKcalTarget = BankingHelpers.roundToNearest25(rollingTarget);
-
-      targetFloorApplied = todayKcalTarget < MIN_DAILY_CALORIES;
-      if (targetFloorApplied) todayKcalTarget = MIN_DAILY_CALORIES;
+    let effectiveFloor = MIN_DAILY_CALORIES;
+    let floorSource = 'min_daily';
+    const _rawWtLb = latestWeightLbFromEntries(state.weightEntries);
+    const { weightLb: _wLb } = resolveCurrentWeightLb(state.userProfile ?? {}, state.analysisResults ?? null, _rawWtLb);
+    if (_wLb) {
+      const _bmrFloorValue = Math.max(MIN_DAILY_CALORIES, Math.round(computeBMR(state.userProfile ?? {}, _wLb).bmr * 0.85));
+      if (_bmrFloorValue > MIN_DAILY_CALORIES) { effectiveFloor = _bmrFloorValue; floorSource = 'bmr_floor'; }
     }
+
+    // ── Mode-specific target resolution (via pure calcBankingCore) ────────────
+    const coreResult = calcBankingCore({
+      todayBaseCalories,
+      todaysTrainingBump,
+      sumPastBaseTargets,
+      sumPastTrainingBumps,
+      sumPast6Actual,
+      windowBudget,
+      targetMode,
+      useRollingBanking: state.goalSettings?.useRollingBanking ?? true,
+      goalTargetDate: state.goalSettings?.targetDate ?? null,
+      targetDateStr,
+      effectiveFloor,
+    });
+    const {
+      bankMode, bankBalance, bankAdjustmentApplied, scheduleAdjustment,
+      rawBankBalance, todayKcalTarget, targetFloorApplied, scheduleCapped,
+    } = coreResult;
 
     // Macro split using today's final target.
     const scaledProteinG = proteinG;
@@ -417,6 +389,16 @@ export function calculateBankingData(targetDateStr) {
       displayFatG,
       displayCarbsG,
 
+      // Base macros (from todayBaseCalories, before exercise/bank/floor)
+      baseProteinG: displayProteinG,
+      baseFatG: displayFatG,
+      baseCarbsG: displayCarbsG,
+
+      // Final macros (from todayKcalTarget — carbs absorbs all adjustments)
+      finalProteinG: displayProteinG,
+      finalFatG: displayFatG,
+      finalCarbsG: carbsG,
+
       // Today's resolved base calorie target
       todayBaseCalories,
       resolvedTargetSource,
@@ -427,12 +409,14 @@ export function calculateBankingData(targetDateStr) {
 
       // Mode / adjustment metadata
       targetMode,
-      bankMode,            // 'manualRolling' | 'autoGoalSchedule'
+      bankMode,            // 'manualRolling' | 'autoGoalSchedule' | 'off'
       bankAdjustmentApplied,
       rawBankBalance,      // cumulative 6-day credit/debt (informational in autoGoal mode)
       scheduleAdjustment,  // auto goal only: spread overage over remaining days
-      targetFloorApplied,  // true when MIN_DAILY_CALORIES floor was applied
+      targetFloorApplied,  // true when effectiveFloor was applied
       minDailyCalories: MIN_DAILY_CALORIES,
+      effectiveFloor,      // actual floor used (BMR-based or MIN_DAILY_CALORIES)
+      floorSource,         // 'bmr_floor' | 'min_daily'
       scheduleCapped,      // true if soft cap (150 kcal/day) was hit
 
       // Config
@@ -457,6 +441,12 @@ export function calculateBankingData(targetDateStr) {
       displayProteinG: BANKING_CONFIG.PROTEIN_G,
       displayFatG: BANKING_CONFIG.FAT_FLOOR_G,
       displayCarbsG: 0,
+      baseProteinG: BANKING_CONFIG.PROTEIN_G,
+      baseFatG: BANKING_CONFIG.FAT_FLOOR_G,
+      baseCarbsG: 0,
+      finalProteinG: BANKING_CONFIG.PROTEIN_G,
+      finalFatG: BANKING_CONFIG.FAT_FLOOR_G,
+      finalCarbsG: 0,
       todayBaseCalories: BANKING_CONFIG.BASE_KCAL,
       resolvedTargetSource: 'manual',
       bankIncomplete: false,
@@ -468,6 +458,8 @@ export function calculateBankingData(targetDateStr) {
       scheduleAdjustment: 0,
       targetFloorApplied: false,
       minDailyCalories: BANKING_CONFIG.MIN_DAILY_CALORIES ?? 1000,
+      effectiveFloor: BANKING_CONFIG.MIN_DAILY_CALORIES ?? 1000,
+      floorSource: 'min_daily',
       scheduleCapped: false,
       config: { windowDays: BANKING_CONFIG.ROLLING_WINDOW_DAYS }
     };
@@ -690,6 +682,7 @@ export function activateTab(name) {
     if (name === 'nutrients') renderNutrientsOutput();
     else if (name === 'energy') renderEnergyOutput();
     else if (name === 'settings') populateSettingsForm();
+    else if (name === 'today') updateDashboard();
 
     debugLog('activate-tab', `Activated tab: ${name}`);
   } catch (error) {
@@ -1192,6 +1185,17 @@ function renderEnergyExerciseBlock(dateStr) {
 export function updateDashboard() {
   try {
     debugLog('update-start', 'Starting dashboard update');
+
+    // Populate analysis cache synchronously when data is available but Energy tab
+    // hasn't been visited yet.  runAnalysis() is pure CPU — no I/O or DOM.
+    if (!state.analysisResults && state.weightEntries?.size > 0 && state.dailyEntries?.size > 0) {
+      try {
+        state.analysisResults = runAnalysis(
+          state.weightEntries, state.dailyEntries,
+          state.userProfile ?? null, state.weightEntriesMulti ?? null
+        );
+      } catch (_) {}
+    }
 
     const { dashboard } = state.dom;
     if (!dashboard) throw new Error('Dashboard container not found');


### PR DESCRIPTION
In Auto Goal mode, the 7-day rolling bank could produce extremely low or
negative daily targets when a few high-calorie days exhausted the window
budget (e.g. 177 lb user targeting 170 lb seeing a negative calorie target).

Key changes:
- Auto Goal mode: today's target = base (from goal engine) + exercise +
  soft schedule correction (max 150 kcal/day, hard cap 250 kcal/day),
  spread over remaining goal days. Rolling bank is NOT applied directly.
- Manual mode: keeps rolling bank with a 1000 kcal/day minimum floor.
- Floor (BANKING_CONFIG.MIN_DAILY_CALORIES = 1000) applied after all
  adjustments; UI shows a warning when floored.
- Today tab shows "Over by X kcal" instead of a negative large number when
  calories eaten exceed the target.
- Formula line distinguishes Bank vs Schedule adjustment by mode.
- Raw 7-day balance shown as informational only in Auto Goal mode.
- Energy tab (Info Box, Banking Panel, Calc Details) shows mode-appropriate
  explanations — no more "rolling bank" language in Auto Goal mode.
- Nutrients tab now uses resolveDailyBaseTargets() in Auto Goal mode so
  micro-targets match Today tab and Charts.
- New test suite in banking.test.js covers schedule adjustment math, floor
  enforcement, mode isolation, and the 177→170 scenario.
- New tests in targetEngine.test.js cover the 177→170 scenario, goal-date
  sensitivity, and calorie floor invariants.
- All 468 tests pass; Next.js build passes.

https://claude.ai/code/session_01NtY4XBaefzoPtNcrYFQNBR