### PR TITLE
Fix quantity double-application in subtract food items

### DIFF
--- a/public/tools/CalorieTracker/package.json
+++ b/public/tools/CalorieTracker/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "serve": "vite --host 0.0.0.0 --port 3000",
-    "test": "node_modules/.bin/vitest run analysis/weightParser.test.js state/schema.test.js targets/targetEngine.test.js analysis/engine.test.js exercise/met.test.js ui/nutrientHelpers.test.js ui/banking.test.js"
+    "test": "node_modules/.bin/vitest run analysis/weightParser.test.js state/schema.test.js targets/targetEngine.test.js analysis/engine.test.js exercise/met.test.js ui/nutrientHelpers.test.js ui/banking.test.js staging/parser.test.js"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/public/tools/CalorieTracker/staging/parser.js
+++ b/public/tools/CalorieTracker/staging/parser.js
@@ -149,8 +149,10 @@ export async function subtractStagedNutrientsFromDailyLog() {
   // Subtract staged values, ensuring totals don't go below zero.
   allNutrients.forEach(n => todayEntry[n] = Math.max(0, (parseFloat(todayEntry[n]) || 0) - (qty * (staged[n] || 0))));
 
-  // Create a food item record for this subtraction with negative values.
-  const negativeStaged = Object.fromEntries(Object.entries(staged).map(([k, v]) => [k, -(qty * (v || 0))]));
+  // Create a food item record for this subtraction with negative per-unit values.
+  // qty must NOT be pre-applied here — every downstream reader (display, recalc,
+  // remove, quantity edit) multiplies quantity × item[n] itself.
+  const negativeStaged = Object.fromEntries(Object.entries(staged).map(([k, v]) => [k, -(v || 0)]));
   const foodName = document.getElementById('food-item-input')?.value.trim() || '(Staged Subtraction)';
   const foodItem = { id: crypto.randomUUID(), name: `${foodName} (subtracted)`, quantity: qty, timestamp: new Date().toISOString(), ...negativeStaged };
   state.dailyFoodItems.push(foodItem);

--- a/public/tools/CalorieTracker/staging/parser.test.js
+++ b/public/tools/CalorieTracker/staging/parser.test.js
@@ -1,0 +1,116 @@
+/**
+ * @file staging/parser.test.js
+ * @description Pure-function tests for the food item construction logic in parser.js.
+ *
+ * These tests validate the invariant that food items store per-unit nutrient values
+ * and that downstream consumers (display, recalc, remove, quantity edit) apply
+ * quantity exactly once via `qty * item[nutrient]`.
+ *
+ * No DOM, no Firebase, no state mutations.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mirror the pure construction formulas from parser.js so the test
+// suite remains independent of DOM-coupled imports.
+// ---------------------------------------------------------------------------
+
+/** Mirrors the add food item construction in addStagedNutrientsToDailyLog. */
+function buildAddItem(staged, qty) {
+  const negativeStaged = Object.fromEntries(
+    Object.entries(staged).map(([k, v]) => [k, v || 0])
+  );
+  return { quantity: qty, ...negativeStaged };
+}
+
+/** Mirrors the subtract food item construction in subtractStagedNutrientsFromDailyLog (fixed). */
+function buildSubtractItem(staged, qty) {
+  const negativeStaged = Object.fromEntries(
+    Object.entries(staged).map(([k, v]) => [k, -(v || 0)])
+  );
+  return { quantity: qty, ...negativeStaged };
+}
+
+/** Mirrors the effective-total calculation used by renderFoodItemsContent, updateItemQuantity, and removeFoodItem. */
+function effectiveTotal(item, nutrient = 'calories') {
+  const q = parseFloat(item.quantity ?? 0) || 0;
+  return q * (parseFloat(item[nutrient]) || 0);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('add food item construction', () => {
+  it('stores per-unit calories; effective total = qty × unitCalories', () => {
+    const item = buildAddItem({ calories: 100, protein: 10, carbs: 20, fat: 5 }, 2);
+    expect(item.quantity).toBe(2);
+    expect(item.calories).toBe(100);       // per-unit, not pre-multiplied
+    expect(effectiveTotal(item)).toBe(200); // 2 × 100
+  });
+
+  it('quantity 1 gives same effective total as stored value', () => {
+    const item = buildAddItem({ calories: 350 }, 1);
+    expect(effectiveTotal(item)).toBe(350);
+  });
+});
+
+describe('subtract food item construction', () => {
+  it('stores negative per-unit calories; effective total = qty × (−unitCalories)', () => {
+    const item = buildSubtractItem({ calories: 100, protein: 10, carbs: 20, fat: 5 }, 2);
+    expect(item.quantity).toBe(2);
+    expect(item.calories).toBe(-100);       // negative per-unit, NOT qty-pre-applied
+    expect(effectiveTotal(item)).toBe(-200); // 2 × −100
+  });
+
+  it('quantity 1 gives effective total equal to the negative staged value', () => {
+    const item = buildSubtractItem({ calories: 100 }, 1);
+    expect(effectiveTotal(item)).toBe(-100);
+  });
+
+  it('effective total is NOT −400 when qty=2 and staged calories=100', () => {
+    const item = buildSubtractItem({ calories: 100 }, 2);
+    expect(effectiveTotal(item)).not.toBe(-400); // the old (buggy) result
+    expect(effectiveTotal(item)).toBe(-200);
+  });
+});
+
+describe('remove subtraction item restores correct day total', () => {
+  it('removing a qty=2 subtract-100-cal item restores +200, not +400', () => {
+    const item = buildSubtractItem({ calories: 100 }, 2);
+    // removeFoodItem computes: itemValue = qty * item[n], then total -= itemValue.
+    // For a subtraction item the itemValue is: 2 * -100 = -200.
+    // Removing it means the daily total increases by 200.
+    const itemValue = parseFloat(item.quantity) * parseFloat(item.calories);
+    expect(itemValue).toBe(-200);
+    expect(-itemValue).toBe(200); // the net effect on the day total
+  });
+});
+
+describe('quantity editing on subtraction item', () => {
+  it('changing qty from 2 to 3 recalculates to −300 calories', () => {
+    const item = buildSubtractItem({ calories: 100 }, 2);
+    item.quantity = 3;
+    expect(effectiveTotal(item)).toBe(-300); // 3 × −100
+  });
+
+  it('changing qty from 2 to 1 recalculates to −100 calories', () => {
+    const item = buildSubtractItem({ calories: 100 }, 2);
+    item.quantity = 1;
+    expect(effectiveTotal(item)).toBe(-100); // 1 × −100
+  });
+});
+
+describe('add and subtract are symmetric at same qty', () => {
+  it('add and subtract of same nutrients at same qty cancel to zero effective total', () => {
+    const staged = { calories: 250, protein: 30, carbs: 40, fat: 8 };
+    const qty = 3;
+    const addItem = buildAddItem(staged, qty);
+    const subItem = buildSubtractItem(staged, qty);
+
+    for (const n of ['calories', 'protein', 'carbs', 'fat']) {
+      expect(effectiveTotal(addItem, n) + effectiveTotal(subItem, n)).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a critical bug in `subtractStagedNutrientsFromDailyLog` where quantity was being applied twice to nutrient values when creating subtraction food items. This caused incorrect effective totals when removing or editing quantities on subtracted items.

## Key Changes
- **parser.js**: Changed `negativeStaged` construction to store negative *per-unit* values instead of pre-multiplying by quantity. The quantity is now applied exactly once by downstream consumers (display, recalc, remove, quantity edit) via `qty × item[nutrient]`.
- **parser.test.js** (new): Added comprehensive pure-function test suite validating the invariant that food items store per-unit nutrient values and that quantity is applied exactly once. Tests cover:
  - Add/subtract item construction
  - Effective total calculation
  - Quantity editing on subtraction items
  - Removal of subtraction items
  - Symmetry between add and subtract operations
- **package.json**: Registered new test file in the test suite

## Implementation Details
The fix ensures that both `addStagedNutrientsToDailyLog` and `subtractStagedNutrientsFromDailyLog` follow the same pattern: store per-unit nutrient values in the food item record, and let all downstream readers (renderFoodItemsContent, updateItemQuantity, removeFoodItem) compute the effective total as `quantity × item[nutrient]`. This eliminates the double-application bug that occurred when quantity was pre-applied during item construction.

https://claude.ai/code/session_01R2Y1eUvgqhfFfdkkDDTsfn