### PR TITLE
TDEE source prioritization & exercise add-mode propagation

### DIFF
--- a/public/tools/CalorieTracker/constants.js
+++ b/public/tools/CalorieTracker/constants.js
@@ -38,6 +38,10 @@ export const BANKING_CONFIG = {
   // Hard cap: absolute maximum correction — goal date may need adjustment
   MAX_SCHEDULE_ADJ_HARD: 250,
 
+  // Manual rolling bank adjustment caps (kcal/day)
+  MANUAL_BANK_CAP_DOWN: -400,  // max downward adjustment per day in manual rolling mode
+  MANUAL_BANK_CAP_UP: 600,     // max upward adjustment per day in manual rolling mode
+
   // Safe daily calorie floor — NIDDK Body Weight Planner public lower bound
   MIN_DAILY_CALORIES: 1000,
 };

--- a/public/tools/CalorieTracker/targets/dailyTargetResolver.js
+++ b/public/tools/CalorieTracker/targets/dailyTargetResolver.js
@@ -1,12 +1,102 @@
 /**
  * @file targets/dailyTargetResolver.js
- * Dedicated entry-point for per-day base target resolution.
+ * Centralized per-day target resolution.
  *
- * Re-exports `resolveDailyBaseTargets` from targetEngine.js so callers can
- * import from this purpose-named module rather than the full engine file.
+ * resolveDailyBaseTargets  — backward-compat resolver used by the banking loop.
+ * resolveDailyPlanningTargets — richer resolver that exposes the full TDEE
+ *   breakdown, exerciseAddMode, weight source, and goal metadata.  Use this
+ *   when any tab needs to explain where today's target came from.
  *
  * Usage:
- *   import { resolveDailyBaseTargets } from '../targets/dailyTargetResolver.js';
+ *   import { resolveDailyBaseTargets }    from '../targets/dailyTargetResolver.js';
+ *   import { resolveDailyPlanningTargets } from '../targets/dailyTargetResolver.js';
  */
 
 export { resolveDailyBaseTargets } from './targetEngine.js';
+
+import { resolveDailyBaseTargets } from './targetEngine.js';
+
+/**
+ * Resolve today's per-day planning targets with full metadata.
+ *
+ * In manual mode most TDEE fields are null (the engine is not run).
+ * In autoGoal mode all fields are populated from generateTargets().
+ *
+ * @param {string} dateStr   - 'YYYY-MM-DD'
+ * @param {object} stateLike - { baselineTargets, goalSettings, userProfile,
+ *                               analysisResults, weightEntries }
+ * @returns {{
+ *   mode:                  'manual'|'autoGoal'|'manual_fallback',
+ *   targets:               object,
+ *   baseCalories:          number,
+ *   calorieFloor:          number,
+ *   exerciseAddMode:       'add'|'skip',
+ *   planningTdee:          number|null,
+ *   planningTdeeSource:    string|null,
+ *   planningTdeeSourceLabel: string|null,
+ *   restDayTdee:           number|null,
+ *   observedTdee:          number|null,
+ *   tdeeCurrent:           number|null,
+ *   tdeeCurrentRejected:   boolean,
+ *   bmr:                   number|null,
+ *   currentWeightLb:       number|null,
+ *   weightSource:          string|null,
+ *   weightSourceLabel:     string,
+ *   goalDeficit:           number|null,
+ *   daysLeft:              number|null,
+ *   targetWeightDeltaLb:   number|null,
+ *   warnings:              string[],
+ * }}
+ */
+export function resolveDailyPlanningTargets(dateStr, stateLike) {
+  const r = resolveDailyBaseTargets(dateStr, stateLike);
+  const m = r.meta;
+
+  if (!m) {
+    return {
+      mode:                  r.source,
+      targets:               r.targets,
+      baseCalories:          parseFloat(r.targets?.calories) || 0,
+      calorieFloor:          r.calorieFloor,
+      exerciseAddMode:       r.exerciseAddMode ?? 'add',
+      planningTdee:          null,
+      planningTdeeSource:    null,
+      planningTdeeSourceLabel: null,
+      restDayTdee:           null,
+      observedTdee:          null,
+      tdeeCurrent:           null,
+      tdeeCurrentRejected:   false,
+      bmr:                   null,
+      currentWeightLb:       null,
+      weightSource:          null,
+      weightSourceLabel:     'Not available',
+      goalDeficit:           null,
+      daysLeft:              null,
+      targetWeightDeltaLb:   null,
+      warnings:              r.warnings,
+    };
+  }
+
+  return {
+    mode:                  r.source,
+    targets:               r.targets,
+    baseCalories:          parseFloat(r.targets?.calories) || 0,
+    calorieFloor:          r.calorieFloor,
+    exerciseAddMode:       r.exerciseAddMode ?? 'add',
+    planningTdee:          m.tdeeValue          ?? null,
+    planningTdeeSource:    m.tdeeSource          ?? null,
+    planningTdeeSourceLabel: m.tdeeSourceLabel   ?? null,
+    restDayTdee:           m.restDayTdee         ?? null,
+    observedTdee:          m.observedTdee        ?? null,
+    tdeeCurrent:           m.tdeeCurrent         ?? null,
+    tdeeCurrentRejected:   m.tdeeCurrentRejected ?? false,
+    bmr:                   m.bmrValue            ?? null,
+    currentWeightLb:       m.weightLb            ?? null,
+    weightSource:          m.weightSource        ?? null,
+    weightSourceLabel:     m.weightLabel         ?? 'Not available',
+    goalDeficit:           m.goalDeficit         ?? null,
+    daysLeft:              m.daysLeft            ?? null,
+    targetWeightDeltaLb:   m.targetWeightDeltaLb ?? null,
+    warnings:              r.warnings,
+  };
+}

--- a/public/tools/CalorieTracker/targets/targetEngine.js
+++ b/public/tools/CalorieTracker/targets/targetEngine.js
@@ -184,33 +184,104 @@ export function computeBMR(profile, weightLb) {
 // ---------------------------------------------------------------------------
 
 /**
- * Compute TDEE using empirical analysis data when sufficient, otherwise BMR × PAL.
+ * Compute planning TDEE using the most stable available empirical estimate.
+ *
+ * Priority order:
+ *   1. Rest-day TDEE (modelPredictedRestDayTdee / tdee_rest_day) — best for daily planning
+ *      because exercise is added separately by the banking layer.
+ *   2. Observed TDEE (trimmed-mean block estimates) — includes activity; not preferred
+ *      when rest-day is available, but better than a potentially noisy recent window.
+ *   3. tdee_current — only used when it is above the sedentary floor
+ *      (max(bmr × 1.2, fittedBmr × 1.2)). If below the floor, it is rejected as a
+ *      recent-low and the next available estimate is tried.
+ *   4. Formula BMR × PAL — fallback when no empirical data is available or valid.
  *
  * @param {{ bmr: number, methodLabel: string }} bmrResult
  * @param {object}      profile
  * @param {object|null} analysisResults
- * @returns {{ tdee: number, source: string, sourceLabel: string, pal: number|null }}
+ * @returns {{ tdee: number, source: string, sourceLabel: string, pal: number|null,
+ *             tdeeCurrent: number|null, tdeeCurrentRejected: boolean,
+ *             restDayTdee: number|null, observedTdee: number|null }}
  */
 export function computeTDEE(bmrResult, profile, analysisResults) {
-  const empirical = analysisResults?.bmrModel?.tdee_current;
-  if (empirical && !analysisResults?.bmrModel?.error && empirical > 800) {
-    return {
-      tdee: roundInt(empirical),
-      source: 'empirical',
-      sourceLabel: 'Measured from your weight and calorie history',
-      pal: null,
-    };
+  const bmrModel = analysisResults?.bmrModel;
+
+  if (bmrModel && !bmrModel.error) {
+    // Sedentary floor: tdee_current values below this are suspect
+    const fittedBmr = bmrModel.fittedBmr ?? bmrModel.bmr_current ?? null;
+    const sedentaryFloor = Math.max(
+      bmrResult.bmr * 1.2,
+      fittedBmr ? fittedBmr * 1.2 : 0
+    );
+
+    const tdeeCurrent  = bmrModel.tdee_current  ? roundInt(bmrModel.tdee_current)  : null;
+    const restDayTdee  = bmrModel.modelPredictedRestDayTdee ?? bmrModel.tdee_rest_day ?? null;
+    const observedTdee = bmrModel.observedTdee ?? null;
+
+    const tdeeCurrentRejected = !!(
+      tdeeCurrent && tdeeCurrent < sedentaryFloor
+    );
+    const rejectedNote = tdeeCurrentRejected
+      ? ` (recent TDEE ${tdeeCurrent} kcal rejected — below sedentary floor ${Math.round(sedentaryFloor)} kcal)`
+      : '';
+
+    // 1. Rest-day TDEE (exercise added separately by banking layer)
+    if (restDayTdee && restDayTdee > 800) {
+      return {
+        tdee: roundInt(restDayTdee),
+        source: 'empirical_rest_day',
+        sourceLabel: `Rest-day TDEE from fitted model${rejectedNote} — exercise calories added on top`,
+        pal: null,
+        tdeeCurrent,
+        tdeeCurrentRejected,
+        restDayTdee: roundInt(restDayTdee),
+        observedTdee: observedTdee ? roundInt(observedTdee) : null,
+      };
+    }
+
+    // 2. Observed TDEE (long-window trimmed-mean block estimate)
+    if (observedTdee && observedTdee > 800) {
+      return {
+        tdee: roundInt(observedTdee),
+        source: 'empirical_observed',
+        sourceLabel: 'Observed TDEE (trimmed-mean block estimates) — includes historical activity',
+        pal: null,
+        tdeeCurrent,
+        tdeeCurrentRejected,
+        restDayTdee: null,
+        observedTdee: roundInt(observedTdee),
+      };
+    }
+
+    // 3. tdee_current — only if above sedentary floor
+    if (tdeeCurrent && tdeeCurrent > 800 && !tdeeCurrentRejected) {
+      return {
+        tdee: tdeeCurrent,
+        source: 'empirical',
+        sourceLabel: 'Recent TDEE from weight and calorie history',
+        pal: null,
+        tdeeCurrent,
+        tdeeCurrentRejected: false,
+        restDayTdee: null,
+        observedTdee: null,
+      };
+    }
   }
 
+  // 4. Formula fallback
   const activityKey = profile.baselineActivityLevel;
   const pal = PAL_MULTIPLIERS[activityKey] ?? PAL_MULTIPLIERS.moderate;
   const label = ACTIVITY_LABELS[activityKey] ?? 'Moderate activity (assumed)';
-
   return {
     tdee: roundInt(bmrResult.bmr * pal),
     source: 'formula',
     sourceLabel: `${bmrResult.methodLabel} × ${pal} PAL (${label})`,
     pal,
+    tdeeCurrent: analysisResults?.bmrModel?.tdee_current
+      ? roundInt(analysisResults.bmrModel.tdee_current) : null,
+    tdeeCurrentRejected: false,
+    restDayTdee: null,
+    observedTdee: null,
   };
 }
 
@@ -611,8 +682,11 @@ export function generateTargets(profile, goals, analysisResults = null, rawLates
     currentWeight: `${round1(weightLb)} lb — ${weightLabel}`,
     bmr: `${bmrResult.bmr} kcal/day via ${bmrResult.methodLabel}`,
     tdee: `${tdeeResult.tdee} kcal/day — ${tdeeResult.sourceLabel}`,
-    activityIgnored: tdeeResult.source === 'empirical'
-      ? `Baseline activity level setting is ignored — TDEE is measured directly from your weight and calorie history (${tdeeResult.tdee} kcal/day)`
+    tdeeCurrentRejected: tdeeResult.tdeeCurrentRejected
+      ? `Recent TDEE (${tdeeResult.tdeeCurrent} kcal) is below the sedentary floor and was not used for planning. Planning TDEE uses rest-day estimate instead.`
+      : null,
+    activityIgnored: tdeeResult.source !== 'formula'
+      ? `Baseline activity level is ignored — planning TDEE is derived from your weight and calorie history.`
       : null,
     calories: `${calResult.calories} kcal/day — ${calResult.deficitNote}`,
     deficitClamped: (goalType === 'fatLoss' && calResult.deficitClampReason !== 'none')

--- a/public/tools/CalorieTracker/targets/targetEngine.js
+++ b/public/tools/CalorieTracker/targets/targetEngine.js
@@ -231,6 +231,7 @@ export function computeTDEE(bmrResult, profile, analysisResults) {
         tdee: roundInt(restDayTdee),
         source: 'empirical_rest_day',
         sourceLabel: `Rest-day TDEE from fitted model${rejectedNote} — exercise calories added on top`,
+        exerciseAddMode: 'add',
         pal: null,
         tdeeCurrent,
         tdeeCurrentRejected,
@@ -240,11 +241,13 @@ export function computeTDEE(bmrResult, profile, analysisResults) {
     }
 
     // 2. Observed TDEE (long-window trimmed-mean block estimate)
+    // Historical activity already baked in — adding exercise bumps would double-count.
     if (observedTdee && observedTdee > 800) {
       return {
         tdee: roundInt(observedTdee),
         source: 'empirical_observed',
         sourceLabel: 'Observed TDEE (trimmed-mean block estimates) — includes historical activity',
+        exerciseAddMode: 'skip',
         pal: null,
         tdeeCurrent,
         tdeeCurrentRejected,
@@ -254,11 +257,13 @@ export function computeTDEE(bmrResult, profile, analysisResults) {
     }
 
     // 3. tdee_current — only if above sedentary floor
+    // Recent-window TDEE includes user's typical activity level; exercise bumps would double-count.
     if (tdeeCurrent && tdeeCurrent > 800 && !tdeeCurrentRejected) {
       return {
         tdee: tdeeCurrent,
         source: 'empirical',
-        sourceLabel: 'Recent TDEE from weight and calorie history',
+        sourceLabel: 'Recent TDEE from weight and calorie history — includes typical activity',
+        exerciseAddMode: 'skip',
         pal: null,
         tdeeCurrent,
         tdeeCurrentRejected: false,
@@ -268,7 +273,7 @@ export function computeTDEE(bmrResult, profile, analysisResults) {
     }
   }
 
-  // 4. Formula fallback
+  // 4. Formula fallback — PAL is a rough multiplier; specific sessions should be added
   const activityKey = profile.baselineActivityLevel;
   const pal = PAL_MULTIPLIERS[activityKey] ?? PAL_MULTIPLIERS.moderate;
   const label = ACTIVITY_LABELS[activityKey] ?? 'Moderate activity (assumed)';
@@ -276,6 +281,7 @@ export function computeTDEE(bmrResult, profile, analysisResults) {
     tdee: roundInt(bmrResult.bmr * pal),
     source: 'formula',
     sourceLabel: `${bmrResult.methodLabel} × ${pal} PAL (${label})`,
+    exerciseAddMode: 'add',
     pal,
     tdeeCurrent: analysisResults?.bmrModel?.tdee_current
       ? roundInt(analysisResults.bmrModel.tdee_current) : null,
@@ -713,11 +719,22 @@ export function generateTargets(profile, goals, analysisResults = null, rawLates
     meta: {
       weightLb: round1(weightLb),
       weightSource,
+      weightLabel,
       bmrValue: bmrResult.bmr,
       bmrMethod: bmrResult.method,
+      bmrMethodLabel: bmrResult.methodLabel,
       tdeeValue: tdeeResult.tdee,
       tdeeSource: tdeeResult.source,
+      tdeeSourceLabel: tdeeResult.sourceLabel,
+      exerciseAddMode: tdeeResult.exerciseAddMode ?? 'add',
+      restDayTdee: tdeeResult.restDayTdee ?? null,
+      observedTdee: tdeeResult.observedTdee ?? null,
+      tdeeCurrent: tdeeResult.tdeeCurrent ?? null,
+      tdeeCurrentRejected: tdeeResult.tdeeCurrentRejected ?? false,
       goalType,
+      goalDeficit: calResult.deficit,
+      daysLeft: calResult.daysLeft,
+      targetWeightDeltaLb: calResult.targetWeightDeltaLb,
       calorieFloor: calResult.calorieFloor,
     },
   };
@@ -804,6 +821,8 @@ export function resolveDailyBaseTargets(dateStr, stateLike) {
       source: 'manual',
       warnings: [],
       calorieFloor: 1000,
+      exerciseAddMode: 'add',
+      meta: null,
     };
   }
 
@@ -824,6 +843,8 @@ export function resolveDailyBaseTargets(dateStr, stateLike) {
       source: 'manual_fallback',
       warnings: [`Auto-goal targets unavailable (${reason}); falling back to manual baseline.`],
       calorieFloor: 1000,
+      exerciseAddMode: 'add',
+      meta: null,
     };
   }
 
@@ -833,6 +854,8 @@ export function resolveDailyBaseTargets(dateStr, stateLike) {
     source: 'autoGoal',
     warnings: result.warnings,
     calorieFloor: result.meta?.calorieFloor ?? 1000,
+    exerciseAddMode: result.meta?.exerciseAddMode ?? 'add',
+    meta: result.meta ?? null,
   };
 }
 

--- a/public/tools/CalorieTracker/targets/targetEngine.test.js
+++ b/public/tools/CalorieTracker/targets/targetEngine.test.js
@@ -243,6 +243,144 @@ describe('computeTDEE', () => {
     const veryActive = computeTDEE(bmrResult, makeProfile({ baselineActivityLevel: 'very_active' }), null);
     expect(sedentary.tdee).toBeLessThan(veryActive.tdee);
   });
+
+  it('prefers rest-day TDEE over tdee_current when both are available', () => {
+    const analysis = makeAnalysis({
+      bmrModel: {
+        tdee_current: 2500,
+        tdee_rest_day: 2100,
+        modelPredictedRestDayTdee: 2100,
+        fittedBmr: 1800,
+        error: null,
+      },
+    });
+    const { tdee, source } = computeTDEE(bmrResult, makeProfile(), analysis);
+    expect(tdee).toBe(2100);
+    expect(source).toBe('empirical_rest_day');
+  });
+
+  it('rejects tdee_current below sedentary floor and uses rest-day TDEE', () => {
+    // bmrResult.bmr = 1800; sedentaryFloor = 1800 * 1.2 = 2160; tdeeCurrent = 1900 < 2160
+    const analysis = makeAnalysis({
+      bmrModel: {
+        tdee_current: 1900,
+        tdee_rest_day: 2100,
+        modelPredictedRestDayTdee: 2100,
+        fittedBmr: 1800,
+        error: null,
+      },
+    });
+    const { tdee, source, tdeeCurrentRejected } = computeTDEE(bmrResult, makeProfile(), analysis);
+    expect(tdeeCurrentRejected).toBe(true);
+    expect(tdee).toBe(2100);
+    expect(source).toBe('empirical_rest_day');
+  });
+
+  it('uses tdee_current when it is above sedentary floor and no rest-day available', () => {
+    const analysis = makeAnalysis({ bmrModel: { tdee_current: 2500, error: null } });
+    // sedentaryFloor = 1800 * 1.2 = 2160; 2500 > 2160 → not rejected
+    const { tdee, source, tdeeCurrentRejected } = computeTDEE(bmrResult, makeProfile(), analysis);
+    expect(tdeeCurrentRejected).toBe(false);
+    expect(tdee).toBe(2500);
+    expect(source).toBe('empirical');
+  });
+
+  it('falls back to formula when tdee_current is below floor and no rest-day exists', () => {
+    const analysis = makeAnalysis({
+      bmrModel: { tdee_current: 1900, error: null }, // no rest-day
+    });
+    // sedentaryFloor = 2160; 1900 < 2160 → rejected; no rest-day or observed → formula
+    const { source } = computeTDEE(bmrResult, makeProfile({ baselineActivityLevel: 'moderate' }), analysis);
+    expect(source).toBe('formula');
+  });
+
+  it('uses observedTdee when rest-day is unavailable but observed is above floor', () => {
+    const analysis = makeAnalysis({
+      bmrModel: {
+        tdee_current: 1900, // below floor → rejected
+        observedTdee: 2300,
+        error: null,
+      },
+    });
+    const { tdee, source } = computeTDEE(bmrResult, makeProfile(), analysis);
+    expect(tdee).toBe(2300);
+    expect(source).toBe('empirical_observed');
+  });
+});
+
+// ── 176.1 → 170 lb regression scenario ──────────────────────────────────────
+
+describe('176.1 → 170 lb by 2026-07-31 planning target (regression)', () => {
+  const analysis176 = {
+    summary: { currentWeight: 176.1 },
+    bmrModel: {
+      tdee_current: 1804,          // recent low estimate — below sedentary floor
+      tdee_rest_day: 2094,
+      modelPredictedRestDayTdee: 2094,
+      fittedBmr: 1746,
+      observedTdee: 2213,
+      error: null,
+    },
+  };
+
+  it('computeTDEE rejects tdee_current=1804 (below floor) and uses rest-day 2094', () => {
+    const bmr = computeBMR(makeProfile({ sex: 'male', age: 35, heightValue: 70 }), 176.1);
+    const { tdee, source, tdeeCurrentRejected } = computeTDEE(bmr, makeProfile(), analysis176);
+    expect(tdeeCurrentRejected).toBe(true);
+    expect(source).toBe('empirical_rest_day');
+    expect(tdee).toBe(2094);
+  });
+
+  it('generateTargets produces base ~1800 kcal (not 1516) when rest-day TDEE is 2094', () => {
+    const profile = makeProfile({ sex: 'male', age: 35, heightValue: 70, heightUnit: 'in' });
+    const goals = makeGoals({
+      goalType: 'fatLoss',
+      targetWeightLb: 170,
+      targetDate: '2026-07-31',
+    });
+    const { targets, meta } = generateTargets(profile, goals, analysis176, null, '2026-05-19');
+    expect(meta.tdeeValue).toBe(2094);
+    // Deficit for 6.1 lb in 73 days ≈ 292 kcal; target ≈ 2094 - 292 = 1802
+    expect(targets.calories).toBeGreaterThan(1700);
+    expect(targets.calories).toBeLessThan(1900);
+    expect(targets.calories).not.toBe(1516); // old broken value
+  });
+
+  it('moving target date later increases calorie target', () => {
+    const profile = makeProfile({ sex: 'male', age: 35, heightValue: 70, heightUnit: 'in' });
+    const goalsNear = makeGoals({ goalType: 'fatLoss', targetWeightLb: 170, targetDate: '2026-07-31' });
+    const goalsFar  = makeGoals({ goalType: 'fatLoss', targetWeightLb: 170, targetDate: '2027-01-31' });
+    const { targets: near } = generateTargets(profile, goalsNear, analysis176, null, '2026-05-19');
+    const { targets: far  } = generateTargets(profile, goalsFar,  analysis176, null, '2026-05-19');
+    expect(far.calories).toBeGreaterThan(near.calories);
+  });
+
+  it('moving target date earlier decreases calorie target', () => {
+    const profile = makeProfile({ sex: 'male', age: 35, heightValue: 70, heightUnit: 'in' });
+    const goalsNear = makeGoals({ goalType: 'fatLoss', targetWeightLb: 170, targetDate: '2026-06-30' });
+    const goalsFar  = makeGoals({ goalType: 'fatLoss', targetWeightLb: 170, targetDate: '2026-07-31' });
+    const { targets: near } = generateTargets(profile, goalsNear, analysis176, null, '2026-05-19');
+    const { targets: far  } = generateTargets(profile, goalsFar,  analysis176, null, '2026-05-19');
+    expect(near.calories).toBeLessThanOrEqual(far.calories);
+  });
+
+  it('target weight >= current weight falls back to default 400 kcal deficit', () => {
+    const profile = makeProfile({ sex: 'male', age: 35, heightValue: 70, heightUnit: 'in' });
+    // target weight above current weight: no time-based deficit
+    const goals = makeGoals({ goalType: 'fatLoss', targetWeightLb: 180, targetDate: '2026-07-31' });
+    const { targets } = generateTargets(profile, goals, analysis176, null, '2026-05-19');
+    // Should use default 400 deficit: 2094 - 400 = 1694
+    expect(targets.calories).toBeGreaterThan(1600);
+    expect(targets.calories).toBeLessThan(1800);
+  });
+
+  it('final target never below minDailyCalories floor', () => {
+    // Artificially extreme scenario: extremely aggressive date
+    const profile = makeProfile({ sex: 'male', age: 35, heightValue: 70, heightUnit: 'in' });
+    const goals = makeGoals({ goalType: 'fatLoss', targetWeightLb: 130, targetDate: '2026-06-01' });
+    const { targets } = generateTargets(profile, goals, analysis176, null, '2026-05-19');
+    expect(targets.calories).toBeGreaterThanOrEqual(1000);
+  });
 });
 
 // ── computeCalorieTarget ──────────────────────────────────────────────────────

--- a/public/tools/CalorieTracker/targets/targetEngine.test.js
+++ b/public/tools/CalorieTracker/targets/targetEngine.test.js
@@ -1568,3 +1568,131 @@ describe('Auto Goal calorie floor', () => {
     }
   });
 });
+
+// ── computeTDEE — exerciseAddMode ────────────────────────────────────────────
+
+describe('computeTDEE — exerciseAddMode', () => {
+  const bmrResult = { bmr: 1800, methodLabel: 'Mifflin-St Jeor RMR' };
+
+  it('formula source → exerciseAddMode is add', () => {
+    const { exerciseAddMode, source } = computeTDEE(bmrResult, makeProfile(), null);
+    expect(source).toBe('formula');
+    expect(exerciseAddMode).toBe('add');
+  });
+
+  it('empirical_rest_day source → exerciseAddMode is add', () => {
+    const analysis = makeAnalysis({
+      bmrModel: {
+        tdee_current: 1900, // below floor → rejected
+        tdee_rest_day: 2100,
+        modelPredictedRestDayTdee: 2100,
+        fittedBmr: 1800,
+        error: null,
+      },
+    });
+    const { exerciseAddMode, source } = computeTDEE(bmrResult, makeProfile(), analysis);
+    expect(source).toBe('empirical_rest_day');
+    expect(exerciseAddMode).toBe('add');
+  });
+
+  it('empirical source (tdee_current above floor, no rest-day) → exerciseAddMode is skip', () => {
+    const analysis = makeAnalysis({ bmrModel: { tdee_current: 2500, error: null } });
+    // sedentaryFloor = 1800 * 1.2 = 2160; 2500 > 2160 → uses empirical
+    const { exerciseAddMode, source } = computeTDEE(bmrResult, makeProfile(), analysis);
+    expect(source).toBe('empirical');
+    expect(exerciseAddMode).toBe('skip');
+  });
+
+  it('empirical_observed source → exerciseAddMode is skip', () => {
+    const analysis = makeAnalysis({
+      bmrModel: {
+        tdee_current: 1900, // below floor → rejected
+        observedTdee: 2300,
+        error: null,
+      },
+    });
+    const { exerciseAddMode, source } = computeTDEE(bmrResult, makeProfile(), analysis);
+    expect(source).toBe('empirical_observed');
+    expect(exerciseAddMode).toBe('skip');
+  });
+});
+
+// ── resolveDailyBaseTargets — exerciseAddMode propagation ────────────────────
+
+describe('resolveDailyBaseTargets — exerciseAddMode', () => {
+  function makeState(overrides = {}) {
+    return {
+      baselineTargets: { calories: 2000, protein: 150, fat: 60, carbs: 200 },
+      goalSettings: { goalType: 'maintenance', targetMode: 'manual', manualTargetOverrides: {} },
+      userProfile: makeProfile({ manualWeightOverrideLb: 185 }),
+      analysisResults: null,
+      ...overrides,
+    };
+  }
+
+  it('manual mode → exerciseAddMode is add', () => {
+    const { exerciseAddMode, source } = resolveDailyBaseTargets('2025-01-01', makeState());
+    expect(source).toBe('manual');
+    expect(exerciseAddMode).toBe('add');
+  });
+
+  it('manual_fallback → exerciseAddMode is add', () => {
+    const s = makeState({
+      userProfile: makeProfile({ manualWeightOverrideLb: null, useUploadedWeightForCurrentWeight: false }),
+      goalSettings: { goalType: 'maintenance', targetMode: 'autoGoal', manualTargetOverrides: {} },
+      analysisResults: null,
+      weightEntries: new Map(),
+    });
+    const { exerciseAddMode, source } = resolveDailyBaseTargets('2025-01-01', s);
+    expect(source).toBe('manual_fallback');
+    expect(exerciseAddMode).toBe('add');
+  });
+
+  it('autoGoal with formula analysis → exerciseAddMode is add', () => {
+    // No analysis results → falls back to formula TDEE inside generateTargets
+    const s = makeState({
+      goalSettings: { goalType: 'maintenance', targetMode: 'autoGoal', manualTargetOverrides: {} },
+      analysisResults: null,
+    });
+    const { exerciseAddMode, source } = resolveDailyBaseTargets('2025-01-01', s);
+    expect(source).toBe('autoGoal');
+    expect(exerciseAddMode).toBe('add');
+  });
+
+  it('autoGoal with empirical_observed TDEE → exerciseAddMode is skip', () => {
+    // observed TDEE above sedentary floor, no rest-day → empirical_observed
+    const analysis = {
+      summary: { currentWeight: 185 },
+      bmrModel: {
+        tdee_current: 1200, // below floor → rejected
+        observedTdee: 2400,
+        error: null,
+      },
+    };
+    const s = makeState({
+      goalSettings: { goalType: 'maintenance', targetMode: 'autoGoal', manualTargetOverrides: {} },
+      analysisResults: analysis,
+    });
+    const { exerciseAddMode } = resolveDailyBaseTargets('2025-01-01', s);
+    expect(exerciseAddMode).toBe('skip');
+  });
+
+  it('autoGoal with empirical_rest_day TDEE → exerciseAddMode is add', () => {
+    const analysis = {
+      summary: { currentWeight: 185 },
+      bmrModel: {
+        tdee_current: 1200, // below floor → rejected
+        tdee_rest_day: 2200,
+        modelPredictedRestDayTdee: 2200,
+        fittedBmr: 1700,
+        error: null,
+      },
+    };
+    const s = makeState({
+      goalSettings: { goalType: 'maintenance', targetMode: 'autoGoal', manualTargetOverrides: {} },
+      analysisResults: analysis,
+    });
+    const { exerciseAddMode } = resolveDailyBaseTargets('2025-01-01', s);
+    expect(exerciseAddMode).toBe('add');
+  });
+});

--- a/public/tools/CalorieTracker/targets/targetEngine.test.js
+++ b/public/tools/CalorieTracker/targets/targetEngine.test.js
@@ -1696,3 +1696,67 @@ describe('resolveDailyBaseTargets — exerciseAddMode', () => {
     expect(exerciseAddMode).toBe('add');
   });
 });
+
+// ── chart target exerciseAddMode consistency ──────────────────────────────────
+// Chart target must agree with Today/Energy: skip exercise when TDEE already
+// includes historical activity, add it when using rest-day TDEE or formula.
+
+describe('chart calorie target — exerciseAddMode consistency', () => {
+  const EXERCISE_KCAL = 300;
+
+  function makeChartState(analysisOverrides = {}) {
+    return {
+      baselineTargets: { calories: 2000 },
+      goalSettings: { goalType: 'maintenance', targetMode: 'autoGoal', manualTargetOverrides: {} },
+      userProfile: makeProfile({ manualWeightOverrideLb: 185 }),
+      analysisResults: Object.keys(analysisOverrides).length ? {
+        summary: { currentWeight: 185 },
+        bmrModel: { error: null, ...analysisOverrides },
+      } : null,
+    };
+  }
+
+  function simulateChartTarget(exerciseAddMode, baseCalories) {
+    // Mirror chart.js getDateTarget logic: only add exercise when mode is 'add'
+    const exerciseKcal = exerciseAddMode === 'skip' ? 0 : EXERCISE_KCAL;
+    return baseCalories + exerciseKcal;
+  }
+
+  it('empirical_rest_day source: chart adds exercise to calorie target', () => {
+    const s = makeChartState({
+      tdee_current: 1200, // below floor → rejected
+      tdee_rest_day: 2200,
+      modelPredictedRestDayTdee: 2200,
+      fittedBmr: 1700,
+    });
+    const { exerciseAddMode, targets } = resolveDailyBaseTargets('2025-01-01', s);
+    expect(exerciseAddMode).toBe('add');
+    const chartTarget = simulateChartTarget(exerciseAddMode, parseFloat(targets.calories));
+    expect(chartTarget).toBe(parseFloat(targets.calories) + EXERCISE_KCAL);
+  });
+
+  it('empirical_observed source: chart skips exercise in calorie target', () => {
+    const s = makeChartState({
+      tdee_current: 1200, // below floor → rejected
+      observedTdee: 2400, // above floor → used
+    });
+    const { exerciseAddMode, targets } = resolveDailyBaseTargets('2025-01-01', s);
+    expect(exerciseAddMode).toBe('skip');
+    const chartTarget = simulateChartTarget(exerciseAddMode, parseFloat(targets.calories));
+    expect(chartTarget).toBe(parseFloat(targets.calories)); // no exercise added
+  });
+
+  it('Today and chart use same base calories for the same date and TDEE source', () => {
+    // Both Today and chart call resolveDailyBaseTargets for the same date — targets must agree
+    const s = makeChartState({
+      tdee_current: 1200,
+      tdee_rest_day: 2200,
+      modelPredictedRestDayTdee: 2200,
+      fittedBmr: 1700,
+    });
+    const todayResult = resolveDailyBaseTargets('2025-01-01', s);
+    const chartResult = resolveDailyBaseTargets('2025-01-01', s);
+    expect(todayResult.targets.calories).toBe(chartResult.targets.calories);
+    expect(todayResult.exerciseAddMode).toBe(chartResult.exerciseAddMode);
+  });
+});

--- a/public/tools/CalorieTracker/ui/banking.test.js
+++ b/public/tools/CalorieTracker/ui/banking.test.js
@@ -438,15 +438,88 @@ describe('calcBankingCore — manual rolling bank', () => {
     expect(r.todayKcalTarget).toBeGreaterThan(2000);
   });
 
-  it('large overage → target floored at effectiveFloor', () => {
+  it('large overage → bank capped at -400/day, target = 1600 (not floored)', () => {
+    // rawBankBalance = 6×2000 − 6×4000 = −12000; cap → −400; target = 2000−400 = 1600
     const r = calcBankingCore(makeCore({ sumPast6Actual: 6 * 4000 }));
-    expect(r.targetFloorApplied).toBe(true);
-    expect(r.todayKcalTarget).toBe(1000);
+    expect(r.rawBankBalance).toBe(-12000);
+    expect(r.bankAdjustmentApplied).toBe(-400);
+    expect(r.todayKcalTarget).toBe(1600);
+    expect(r.targetFloorApplied).toBe(false);
+    expect(r.manualBankCapped).toBe(true);
   });
 
-  it('floor of 1200 (BMR-based) is used when provided', () => {
-    const r = calcBankingCore(makeCore({ sumPast6Actual: 6 * 4000, effectiveFloor: 1200 }));
+  it('floor applies when base + capped adjustment is below effectiveFloor', () => {
+    // base 1200, adjustment −400 → 800 < effectiveFloor 1200 → floored
+    const r = calcBankingCore(makeCore({
+      todayBaseCalories: 1200,
+      sumPastBaseTargets: 6 * 1200,
+      sumPast6Actual: 6 * 4000,
+      effectiveFloor: 1200,
+    }));
+    expect(r.bankAdjustmentApplied).toBe(-400);
+    expect(r.targetFloorApplied).toBe(true);
     expect(r.todayKcalTarget).toBe(1200);
+  });
+});
+
+describe('calcBankingCore — manual rolling bank cap', () => {
+  it('-1980 bank → capped to -400, target = 1600 (not -475)', () => {
+    // 6-day raw balance = -1980 (exactly the bug scenario)
+    const r = calcBankingCore(makeCore({
+      sumPastBaseTargets: 6 * 2000,
+      sumPast6Actual: 6 * 2000 + 1980, // over by 1980
+    }));
+    expect(r.rawBankBalance).toBe(-1980);
+    expect(r.bankAdjustmentApplied).toBe(-400); // capped
+    expect(r.todayKcalTarget).toBe(1600);       // 2000 - 400
+    expect(r.manualBankCapped).toBe(true);
+  });
+
+  it('small overage within cap applied directly (no cap)', () => {
+    // rawBankBalance = -200 (well within -400 cap)
+    const r = calcBankingCore(makeCore({
+      sumPastBaseTargets: 6 * 2000,
+      sumPast6Actual: 6 * 2000 + 200,
+    }));
+    expect(r.rawBankBalance).toBe(-200);
+    expect(r.bankAdjustmentApplied).toBe(-200); // within cap
+    expect(r.todayKcalTarget).toBe(1800);
+    expect(r.manualBankCapped).toBe(false);
+  });
+
+  it('large credit capped at +600 kcal/day', () => {
+    // rawBankBalance = 9000 (6 days at 500 kcal vs 2000 target)
+    const r = calcBankingCore(makeCore({ sumPast6Actual: 6 * 500 }));
+    expect(r.rawBankBalance).toBe(9000);
+    expect(r.bankAdjustmentApplied).toBe(600); // capped at +600
+    expect(r.todayKcalTarget).toBe(2600);
+    expect(r.manualBankCapped).toBe(true);
+  });
+
+  it('floor still applies when base + capped adjustment is below floor', () => {
+    // base = 1100, cap adjustment = -400, raw = 1100 - 400 = 700 → floored to 1000
+    const r = calcBankingCore(makeCore({
+      todayBaseCalories: 1100,
+      sumPastBaseTargets: 6 * 1100,
+      sumPast6Actual: 6 * 4000,
+      effectiveFloor: 1000,
+    }));
+    expect(r.bankAdjustmentApplied).toBe(-400);
+    expect(r.todayKcalTarget).toBe(1000);
+    expect(r.targetFloorApplied).toBe(true);
+  });
+
+  it('Auto Goal mode never gets manual cap (uses schedule adjustment instead)', () => {
+    const far = new Date(TODAY); far.setDate(far.getDate() + 74);
+    const r = calcBankingCore(makeCore({
+      targetMode: 'autoGoal',
+      sumPast6Actual: 6 * 4000,
+      goalTargetDate: far.toISOString().slice(0, 10),
+    }));
+    expect(r.bankMode).toBe('autoGoalSchedule');
+    expect(r.manualBankCapped).toBe(false); // only manual mode uses the cap
+    expect(r.scheduleAdjustment).toBeLessThan(0); // schedule adjustment, not cap
+    expect(Math.abs(r.scheduleAdjustment)).toBeLessThanOrEqual(250); // within hard cap
   });
 });
 
@@ -598,5 +671,42 @@ describe('calcBankingCore — banking off UI safety', () => {
     }
     expect(typeof r.todayKcalTarget).toBe('number');
     expect(typeof r.bankBalance).toBe('number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Calories remaining display behavior
+// ---------------------------------------------------------------------------
+
+describe('calories remaining display logic', () => {
+  it('eaten < target → remaining is positive', () => {
+    const target = 1800;
+    const eaten = 1200;
+    const remaining = target - eaten;
+    expect(remaining).toBeGreaterThan(0);
+    // UI should show "Calories Remaining"
+  });
+
+  it('eaten > target → remaining is negative (Over by)', () => {
+    const target = 1800;
+    const eaten = 2200;
+    const remaining = target - eaten;
+    expect(remaining).toBeLessThan(0);
+    // UI should show "Calories Over Target"
+    expect(Math.abs(remaining)).toBe(400);
+  });
+
+  it('final target after all adjustments is always at least effectiveFloor', () => {
+    const effectiveFloor = 1484; // BMR-based for 176.1 lb user
+    // Scenario: base 1516 + bank -400 (capped) = 1116 → below floor → floored
+    const r = calcBankingCore(makeCore({
+      todayBaseCalories: 1516,
+      sumPastBaseTargets: 6 * 1516,
+      sumPastTrainingBumps: 0,
+      sumPast6Actual: 6 * 1516 + 1980, // rawBankBalance = -1980
+      windowBudget: 7 * 1516,
+      effectiveFloor,
+    }));
+    expect(r.todayKcalTarget).toBeGreaterThanOrEqual(effectiveFloor);
   });
 });

--- a/public/tools/CalorieTracker/ui/banking.test.js
+++ b/public/tools/CalorieTracker/ui/banking.test.js
@@ -229,17 +229,24 @@ function calcBankingAutoGoal(targetDateStr, dailyEntries, baseKcal, goalTargetDa
   const rawBankBalance = Math.round(baseKcal * (WINDOW - 1) - sumPastActual);
   const cumulativeDebt = Math.max(0, -rawBankBalance);
 
+  const cumulativeCredit = Math.max(0, rawBankBalance);
+
   let scheduleAdjustment = 0;
   let scheduleCapped = false;
 
-  if (cumulativeDebt > 0 && goalTargetDate) {
+  if ((cumulativeDebt > 0 || cumulativeCredit > 0) && goalTargetDate) {
     const targetMs    = new Date(`${goalTargetDate}T00:00:00`).getTime();
     const todayMs     = new Date(`${targetDateStr}T00:00:00`).getTime();
     const remainingDays = Math.round((targetMs - todayMs) / 86400000);
     if (remainingDays > 1) {
-      const rawAdj = -cumulativeDebt / remainingDays;
-      scheduleAdjustment = Math.round(Math.max(-MAX_SCHEDULE_ADJ_HARD, rawAdj));
-      if (rawAdj < -MAX_SCHEDULE_ADJ_SOFT) scheduleCapped = true;
+      if (cumulativeDebt > 0) {
+        const rawAdj = -cumulativeDebt / remainingDays;
+        scheduleAdjustment = Math.round(Math.max(-MAX_SCHEDULE_ADJ_HARD, rawAdj));
+        if (rawAdj < -MAX_SCHEDULE_ADJ_SOFT) scheduleCapped = true;
+      } else {
+        const rawAdj = cumulativeCredit / remainingDays;
+        scheduleAdjustment = Math.round(Math.min(MAX_SCHEDULE_ADJ_SOFT, rawAdj));
+      }
     }
   }
 
@@ -338,8 +345,8 @@ describe('Auto Goal mode — schedule adjustment, not full rolling bank', () => 
     if (targetFloorApplied) expect(todayKcalTarget).toBe(MIN_DAILY_CALORIES);
   });
 
-  it('under-eating in auto goal mode produces zero schedule adjustment (no bonus calories)', () => {
-    // 6 × 1600 vs 2000 = +2400 kcal credit → rawBankBalance > 0 → no schedule adjustment
+  it('under-eating in auto goal mode with goal date → positive schedule credit spreads forward', () => {
+    // 6 × 1600 vs 2000 = +2400 kcal credit; 60 days → 2400/60 = 40 kcal/day bonus
     const entries = makeEntries(Object.fromEntries(
       [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 1600])
     ));
@@ -348,6 +355,16 @@ describe('Auto Goal mode — schedule adjustment, not full rolling bank', () => 
     const { scheduleAdjustment, rawBankBalance } =
       calcBankingAutoGoal(TODAY, entries, 2000, far.toISOString().slice(0, 10));
     expect(rawBankBalance).toBeGreaterThan(0);
+    expect(scheduleAdjustment).toBeGreaterThan(0); // credit bonus applied
+    expect(scheduleAdjustment).toBeLessThanOrEqual(MAX_SCHEDULE_ADJ_SOFT); // capped at 150
+  });
+
+  it('under-eating in auto goal mode with NO goal date → no adjustment', () => {
+    // Without a goal date, no spread is possible
+    const entries = makeEntries(Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map(i => [dateStr(i), 1600])
+    ));
+    const { scheduleAdjustment } = calcBankingAutoGoal(TODAY, entries, 2000, null);
     expect(scheduleAdjustment).toBe(0);
   });
 });

--- a/public/tools/CalorieTracker/ui/bankingEngine.js
+++ b/public/tools/CalorieTracker/ui/bankingEngine.js
@@ -50,16 +50,25 @@ export function calcBankingCore(p) {
 
   if (targetMode === 'autoGoal') {
     // AUTO GOAL: base + exercise + soft schedule correction.
-    // Full rolling bank NOT applied — only spread overages gently.
-    const cumulativeDebt = Math.max(0, -rawBankBalance);
-    if (cumulativeDebt > 0 && goalTargetDate) {
+    // Full rolling bank NOT applied — overages AND credits are spread gently.
+    const cumulativeDebt   = Math.max(0, -rawBankBalance);
+    const cumulativeCredit = Math.max(0, rawBankBalance);
+    const MAX_CREDIT_PER_DAY = BANKING_CONFIG.MAX_SCHEDULE_ADJ_SOFT ?? 150;
+
+    if ((cumulativeDebt > 0 || cumulativeCredit > 0) && goalTargetDate) {
       const targetMs = new Date(`${goalTargetDate}T00:00:00`).getTime();
       const todayMs  = new Date(`${targetDateStr}T00:00:00`).getTime();
       const remainingDays = Math.round((targetMs - todayMs) / 86400000);
       if (remainingDays > 1) {
-        const rawAdj = -cumulativeDebt / remainingDays;
-        scheduleAdjustment = Math.round(Math.max(HARD_CAP, rawAdj));
-        if (rawAdj < SOFT_CAP) scheduleCapped = true;
+        if (cumulativeDebt > 0) {
+          const rawAdj = -cumulativeDebt / remainingDays;
+          scheduleAdjustment = Math.round(Math.max(HARD_CAP, rawAdj));
+          if (rawAdj < SOFT_CAP) scheduleCapped = true;
+        } else {
+          // Spread credit forward; cap at soft-cap to avoid over-eating days
+          const rawAdj = cumulativeCredit / remainingDays;
+          scheduleAdjustment = Math.round(Math.min(MAX_CREDIT_PER_DAY, rawAdj));
+        }
       }
     }
     bankMode = 'autoGoalSchedule';

--- a/public/tools/CalorieTracker/ui/bankingEngine.js
+++ b/public/tools/CalorieTracker/ui/bankingEngine.js
@@ -76,16 +76,23 @@ export function calcBankingCore(p) {
 
   } else {
     // MANUAL rolling bank: window budget adjusts today's target up/down.
+    // The raw adjustment is capped so a single bad week never crashes the target.
     bankMode = 'manualRolling';
-    const rollingTarget = windowBudget - sumPast6Actual;
-    bankBalance = Math.round(rollingTarget - todayBaseCalories - todaysTrainingBump);
-    bankAdjustmentApplied = bankBalance;
-    todayKcalTarget = BankingHelpers.roundToNearest25(rollingTarget);
+    const MANUAL_DOWN = BANKING_CONFIG.MANUAL_BANK_CAP_DOWN ?? -400;
+    const MANUAL_UP   = BANKING_CONFIG.MANUAL_BANK_CAP_UP   ?? 600;
+    // rawBankBalance already computed above (positive = credit, negative = debt)
+    const cappedBankAdj = Math.max(MANUAL_DOWN, Math.min(MANUAL_UP, rawBankBalance));
+    bankBalance = rawBankBalance;            // keep raw as informational
+    bankAdjustmentApplied = cappedBankAdj;  // what actually moves the target
+    todayKcalTarget = BankingHelpers.roundToNearest25(
+      todayBaseCalories + todaysTrainingBump + cappedBankAdj
+    );
   }
 
   const targetFloorApplied = todayKcalTarget < effectiveFloor;
   if (targetFloorApplied) todayKcalTarget = effectiveFloor;
 
+  const manualBankCapped = bankMode === 'manualRolling' && bankAdjustmentApplied !== bankBalance;
   return {
     bankMode,
     bankBalance: Math.round(bankBalance),
@@ -95,5 +102,6 @@ export function calcBankingCore(p) {
     todayKcalTarget,
     targetFloorApplied,
     scheduleCapped,
+    manualBankCapped,
   };
 }

--- a/public/tools/CalorieTracker/ui/chart.js
+++ b/public/tools/CalorieTracker/ui/chart.js
@@ -218,6 +218,13 @@ function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = fals
 
     const isAutoGoal = (state.goalSettings?.targetMode === 'autoGoal');
 
+    // Resolve exerciseAddMode once from today's target so the chart agrees with Today/Energy.
+    // When TDEE source is empirical_observed or empirical, historical activity is already
+    // baked in and adding logged exercise would double-count it.
+    const chartExerciseAddMode = isAutoGoal
+      ? (resolveDailyBaseTargets(displayLabels[displayLabels.length - 1] ?? formatDate(new Date()), state).exerciseAddMode ?? 'add')
+      : 'add';
+
     nutrientKeys.forEach((nutrient, idx) => {
       const color = CONFIG.CHART_COLORS[idx % CONFIG.CHART_COLORS.length];
       const baseTarget = parseFloat(state.baselineTargets[nutrient]) || 1;
@@ -226,7 +233,10 @@ function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = fals
           const calBase = isAutoGoal
             ? (parseFloat(resolveDailyBaseTargets(dateStr, state).targets?.calories) || baseTarget)
             : baseTarget;
-          return calBase + getEntryExerciseKcal(state.dailyEntries.get(dateStr) || {}, weightKg);
+          const exerciseKcal = chartExerciseAddMode === 'skip'
+            ? 0
+            : getEntryExerciseKcal(state.dailyEntries.get(dateStr) || {}, weightKg);
+          return calBase + exerciseKcal;
         }
         if (isAutoGoal) {
           const resolved = parseFloat(resolveDailyBaseTargets(dateStr, state).targets?.[nutrient]);

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -878,6 +878,7 @@ function renderCalcDetailsPanel(bankingData) {
     todayBaseCalories, todaysTrainingBump, bankBalance, targetMode, bankMode,
     sumPast6Actual, sumPastTargets, windowBudget, todayKcalTarget,
     scheduleAdjustment, rawBankBalance, targetFloorApplied, effectiveFloor, floorSource,
+    bankAdjustmentApplied, manualBankCapped,
   } = bankingData;
 
   if (bankMode === 'autoGoalSchedule') {
@@ -973,14 +974,20 @@ function renderCalcDetailsPanel(bankingData) {
         ${todaysTrainingBump > 0 ? `
           <p class="text-xs text-muted px-2 italic">Exercise calories included in today's budget (+${todaysTrainingBump} kcal)</p>
         ` : ''}
-        ${bankBalance !== 0 ? `
+        ${bankAdjustmentApplied !== 0 ? `
           <div class="flex justify-between items-center p-2 rounded border surface-2">
-            <span>Rolling balance adjustment:</span>
-            <span class="font-medium ${bankBalance > 0 ? 'text-positive' : 'text-negative'}">${bankBalance > 0 ? '+' : ''}${bankBalance} kcal</span>
+            <span>Rolling balance adjustment${manualBankCapped ? ' (capped)' : ''}:</span>
+            <span class="font-medium ${bankAdjustmentApplied > 0 ? 'text-positive' : 'text-negative'}">${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied} kcal</span>
           </div>
+          ${manualBankCapped ? `
+            <div class="flex justify-between items-center p-2 rounded border surface-1 text-xs text-muted">
+              <span>Raw 7-day balance (informational):</span>
+              <span>${bankBalance > 0 ? '+' : ''}${bankBalance} kcal (capped to ${bankAdjustmentApplied} kcal/day)</span>
+            </div>
+          ` : ''}
         ` : ''}
         <div class="mt-2 pt-2 border-t border text-xs text-muted space-y-1">
-          <div>${windowBudget} − ${sumPast6Actual} = <strong>${todayKcalTarget} kcal today</strong></div>
+          <div>${todayBaseCalories}${todaysTrainingBump > 0 ? ` + ${todaysTrainingBump}` : ''} + ${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied}${manualBankCapped ? ` (raw: ${bankBalance > 0 ? '+' : ''}${bankBalance}, capped)` : ''} = <strong>${todayKcalTarget} kcal today</strong></div>
           <div>${tomorrowNote}</div>
         </div>
       </div>
@@ -996,7 +1003,7 @@ function renderTodayCompact(bankingData) {
     todayKcalTarget, finalProteinG, finalFatG, finalCarbsG,
     todayBaseCalories, todaysTrainingBump, bankBalance, bankIncomplete, unknownDays, targetMode,
     bankMode, scheduleAdjustment, rawBankBalance, targetFloorApplied, effectiveFloor, floorSource, scheduleCapped,
-    macroFloorExceedsCalories,
+    macroFloorExceedsCalories, bankAdjustmentApplied, manualBankCapped,
   } = bankingData;
 
   const totals = state.dailyFoodItems.reduce((acc, item) => {
@@ -1044,9 +1051,12 @@ function renderTodayCompact(bankingData) {
       adjSegment = ` + Schedule: ${scheduleAdjustment > 0 ? '+' : ''}${scheduleAdjustment}`;
     }
   } else {
-    // Manual mode — rolling bank
-    if (bankBalance !== 0) {
-      adjSegment = ` + Bank: ${bankBalance > 0 ? '+' : ''}${bankBalance}`;
+    // Manual mode — rolling bank (use applied/capped value in formula)
+    if (bankAdjustmentApplied !== 0) {
+      adjSegment = ` + Bank: ${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied}`;
+      if (manualBankCapped) {
+        adjSegment += ` (raw: ${bankBalance > 0 ? '+' : ''}${bankBalance}, capped)`;
+      }
     }
   }
   const exerciseSegment = todaysTrainingBump > 0 ? ` + Exercise: +${todaysTrainingBump}` : '';
@@ -1388,6 +1398,7 @@ function renderBankingPanel(bankingData) {
     bankBalance, rawBankBalance, pastDays, sumPast6Actual, sumPastTargets,
     windowBudget, todayBaseCalories, todaysTrainingBump, targetMode, bankMode, scheduleAdjustment,
     targetFloorApplied, effectiveFloor, floorSource, scheduleCapped, todayKcalTarget,
+    bankAdjustmentApplied, manualBankCapped,
   } = bankingData;
 
   const contributionRows = pastDays.map(d => `
@@ -1506,9 +1517,9 @@ function renderBankingPanel(bankingData) {
 
   // Manual mode — rolling bank panel
   const bankExplanation = bankBalance > 0
-    ? `You have ${bankBalance} kcal banked from under-eating — today's target is higher to use it.`
+    ? `You have ${bankBalance} kcal banked from under-eating — today's target is ${bankAdjustmentApplied > 0 ? `+${bankAdjustmentApplied}` : `${bankAdjustmentApplied}`} kcal${manualBankCapped ? ` (capped from +${bankBalance})` : ''}.`
     : bankBalance < 0
-    ? `You're ${Math.abs(bankBalance)} kcal over budget — today's target is lower to balance it out.`
+    ? `You're ${Math.abs(bankBalance)} kcal over budget — today's target is reduced by ${Math.abs(bankAdjustmentApplied)} kcal${manualBankCapped ? ` (capped from −${Math.abs(bankBalance)})` : ''}.`
     : "You're perfectly on track — no adjustment needed!";
 
   const budgetExplain = `${windowBudget} kcal (${todayBaseCalories}/day × 7 + training bumps).`;

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -31,7 +31,7 @@ import { renderAnalysisSection, initAnalysisEvents } from '../analysis/analysisU
 import { UL_TABLE } from '../targets/nutritionReferences.js';
 import { resolveDailyBaseTargets, resolveDailyPlanningTargets } from '../targets/dailyTargetResolver.js';
 import { runAnalysis } from '../analysis/engine.js';
-import { computeBMR, resolveCurrentWeightLb, latestWeightLbFromEntries } from '../targets/targetEngine.js';
+import { computeBMR, resolveCurrentWeightLb, latestWeightLbFromEntries, computeMicronutrientTargets } from '../targets/targetEngine.js';
 import { calcBankingCore } from './bankingEngine.js';
 
 // =========================
@@ -226,12 +226,12 @@ export function calculateBankingData(targetDateStr) {
     const weightKg = resolveWeightKg();
     const targetMode = state.goalSettings?.targetMode ?? 'manual';
 
-    // Resolve today's full planning targets ONCE — supplies baseCalories, exerciseAddMode,
-    // displayBaseTargets, and TDEE metadata. Avoids a second resolveDailyBaseTargets call below.
-    const todayResolvedFull   = resolveDailyBaseTargets(targetDateStr, state);
-    const todayBaseCalories   = parseFloat(todayResolvedFull.targets?.calories) || baseKcal;
+    // Resolve today's full planning targets ONCE via the rich planning resolver —
+    // supplies baseCalories, exerciseAddMode, displayBaseTargets, and full TDEE metadata.
+    const todayResolvedFull   = resolveDailyPlanningTargets(targetDateStr, state);
+    const todayBaseCalories   = todayResolvedFull.baseCalories || baseKcal;
     const exerciseAddMode     = todayResolvedFull.exerciseAddMode ?? 'add';
-    const resolvedTargetSource = todayResolvedFull.source;
+    const resolvedTargetSource = todayResolvedFull.mode;
     const displayBaseTargets  = todayResolvedFull.targets || {};
 
     // Helper: resolve per-day calorie target for PAST days only.
@@ -426,10 +426,58 @@ export function calculateBankingData(targetDateStr) {
       floorSource,         // 'bmr_floor' | 'min_daily'
       scheduleCapped,      // true if soft cap was exceeded on debt correction
       exerciseAddMode,     // 'add' | 'skip' — 'skip' when TDEE includes historical activity
-      // TDEE provenance (autoGoal only):
-      tdeeSource:      todayResolvedFull.meta?.tdeeSource      ?? null,
-      tdeeSourceLabel: todayResolvedFull.meta?.tdeeSourceLabel ?? null,
-      planningTdee:    todayResolvedFull.meta?.tdeeValue       ?? null,
+      // TDEE provenance (autoGoal only) — from resolveDailyPlanningTargets:
+      tdeeSource:      todayResolvedFull.planningTdeeSource      ?? null,
+      tdeeSourceLabel: todayResolvedFull.planningTdeeSourceLabel ?? null,
+      planningTdee:    todayResolvedFull.planningTdee            ?? null,
+
+      // Aliases for structured consumers (Today/Energy/Nutrients)
+      finalCalories:    todayKcalTarget,
+      exerciseCalories: todaysTrainingBump,
+
+      // Structured adjustment object
+      adjustment: {
+        type:               bankMode,
+        rawBankBalance,
+        appliedAdjustment:  bankAdjustmentApplied,
+        capped:             scheduleCapped || manualBankCapped,
+        capReason:          scheduleCapped ? 'schedule_cap' : manualBankCapped ? 'manual_cap' : null,
+        overageSpreadPerDay: scheduleAdjustment,
+      },
+
+      // Structured floor object
+      floor: {
+        minDailyCalories: MIN_DAILY_CALORIES,
+        effectiveFloor,
+        source:  floorSource,
+        applied: targetFloorApplied,
+        reason:  floorSource === 'bmr_floor'
+          ? `85% of BMR floor (${effectiveFloor} kcal)`
+          : `Minimum daily floor (${MIN_DAILY_CALORIES} kcal)`,
+      },
+
+      // Explanation: ordered list of what shaped today's target
+      explanation: (() => {
+        const parts = [`Base: ${todayBaseCalories} kcal (${resolvedTargetSource === 'autoGoal' ? 'Auto Goal' : 'Manual Baseline'})`];
+        if (exerciseAddMode === 'skip' && todaysTrainingBumpRaw > 0) {
+          parts.push(`Exercise (${todaysTrainingBumpRaw} kcal): reflected in TDEE — not added separately`);
+        } else if (todaysTrainingBump > 0) {
+          parts.push(`Exercise: +${todaysTrainingBump} kcal`);
+        }
+        if (scheduleAdjustment > 0) {
+          parts.push(`Schedule credit spread forward: +${scheduleAdjustment} kcal/day`);
+        } else if (scheduleAdjustment < 0) {
+          parts.push(`Schedule overage spread: ${scheduleAdjustment} kcal/day`);
+        }
+        if (bankAdjustmentApplied !== 0 && bankMode === 'manualRolling') {
+          parts.push(`Rolling bank: ${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied} kcal`);
+        }
+        if (targetFloorApplied) {
+          parts.push(`Floor applied: ${effectiveFloor} kcal (${floorSource === 'bmr_floor' ? '85% BMR' : 'minimum'})`);
+        }
+        parts.push(`Final: ${todayKcalTarget} kcal`);
+        return parts;
+      })(),
 
       // Config
       config: { windowDays }
@@ -500,6 +548,10 @@ export function calculateMicronutrientMetrics(dateStr) {
       ? (resolveDailyBaseTargets(dateStr, state).targets ?? state.baselineTargets)
       : state.baselineTargets;
 
+    // Profile-specific DRI targets (age/sex adjusted) for accurate source classification.
+    // These differ from DEFAULT_TARGETS for age groups outside the generic reference range.
+    const { microTargets: profileDriTargets } = computeMicronutrientTargets(state.userProfile ?? {});
+
     const metrics = {};
 
     allNutrients.forEach(nutrient => {
@@ -568,13 +620,15 @@ export function calculateMicronutrientMetrics(dateStr) {
         trendDirection = computeTrendDirection(todaysIntake, priorAvg);
       }
 
-      // Target source classification (pass targetMode so auto-goal vs manual-baseline is distinguished)
+      // Target source classification (pass profileDriTargets so age/sex DRI values aren't
+      // mislabeled as auto_goal or manual_baseline when they merely reflect the user's DRI)
       const targetSource = classifyTargetSource(
         nutrient,
         effectiveTargets,
         DEFAULT_TARGETS,
         state.goalSettings?.manualTargetOverrides,
         targetMode,
+        profileDriTargets,
       );
 
       // Upper-limit check (warn at ≥ 80% of UL)
@@ -922,7 +976,7 @@ function renderCalcDetailsPanel(bankingData) {
           ` : ''}
           ${scheduleAdjustment !== 0 ? `
             <div class="flex justify-between items-center p-2 surface-1 rounded border">
-              <span>Schedule correction (overage spread over goal window):</span>
+              <span>${scheduleAdjustment > 0 ? 'Schedule credit (spread forward over remaining goal days):' : 'Schedule correction (overage spread over goal window):'}</span>
               <span class="font-medium ${scheduleAdjustment > 0 ? 'text-positive' : 'text-negative'}">${scheduleAdjustment > 0 ? '+' : ''}${scheduleAdjustment} kcal</span>
             </div>
           ` : ''}
@@ -935,7 +989,7 @@ function renderCalcDetailsPanel(bankingData) {
           <div class="mt-2 pt-2 border-t border text-xs text-muted space-y-1">
             <div>${todayBaseCalories} + ${todaysTrainingBump} + ${scheduleAdjustment} = <strong>${todayKcalTarget} kcal today</strong></div>
             ${rawBankBalance !== 0 ? `
-              <div class="italic">7-day raw balance: ${rawBankBalance > 0 ? '+' : ''}${rawBankBalance} kcal (${rawBankBalance < 0 ? 'overage spread over remaining goal days — not applied as a single crash day' : 'credit — not added to today\'s target in Auto Goal mode'}).</div>
+              <div class="italic">7-day raw balance: ${rawBankBalance > 0 ? '+' : ''}${rawBankBalance} kcal (${rawBankBalance < 0 ? 'overage spread over remaining goal days — not applied as a single crash day' : 'credit spread forward as a small schedule increase'}).</div>
             ` : ''}
             <div>${tomorrowNote}</div>
             <div>In Auto Goal mode: overages are spread gently, not concentrated. The base target recalculates as your weight changes.</div>
@@ -1089,6 +1143,7 @@ function renderTodayCompact(bankingData) {
     ? `<div class="text-xs text-muted mt-0.5">
         7-day raw ${rawBankBalance < 0 ? 'overage' : 'credit'}: ${Math.abs(rawBankBalance)} kcal
         ${rawBankBalance < 0 && scheduleAdjustment !== 0 ? '— spread over goal window' : ''}
+        ${rawBankBalance > 0 && scheduleAdjustment > 0 ? '— spread forward as a small schedule increase' : ''}
        </div>`
     : '';
 
@@ -1675,6 +1730,8 @@ function renderMicronutrientSections(metrics, filter = 'all') {
       ? `<span class="nt-badge nt-badge-custom" title="Auto Goal calculated target">🎯</span>`
       : targetSource === 'manual_baseline'
       ? `<span class="nt-badge nt-badge-custom" title="Custom target from Settings">✏️</span>`
+      : targetSource === 'dri_profile_default'
+      ? `<span class="nt-badge nt-badge-custom" title="Age/sex-specific DRI for your profile">👤</span>`
       : '';
 
     // Exercise-scaling note
@@ -1693,10 +1750,11 @@ function renderMicronutrientSections(metrics, filter = 'all') {
       : '';
 
     // Source label in target span
-    const srcLabel = targetSource === 'manual_override' ? ' (pinned)'
-                   : targetSource === 'auto_goal'       ? ' (auto goal)'
-                   : targetSource === 'manual_baseline' ? ' (custom)'
-                   : ' (DRI)'; // 'dri' = matches DRI reference value
+    const srcLabel = targetSource === 'manual_override'    ? ' (pinned)'
+                   : targetSource === 'auto_goal'           ? ' (auto goal)'
+                   : targetSource === 'manual_baseline'     ? ' (custom)'
+                   : targetSource === 'dri_profile_default' ? ' (profile DRI)'
+                   : ' (DRI)'; // 'dri' = matches generic DRI reference value
 
     // For averaged nutrients show today's value as sub-detail below the bar
     const subDetail = isAveraged

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -29,7 +29,7 @@ import { initializeChartControls } from './chart.js';
 import { CONFIG } from '../config.js';
 import { renderAnalysisSection, initAnalysisEvents } from '../analysis/analysisUI.js';
 import { UL_TABLE } from '../targets/nutritionReferences.js';
-import { resolveDailyBaseTargets } from '../targets/dailyTargetResolver.js';
+import { resolveDailyBaseTargets, resolveDailyPlanningTargets } from '../targets/dailyTargetResolver.js';
 import { runAnalysis } from '../analysis/engine.js';
 import { computeBMR, resolveCurrentWeightLb, latestWeightLbFromEntries } from '../targets/targetEngine.js';
 import { calcBankingCore } from './bankingEngine.js';
@@ -226,7 +226,15 @@ export function calculateBankingData(targetDateStr) {
     const weightKg = resolveWeightKg();
     const targetMode = state.goalSettings?.targetMode ?? 'manual';
 
-    // Helper: resolve per-day calorie target.
+    // Resolve today's full planning targets ONCE — supplies baseCalories, exerciseAddMode,
+    // displayBaseTargets, and TDEE metadata. Avoids a second resolveDailyBaseTargets call below.
+    const todayResolvedFull   = resolveDailyBaseTargets(targetDateStr, state);
+    const todayBaseCalories   = parseFloat(todayResolvedFull.targets?.calories) || baseKcal;
+    const exerciseAddMode     = todayResolvedFull.exerciseAddMode ?? 'add';
+    const resolvedTargetSource = todayResolvedFull.source;
+    const displayBaseTargets  = todayResolvedFull.targets || {};
+
+    // Helper: resolve per-day calorie target for PAST days only.
     // In autoGoal mode, each past day uses the date-specific dynamically computed target.
     // In manual mode, every day uses the same baseKcal from baseline targets.
     function resolveDayCalorieTarget(dateStr) {
@@ -236,8 +244,8 @@ export function calculateBankingData(targetDateStr) {
     }
 
     // Sum actual intake AND exercise bumps for the previous (windowDays - 1) days.
-    // For days with no logged data ("unknown"), we use the day's target as a
-    // bank-neutral stand-in to prevent phantom calorie banks from blank days.
+    // When exerciseAddMode='skip', exercise bumps are excluded — the TDEE already
+    // encodes historical activity, so adding bumps would double-count.
     const pastDays = [];
     let sumPast6Actual       = 0;
     let sumPastTrainingBumps = 0;
@@ -249,7 +257,7 @@ export function calculateBankingData(targetDateStr) {
       const pastDateStr = formatDate(pastDate);
       const entry       = state.dailyEntries.get(pastDateStr) || {};
 
-      const trainingBump    = getEntryExerciseKcal(entry, weightKg);
+      const trainingBump    = exerciseAddMode === 'skip' ? 0 : getEntryExerciseKcal(entry, weightKg);
       const dayBaseCalories = resolveDayCalorieTarget(pastDateStr);
       const dailyTarget     = dayBaseCalories + trainingBump;
 
@@ -278,10 +286,10 @@ export function calculateBankingData(targetDateStr) {
 
     const bankIncomplete = unknownDays.length > 0;
 
-    // Today's base calorie target and exercise bump
-    const todaysEntry         = state.dailyEntries.get(targetDateStr) || {};
-    const todaysTrainingBump  = getEntryExerciseKcal(todaysEntry, weightKg);
-    const todayBaseCalories   = resolveDayCalorieTarget(targetDateStr);
+    // Today's exercise bump (raw = actual logged kcal; effective = 0 when skip mode)
+    const todaysEntry            = state.dailyEntries.get(targetDateStr) || {};
+    const todaysTrainingBumpRaw  = getEntryExerciseKcal(todaysEntry, weightKg);
+    const todaysTrainingBump     = exerciseAddMode === 'skip' ? 0 : todaysTrainingBumpRaw;
 
     // The full 7-day window budget (for display and manual-mode calc).
     const windowBudget = sumPastBaseTargets + todayBaseCalories + sumPastTrainingBumps + todaysTrainingBump;
@@ -317,6 +325,7 @@ export function calculateBankingData(targetDateStr) {
     const {
       bankMode, bankBalance, bankAdjustmentApplied, scheduleAdjustment,
       rawBankBalance, todayKcalTarget, targetFloorApplied, scheduleCapped,
+      manualBankCapped,
     } = coreResult;
 
     // Macro split using today's final target.
@@ -326,22 +335,15 @@ export function calculateBankingData(targetDateStr) {
     const remainingKcal  = Math.max(0, todayKcalTarget - proteinKcal - fatKcal);
     const carbsG         = Math.round(remainingKcal / 4);
 
-    // Resolve today's stable base macro targets for progress bars.
-    // carbsG above can be 0 when rolling target < protein+fat budget — show stable targets instead.
-    let resolvedTargetSource = targetMode;
-    const displayBaseTargets = targetMode === 'autoGoal'
-      ? (() => {
-        const r = resolveDailyBaseTargets(targetDateStr, state);
-        resolvedTargetSource = r.source;
-        return r.targets || {};
-      })()
-      : state.baselineTargets;
-    const displayProteinG = Math.round(parseFloat(displayBaseTargets.protein) || scaledProteinG);
-    const displayFatG     = Math.round(parseFloat(displayBaseTargets.fatMinimum ?? displayBaseTargets.fat) || fatFloorG);
+    // displayBaseTargets and resolvedTargetSource already computed from todayResolvedFull above.
+    // For manual mode, fall back to state.baselineTargets (todayResolvedFull.targets = same).
+    const effectiveDisplayTargets = targetMode === 'autoGoal' ? displayBaseTargets : state.baselineTargets;
+    const displayProteinG = Math.round(parseFloat(effectiveDisplayTargets.protein) || scaledProteinG);
+    const displayFatG     = Math.round(parseFloat(effectiveDisplayTargets.fatMinimum ?? effectiveDisplayTargets.fat) || fatFloorG);
     const displayCarbsG   = (() => {
-      const fromTargets = parseFloat(displayBaseTargets.carbs);
+      const fromTargets = parseFloat(effectiveDisplayTargets.carbs);
       if (fromTargets > 0) return Math.round(fromTargets);
-      const calBudget = parseFloat(displayBaseTargets.calories) || baseKcal;
+      const calBudget = parseFloat(effectiveDisplayTargets.calories) || baseKcal;
       return Math.round(Math.max(0, (calBudget - displayProteinG * 4 - displayFatG * 9) / 4));
     })();
 
@@ -376,6 +378,7 @@ export function calculateBankingData(targetDateStr) {
       // Base parameters
       baseKcal,
       todaysTrainingBump,
+      todaysTrainingBumpRaw,  // actual logged exercise (may differ from bump when skip mode)
 
       // Target results
       todayKcalTarget,
@@ -414,13 +417,19 @@ export function calculateBankingData(targetDateStr) {
       targetMode,
       bankMode,            // 'manualRolling' | 'autoGoalSchedule' | 'off'
       bankAdjustmentApplied,
+      manualBankCapped,    // true when manual bank adj was capped by MANUAL_BANK_CAP_DOWN/UP
       rawBankBalance,      // cumulative 6-day credit/debt (informational in autoGoal mode)
-      scheduleAdjustment,  // auto goal only: spread overage over remaining days
+      scheduleAdjustment,  // auto goal only: spread overage/credit over remaining days
       targetFloorApplied,  // true when effectiveFloor was applied
       minDailyCalories: MIN_DAILY_CALORIES,
       effectiveFloor,      // actual floor used (BMR-based or MIN_DAILY_CALORIES)
       floorSource,         // 'bmr_floor' | 'min_daily'
-      scheduleCapped,      // true if soft cap (150 kcal/day) was hit
+      scheduleCapped,      // true if soft cap was exceeded on debt correction
+      exerciseAddMode,     // 'add' | 'skip' — 'skip' when TDEE includes historical activity
+      // TDEE provenance (autoGoal only):
+      tdeeSource:      todayResolvedFull.meta?.tdeeSource      ?? null,
+      tdeeSourceLabel: todayResolvedFull.meta?.tdeeSourceLabel ?? null,
+      planningTdee:    todayResolvedFull.meta?.tdeeValue       ?? null,
 
       // Config
       config: { windowDays }
@@ -559,12 +568,13 @@ export function calculateMicronutrientMetrics(dateStr) {
         trendDirection = computeTrendDirection(todaysIntake, priorAvg);
       }
 
-      // Target source classification (use effectiveTargets so auto-goal values are classified correctly)
+      // Target source classification (pass targetMode so auto-goal vs manual-baseline is distinguished)
       const targetSource = classifyTargetSource(
         nutrient,
         effectiveTargets,
         DEFAULT_TARGETS,
         state.goalSettings?.manualTargetOverrides,
+        targetMode,
       );
 
       // Upper-limit check (warn at ≥ 80% of UL)
@@ -860,7 +870,7 @@ function renderEnergyOutput() {
   if (dateStr) {
     const bankingData = calculateBankingData(dateStr);
     bankingHtml = renderInfoBox()
-      + renderEnergyExerciseBlock(dateStr)
+      + renderEnergyExerciseBlock(dateStr, bankingData.exerciseAddMode)
       + renderBankingPanel(bankingData)
       + renderCalcDetailsPanel(bankingData);
   }
@@ -875,22 +885,35 @@ function renderEnergyOutput() {
  */
 function renderCalcDetailsPanel(bankingData) {
   const {
-    todayBaseCalories, todaysTrainingBump, bankBalance, targetMode, bankMode,
+    todayBaseCalories, todaysTrainingBump, todaysTrainingBumpRaw, bankBalance, targetMode, bankMode,
     sumPast6Actual, sumPastTargets, windowBudget, todayKcalTarget,
     scheduleAdjustment, rawBankBalance, targetFloorApplied, effectiveFloor, floorSource,
-    bankAdjustmentApplied, manualBankCapped,
+    bankAdjustmentApplied, manualBankCapped, exerciseAddMode, tdeeSourceLabel, planningTdee,
   } = bankingData;
 
   if (bankMode === 'autoGoalSchedule') {
     const tomorrowNote = 'Hit this target and tomorrow recalculates from Auto Goal mode.';
+    const exerciseSkipNote = exerciseAddMode === 'skip' && todaysTrainingBumpRaw > 0
+      ? `<div class="flex justify-between items-center p-2 surface-1 rounded border text-muted text-xs">
+           <span>Exercise logged (+${todaysTrainingBumpRaw} kcal) — not added separately:</span>
+           <span>already in TDEE estimate</span>
+         </div>`
+      : '';
     return `
       <div class="section-card p-4 mb-6">
         <h3 class="text-responsive-xl font-bold text-secondary mb-3">🧮 How Today's Target Was Calculated</h3>
         <div class="grid grid-cols-1 gap-2 text-sm">
+          ${planningTdee ? `
+            <div class="flex justify-between items-center p-2 surface-1 rounded border text-xs text-muted">
+              <span>Planning TDEE:</span>
+              <span>${planningTdee} kcal — ${tdeeSourceLabel ?? ''}</span>
+            </div>
+          ` : ''}
           <div class="flex justify-between items-center p-2 surface-1 rounded border">
             <span>Auto Goal base target (from weight &amp; goal):</span>
             <span class="font-medium">${todayBaseCalories} kcal</span>
           </div>
+          ${exerciseSkipNote}
           ${todaysTrainingBump > 0 ? `
             <div class="flex justify-between items-center p-2 surface-1 rounded border">
               <span>Exercise:</span>
@@ -1123,8 +1146,10 @@ function renderTodayCompact(bankingData) {
 /**
  * Render a compact exercise summary card for the Today dashboard output.
  * Shows sessions, calorie estimate, and method source.
+ * @param {string} dateStr
+ * @param {'add'|'skip'} [exerciseAddMode] - when 'skip', show note that calories are in TDEE
  */
-function renderExerciseSummaryCard(dateStr) {
+function renderExerciseSummaryCard(dateStr, exerciseAddMode = 'add') {
   const entry    = state.dailyEntries.get(dateStr) || {};
   const sessions = Array.isArray(entry.exerciseSessions) ? entry.exerciseSessions : [];
   const weightKg = resolveWeightKg();
@@ -1147,6 +1172,9 @@ function renderExerciseSummaryCard(dateStr) {
 
   const { totalKcal, source } = computeSessionTotals(sessions, weightKg);
   const sourceLabel = source === 'manual' ? 'manual override' : source === 'wearable' ? 'wearable device' : 'MET estimate';
+  const skipNote = exerciseAddMode === 'skip'
+    ? `<div class="text-xs text-warning mt-1">⚠ Exercise calories are already reflected in your planning TDEE — not added separately to today's target.</div>`
+    : '';
 
   const sessionLines = sessions.map(s => {
     const { kcal } = estimateSessionCalories(s, weightKg);
@@ -1159,16 +1187,19 @@ function renderExerciseSummaryCard(dateStr) {
     <div class="mb-3 p-3 surface-2 rounded-lg border">
       <div class="flex justify-between items-center mb-1">
         <span class="text-sm font-medium text-secondary">🏋️ Exercise</span>
-        <span class="text-sm font-bold text-accent">+${totalKcal} kcal <span class="text-xs text-muted font-normal">(${sourceLabel})</span></span>
+        <span class="text-sm font-bold text-accent">${exerciseAddMode === 'add' ? '+' : ''}${totalKcal} kcal <span class="text-xs text-muted font-normal">(${sourceLabel})</span></span>
       </div>
       ${sessionLines}
+      ${skipNote}
     </div>`;
 }
 
 /**
  * Render an exercise impact block for the Energy tab.
+ * @param {string} dateStr
+ * @param {'add'|'skip'} [exerciseAddMode]
  */
-function renderEnergyExerciseBlock(dateStr) {
+function renderEnergyExerciseBlock(dateStr, exerciseAddMode = 'add') {
   const entry    = state.dailyEntries.get(dateStr) || {};
   const sessions = Array.isArray(entry.exerciseSessions) ? entry.exerciseSessions : [];
   const weightKg = resolveWeightKg();
@@ -1222,6 +1253,10 @@ function renderEnergyExerciseBlock(dateStr) {
       <p class="text-xs text-muted mt-2">
         MET estimates from the 2024 Compendium of Physical Activities. Add wearable or manual calorie values in the session form to override estimates.
       </p>
+      ${exerciseAddMode === 'skip' ? `
+        <p class="text-xs text-warning mt-1">
+          ⚠ Your planning TDEE is derived from observed data that already includes your historical activity. Exercise calories above are logged but not added separately to today's target — they are already reflected in the base estimate.
+        </p>` : ''}
     </div>`;
 }
 
@@ -1272,7 +1307,7 @@ export function updateDashboard() {
 
     dashboard.innerHTML = `
       <div id="dashboard-errors"></div>
-      ${renderExerciseSummaryCard(dateStr)}
+      ${renderExerciseSummaryCard(dateStr, bankingData.exerciseAddMode)}
       ${renderTodayCompact(bankingData)}
     `;
 
@@ -1350,14 +1385,15 @@ function renderInfoBox() {
 
   if (targetMode === 'autoGoal') {
     const softCap = BANKING_CONFIG.MAX_SCHEDULE_ADJ_SOFT ?? 150;
+    const hardCap = BANKING_CONFIG.MAX_SCHEDULE_ADJ_HARD ?? 250;
     return `
       <div class="mb-6 p-4 surface-2 rounded-lg border">
         <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How Auto Goal Works</h3>
         <div class="text-sm text-muted space-y-1">
           <p><strong>Daily Target:</strong> Recalculated from your current weight, goal, and target date — adapts as your weight changes. The base calorie target never comes from a fixed 7-day window.</p>
-          <p><strong>Schedule Correction:</strong> If you've eaten over target this week, a small correction (max ${softCap} kcal/day) is spread across the remaining goal days — never concentrated into a single crash day.</p>
-          <p><strong>Training Days:</strong> Select your workout type above — this adds calories and scales electrolytes appropriately.</p>
-          <p><strong>7-Day Raw Balance:</strong> Shown as informational context only. In Auto Goal mode it does not directly set today's target.</p>
+          <p><strong>Schedule Correction:</strong> Weekly overages and credits are spread symmetrically across remaining goal days. Overage correction: up to ${softCap} kcal/day normally, up to ${hardCap} kcal/day in extreme cases. Credit bonus: up to ${softCap} kcal/day — never concentrated into a single day.</p>
+          <p><strong>Training Days:</strong> Exercise calories are added when the planning TDEE is a rest-day estimate. If your TDEE was derived from observed data (which already includes your activity), exercise bumps are skipped to avoid double-counting.</p>
+          <p><strong>7-Day Raw Balance:</strong> Shown as informational context only. In Auto Goal mode it feeds the schedule correction but does not directly set today's target.</p>
         </div>
       </div>
     `;
@@ -1398,7 +1434,7 @@ function renderBankingPanel(bankingData) {
     bankBalance, rawBankBalance, pastDays, sumPast6Actual, sumPastTargets,
     windowBudget, todayBaseCalories, todaysTrainingBump, targetMode, bankMode, scheduleAdjustment,
     targetFloorApplied, effectiveFloor, floorSource, scheduleCapped, todayKcalTarget,
-    bankAdjustmentApplied, manualBankCapped,
+    bankAdjustmentApplied, manualBankCapped, exerciseAddMode,
   } = bankingData;
 
   const contributionRows = pastDays.map(d => `
@@ -1448,7 +1484,10 @@ function renderBankingPanel(bankingData) {
         statusText += ` Spreading correction over remaining goal window (${scheduleAdjustment} kcal/day today).`;
       }
     } else if (rawBankBalance > 0) {
-      statusText = `Under budget by ${rawBankBalance} kcal this week — no upward adjustment applied.`;
+      statusText = `Under budget by ${rawBankBalance} kcal this week.`;
+      if (scheduleAdjustment > 0) {
+        statusText += ` Credit spread forward (+${scheduleAdjustment} kcal/day today).`;
+      }
     } else {
       statusText = `On track this week — no adjustment needed.`;
     }
@@ -1611,7 +1650,7 @@ function renderMicronutrientSections(metrics, filter = 'all') {
       case 'low':      return data.status === 'red';
       case 'near':     return data.status === 'amber';
       case 'above':    return data.status === 'green';
-      case 'override': return data.targetSource === 'override';
+      case 'override': return data.targetSource === 'manual_override';
       default:         return true;
     }
   };
@@ -1630,10 +1669,12 @@ function renderMicronutrientSections(metrics, filter = 'all') {
     const remaining    = targetValue - displayValue;
 
     // Source badge (no badge for DRI defaults — only call out deviations)
-    const sourceBadge = targetSource === 'override'
+    const sourceBadge = targetSource === 'manual_override'
       ? `<span class="nt-badge nt-badge-override" title="Manually pinned target">📌</span>`
-      : targetSource === 'custom'
-      ? `<span class="nt-badge nt-badge-custom" title="Custom target (goal-engine or manual setting)">✏️</span>`
+      : targetSource === 'auto_goal'
+      ? `<span class="nt-badge nt-badge-custom" title="Auto Goal calculated target">🎯</span>`
+      : targetSource === 'manual_baseline'
+      ? `<span class="nt-badge nt-badge-custom" title="Custom target from Settings">✏️</span>`
       : '';
 
     // Exercise-scaling note
@@ -1652,9 +1693,10 @@ function renderMicronutrientSections(metrics, filter = 'all') {
       : '';
 
     // Source label in target span
-    const srcLabel = targetSource === 'override' ? ' (pinned)'
-                   : targetSource === 'custom'   ? ' (custom)'
-                   : ' (DRI)'; // 'dri' = matches reference value exactly
+    const srcLabel = targetSource === 'manual_override' ? ' (pinned)'
+                   : targetSource === 'auto_goal'       ? ' (auto goal)'
+                   : targetSource === 'manual_baseline' ? ' (custom)'
+                   : ' (DRI)'; // 'dri' = matches DRI reference value
 
     // For averaged nutrients show today's value as sub-detail below the bar
     const subDetail = isAveraged

--- a/public/tools/CalorieTracker/ui/nutrientHelpers.js
+++ b/public/tools/CalorieTracker/ui/nutrientHelpers.js
@@ -50,21 +50,25 @@ export function computeTrendDirection(recentVal, priorVal) {
  * Classify the source of a nutrient target.
  *
  * Returns one of:
- *  - 'override' — user explicitly pinned this nutrient via manualTargetOverrides
- *  - 'custom'   — target differs from the DRI/default (goal-engine or manual settings)
- *  - 'dri'      — target exactly matches the DRI/default value
+ *  - 'manual_override' — user explicitly pinned this nutrient via manualTargetOverrides
+ *  - 'auto_goal'       — computed by the auto-goal engine (targetMode='autoGoal')
+ *  - 'manual_baseline' — user saved a custom value via the Settings tab (manual mode)
+ *  - 'dri'             — matches the DRI/default reference value
  *
  * @param {string} nutrient
- * @param {object} baselineTargets   - state.baselineTargets
- * @param {object} defaultTargets    - DEFAULT_TARGETS (reference values)
+ * @param {object} effectiveTargets  - resolved targets (baseline or auto-goal)
+ * @param {object} defaultTargets    - DEFAULT_TARGETS (DRI reference values)
  * @param {object} manualOverrides   - state.goalSettings?.manualTargetOverrides (may be undefined)
- * @returns {'override'|'custom'|'dri'}
+ * @param {string} [targetMode]      - 'manual' | 'autoGoal' (default 'manual')
+ * @returns {'manual_override'|'auto_goal'|'manual_baseline'|'dri'}
  */
-export function classifyTargetSource(nutrient, baselineTargets, defaultTargets, manualOverrides) {
-  if (manualOverrides?.[nutrient] !== undefined) return 'override';
+export function classifyTargetSource(nutrient, effectiveTargets, defaultTargets, manualOverrides, targetMode = 'manual') {
+  if (manualOverrides?.[nutrient] !== undefined) return 'manual_override';
   if (
-    baselineTargets[nutrient] !== undefined &&
-    Math.abs((baselineTargets[nutrient] ?? 0) - (defaultTargets[nutrient] ?? 0)) > 0.001
-  ) return 'custom';
+    effectiveTargets[nutrient] !== undefined &&
+    Math.abs((effectiveTargets[nutrient] ?? 0) - (defaultTargets[nutrient] ?? 0)) > 0.001
+  ) {
+    return targetMode === 'autoGoal' ? 'auto_goal' : 'manual_baseline';
+  }
   return 'dri';
 }

--- a/public/tools/CalorieTracker/ui/nutrientHelpers.js
+++ b/public/tools/CalorieTracker/ui/nutrientHelpers.js
@@ -50,24 +50,29 @@ export function computeTrendDirection(recentVal, priorVal) {
  * Classify the source of a nutrient target.
  *
  * Returns one of:
- *  - 'manual_override' — user explicitly pinned this nutrient via manualTargetOverrides
- *  - 'auto_goal'       — computed by the auto-goal engine (targetMode='autoGoal')
- *  - 'manual_baseline' — user saved a custom value via the Settings tab (manual mode)
- *  - 'dri'             — matches the DRI/default reference value
+ *  - 'manual_override'    — user explicitly pinned this nutrient via manualTargetOverrides
+ *  - 'auto_goal'          — computed by the auto-goal engine (targetMode='autoGoal')
+ *  - 'manual_baseline'    — user saved a custom value via the Settings tab (manual mode)
+ *  - 'dri_profile_default'— matches the age/sex-specific profile DRI (differs from generic default)
+ *  - 'dri'                — matches the generic DEFAULT_TARGETS reference value
  *
  * @param {string} nutrient
  * @param {object} effectiveTargets  - resolved targets (baseline or auto-goal)
- * @param {object} defaultTargets    - DEFAULT_TARGETS (DRI reference values)
+ * @param {object} defaultTargets    - DEFAULT_TARGETS (generic DRI reference values)
  * @param {object} manualOverrides   - state.goalSettings?.manualTargetOverrides (may be undefined)
  * @param {string} [targetMode]      - 'manual' | 'autoGoal' (default 'manual')
- * @returns {'manual_override'|'auto_goal'|'manual_baseline'|'dri'}
+ * @param {object} [profileDriTargets] - age/sex-specific DRI from computeMicronutrientTargets()
+ * @returns {'manual_override'|'auto_goal'|'manual_baseline'|'dri_profile_default'|'dri'}
  */
-export function classifyTargetSource(nutrient, effectiveTargets, defaultTargets, manualOverrides, targetMode = 'manual') {
+export function classifyTargetSource(nutrient, effectiveTargets, defaultTargets, manualOverrides, targetMode = 'manual', profileDriTargets = null) {
   if (manualOverrides?.[nutrient] !== undefined) return 'manual_override';
-  if (
-    effectiveTargets[nutrient] !== undefined &&
-    Math.abs((effectiveTargets[nutrient] ?? 0) - (defaultTargets[nutrient] ?? 0)) > 0.001
-  ) {
+  const effective = effectiveTargets[nutrient];
+  if (effective !== undefined) {
+    // Exact match against generic default → plain DRI
+    if (Math.abs((effective ?? 0) - (defaultTargets[nutrient] ?? 0)) <= 0.001) return 'dri';
+    // Match against profile-specific DRI (age/sex adjusted) — a profile DRI default, not customized
+    if (profileDriTargets && profileDriTargets[nutrient] !== undefined &&
+        Math.abs((effective ?? 0) - (profileDriTargets[nutrient] ?? 0)) <= 0.001) return 'dri_profile_default';
     return targetMode === 'autoGoal' ? 'auto_goal' : 'manual_baseline';
   }
   return 'dri';

--- a/public/tools/CalorieTracker/ui/nutrientHelpers.test.js
+++ b/public/tools/CalorieTracker/ui/nutrientHelpers.test.js
@@ -61,16 +61,16 @@ describe('computeTrendDirection', () => {
 describe('classifyTargetSource', () => {
   const defaults = { vitaminC: 90, zinc: 11 };
 
-  it('returns override when nutrient is in manualTargetOverrides', () => {
+  it('returns manual_override when nutrient is in manualTargetOverrides', () => {
     // Even if baseline matches default, explicit override wins
-    expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, { vitaminC: 75 })).toBe('override');
+    expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, { vitaminC: 75 })).toBe('manual_override');
   });
 
-  it('returns override regardless of baseline value', () => {
-    expect(classifyTargetSource('zinc', { zinc: 20 }, defaults, { zinc: 15 })).toBe('override');
+  it('returns manual_override regardless of baseline value', () => {
+    expect(classifyTargetSource('zinc', { zinc: 20 }, defaults, { zinc: 15 })).toBe('manual_override');
   });
 
-  it('returns dri when baseline matches default exactly', () => {
+  it('returns dri when baseline matches default exactly (manual mode)', () => {
     expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, {})).toBe('dri');
   });
 
@@ -78,12 +78,24 @@ describe('classifyTargetSource', () => {
     expect(classifyTargetSource('vitaminC', {}, defaults, {})).toBe('dri');
   });
 
-  it('returns custom when baseline differs from default', () => {
-    expect(classifyTargetSource('vitaminC', { vitaminC: 120 }, defaults, {})).toBe('custom');
+  it('returns manual_baseline when baseline differs from default (manual mode)', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 120 }, defaults, {})).toBe('manual_baseline');
   });
 
-  it('returns custom when baseline is zero but default is non-zero', () => {
-    expect(classifyTargetSource('vitaminC', { vitaminC: 0 }, defaults, {})).toBe('custom');
+  it('returns manual_baseline when baseline is zero but default is non-zero (manual mode)', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 0 }, defaults, {})).toBe('manual_baseline');
+  });
+
+  it('returns auto_goal when baseline differs from default in autoGoal mode', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 120 }, defaults, {}, 'autoGoal')).toBe('auto_goal');
+  });
+
+  it('returns dri in autoGoal mode when value matches DRI', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, {}, 'autoGoal')).toBe('dri');
+  });
+
+  it('manual_override takes priority over auto_goal mode', () => {
+    expect(classifyTargetSource('vitaminC', { vitaminC: 120 }, defaults, { vitaminC: 100 }, 'autoGoal')).toBe('manual_override');
   });
 
   it('returns dri when manualOverrides is undefined', () => {
@@ -92,5 +104,10 @@ describe('classifyTargetSource', () => {
 
   it('returns dri when manualOverrides is null', () => {
     expect(classifyTargetSource('vitaminC', { vitaminC: 90 }, defaults, null)).toBe('dri');
+  });
+
+  it('defaults to manual mode when targetMode omitted', () => {
+    // Existing call sites that don't pass targetMode get manual_baseline (not breaking)
+    expect(classifyTargetSource('vitaminC', { vitaminC: 120 }, defaults, {})).toBe('manual_baseline');
   });
 });

--- a/public/tools/CalorieTracker/ui/nutrientHelpers.test.js
+++ b/public/tools/CalorieTracker/ui/nutrientHelpers.test.js
@@ -110,4 +110,53 @@ describe('classifyTargetSource', () => {
     // Existing call sites that don't pass targetMode get manual_baseline (not breaking)
     expect(classifyTargetSource('vitaminC', { vitaminC: 120 }, defaults, {})).toBe('manual_baseline');
   });
+
+  // ── profileDriTargets (6th parameter) ──────────────────────────────────────
+
+  it('returns dri_profile_default when effective matches profileDriTargets but not DEFAULT_TARGETS', () => {
+    // Older female calcium: profile DRI = 1200, generic DEFAULT_TARGETS = 1000
+    // → labeled as profile DRI default, not custom/auto_goal
+    const defaultsLow = { calcium: 1000 };
+    const profileDri  = { calcium: 1200 };
+    expect(classifyTargetSource('calcium', { calcium: 1200 }, defaultsLow, {}, 'manual', profileDri)).toBe('dri_profile_default');
+  });
+
+  it('returns dri_profile_default in autoGoal mode when value matches profile DRI', () => {
+    const defaultsLow = { calcium: 1000 };
+    const profileDri  = { calcium: 1200 };
+    // Profile DRI match takes priority over auto_goal classification
+    expect(classifyTargetSource('calcium', { calcium: 1200 }, defaultsLow, {}, 'autoGoal', profileDri)).toBe('dri_profile_default');
+  });
+
+  it('returns dri when effective matches generic DEFAULT_TARGETS (profile DRI is same)', () => {
+    // When generic and profile DRI agree, generic match fires first → plain 'dri'
+    const defaults   = { calcium: 1000 };
+    const profileDri = { calcium: 1000 }; // same as defaults
+    expect(classifyTargetSource('calcium', { calcium: 1000 }, defaults, {}, 'manual', profileDri)).toBe('dri');
+  });
+
+  it('returns auto_goal when value differs from both DEFAULT_TARGETS and profileDriTargets', () => {
+    const defaultsLow = { calcium: 1000 };
+    const profileDri  = { calcium: 1200 };
+    // 1300 differs from both 1000 and 1200 → auto_goal in autoGoal mode
+    expect(classifyTargetSource('calcium', { calcium: 1300 }, defaultsLow, {}, 'autoGoal', profileDri)).toBe('auto_goal');
+  });
+
+  it('returns manual_baseline when value differs from both defaults in manual mode', () => {
+    const defaultsLow = { calcium: 1000 };
+    const profileDri  = { calcium: 1200 };
+    expect(classifyTargetSource('calcium', { calcium: 1500 }, defaultsLow, {}, 'manual', profileDri)).toBe('manual_baseline');
+  });
+
+  it('manual_override still wins when profileDriTargets is provided', () => {
+    const defaultsLow = { calcium: 1000 };
+    const profileDri  = { calcium: 1200 };
+    expect(classifyTargetSource('calcium', { calcium: 1200 }, defaultsLow, { calcium: 1300 }, 'autoGoal', profileDri)).toBe('manual_override');
+  });
+
+  it('profileDriTargets null falls back to DEFAULT_TARGETS comparison only', () => {
+    const defaultsLow = { calcium: 1000 };
+    // 1200 differs from 1000 default, no profileDri provided → auto_goal
+    expect(classifyTargetSource('calcium', { calcium: 1200 }, defaultsLow, {}, 'autoGoal', null)).toBe('auto_goal');
+  });
 });


### PR DESCRIPTION
## Summary
Refactors TDEE computation to prioritize rest-day estimates for daily planning, introduces `exerciseAddMode` to distinguish when exercise should be added separately vs. already included in TDEE, and propagates this mode through the banking and UI layers to prevent double-counting of activity.

## Key Changes

### TDEE Computation (`targetEngine.js`)
- **Priority reordering**: Rest-day TDEE (best for planning) → Observed TDEE → tdee_current (if above sedentary floor) → Formula fallback
- **Sedentary floor validation**: Rejects `tdee_current` values below `max(bmr × 1.2, fittedBmr × 1.2)` as suspect recent-lows
- **Exercise add-mode classification**:
  - `'add'` for formula and rest-day sources (exercise logged separately)
  - `'skip'` for empirical and empirical_observed sources (activity already baked in)
- **Expanded return object**: Now includes `exerciseAddMode`, `tdeeCurrent`, `tdeeCurrentRejected`, `restDayTdee`, `observedTdee` for full transparency

### Daily Target Resolution (`dailyTargetResolver.js`)
- New `resolveDailyPlanningTargets()` function exposes full TDEE metadata (source, rest-day/observed values, BMR, weight, goal deficit, days left)
- Backward-compatible `resolveDailyBaseTargets()` re-exported for existing callers

### Banking Layer (`bankingEngine.js`, `dashboard.js`)
- **Exercise bump handling**: Respects `exerciseAddMode` — skips adding logged exercise bumps when TDEE already includes historical activity
- **Schedule adjustment for credits**: Auto Goal mode now spreads positive bank balances forward (capped at soft limit) in addition to spreading debt
- **Manual bank cap**: Introduces `MANUAL_BANK_CAP_DOWN` (−400 kcal/day) and `MANUAL_BANK_CAP_UP` (+600 kcal/day) to prevent extreme rolling-bank swings
- **Structured output**: Returns `manualBankCapped`, `adjustment`, `floor`, and `explanation` objects for richer UI consumption

### UI & Display (`dashboard.js`, `chart.js`, `nutrientHelpers.js`)
- **Consistent exercise handling**: Chart and Today/Energy tabs now agree on whether to add exercise via `exerciseAddMode`
- **Nutrient source classification**: Updated labels (`manual_override`, `manual_baseline`, `auto_goal`, `dri_profile_default`) to clarify target provenance in both manual and auto-goal modes
- **Rich metadata**: Banking result now includes TDEE source, rest-day/observed values, and structured explanation for debugging and UI display

### Test Coverage
- 8 new `computeTDEE` tests covering rest-day preference, sedentary floor rejection, fallback chains, and `exerciseAddMode` assignment
- Regression test for 176.1 → 170 lb scenario (validates rest-day TDEE use and correct calorie targets)
- 6 `exerciseAddMode` propagation tests across `computeTDEE`, `resolveDailyBaseTargets`, and chart consistency
- 4 new manual rolling bank cap tests; updated auto-goal schedule adjustment tests to cover credit spreading

## Notable Implementation Details
- Rest-day TDEE is preferred because the banking layer adds exercise bumps separately, avoiding double-counting
- Observed TDEE and empirical sources skip exercise bumps because they represent long-window or recent activity already included in the estimate
- Sedentary floor prevents using noisy recent-window TDEE values that fall below a reasonable minimum (1.2× BMR)
- Schedule adjustment now handles both debt (negative) and credit (positive) spreads, with soft caps to prevent extreme daily targets
- All TDEE metadata flows through `resolveDailyPlanningTargets()` for unified access by UI tabs

https://claude.ai/code/session_01Ew46A81SAU69UY2WLmPGaW