### PR TITLE
Add selectable Gemini models and model-aware AI integration for Shows tool

### DIFF
--- a/AI_AGENTS.md
+++ b/AI_AGENTS.md
@@ -17,6 +17,7 @@ This document is the **single source of truth** for automated assistants (Claude
   - `tools/trip-planner/**` Trip Planner scaffold (Firebase Auth + UI timeline)
   - `tools/date-night/**` Date Night Roulette (Firebase Auth + Firestore roller + reviews + batch CSV imports; split math in `lib/{decay,stacking,roller}.ts` with Vitest tests)
   - `tools/conflict-tracker/**` Conflict Tracker (Firebase Auth + Firestore; two-person tracker groups, per-conflict reflections, shared section, trend dashboard; helpers in `lib/{firebase,db,types,tags}.ts`)
+  - `tools/shows/**` Movie/TV Show Tracker (Firebase Auth + Firestore; Gemini title classification and mood recommendations via Edge API routes; model metadata in `app/lib/aiModels.ts`)
 - **/components** — Reusable UI (Button via CVA, Input, Select, Nav, ProjectCard)
 - **/public** — Static HTML/CSS/JS sub-sites and assets
   - `/games/**`, `/tools/**`, `/trips/**` each with their own `index.html`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,6 +20,7 @@ app/
   tools/date-night/  # Date Night Roulette (Auth + Firestore + weighted roller + reviews)
     lib/decay.ts, lib/stacking.ts, lib/roller.ts # Pure roll math modules
     __tests__/ # Vitest coverage for decay/stacking/rarity behavior
+  tools/shows/       # Movie/TV tracker (Auth + Firestore + Gemini classify/recommend routes)
 components/
   Button.tsx, Input.tsx, Select.tsx, Nav.tsx, ProjectCard.tsx
 public/
@@ -48,6 +49,8 @@ public/
   Path: `/tools/trip-planner`
 - **Date Night Roulette** — Firebase-backed picker for date ideas/modifiers with veto/accept flow, batch CSV uploads for pool items, and photo/review history.
   Path: `/tools/date-night`
+- **Movie/TV Show Tracker** — Firebase-backed shared watchlist with ratings, notes, Gemini title classification, local model settings, and mood recommendations that can include rewatchable completed shows.
+  Path: `/tools/shows`
 - **Calorie Tracker** — A simple tool to track daily calorie intake (Static HTML).
   Path: `/tools/CalorieTracker/index.html`
 - **Social Security (interactive guide)** — Learn how benefits and earnings interact through simulations.  
@@ -58,6 +61,12 @@ public/
 - **Trips** (static):  
 - **Chicago Trip Itinerary** — An itinerary for a trip to Chicago (Static HTML).  
   Path: `/trips/ChicagoTripItinerary/index.html`
+
+## Movie/TV Show Tracker: AI Model Selection
+- **Shared model metadata:** `app/lib/aiModels.ts` is client-safe and holds available Gemini model IDs, display labels, defaults, validation helpers, and localStorage keys.
+- **Gemini request utility:** `app/lib/aiConfig.ts` builds plain JSON Gemini requests for Edge routes without tools, grounding, URL context, code execution, file search, or function calling.
+- **Defaults:** Classification/title expansion defaults to `gemini-3.1-flash-lite`; recommendations default to `gemini-2.5-flash`.
+- **Recommendation eligibility:** `candidateShows` includes Watching, Planned, On Hold, and Completed shows only when relevant viewers marked `wouldRewatch` as `yes` or `maybe`, before applying watcher preference tiers.
 
 ## Trip Cost & Trip Planner: Data & Modules
 - **Config:** `app/tools/trip-cost/firebaseConfig.ts` (admin email `arkkahdarkkahd@gmail.com`).

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Key features:
 
 Data persists under `artifacts/conflict-tracker/trackers/{trackerId}/conflicts/{conflictId}/reflections/{personA|personB}`. Typed helpers in `app/tools/conflict-tracker/lib/`.
 
+### Movie/TV Show Tracker (Firebase + Gemini-backed)
+
+_"Track shared watchlists, ratings, notes, and mood-based recommendations."_
+
+This React tool lives under **app/tools/shows/** with Edge API routes in **app/api/classify/** and **app/api/recommend/**. Gemini is used as a plain text-in / JSON-out helper for title classification/expansion and watch recommendations. Model choices are client-safe metadata in **app/lib/aiModels.ts**, with local device settings for classification (`gemini-3.1-flash-lite` by default) and recommendations (`gemini-2.5-flash` by default). Recommendation candidates include Watching, Planned, On Hold, and Completed shows that relevant viewers marked as rewatchable.
+
 ### Date Night Roulette (Firebase-backed)
 
 _"Spin to pick a random date idea and modifier, log how it went."_

--- a/app/api/classify/route.ts
+++ b/app/api/classify/route.ts
@@ -4,6 +4,7 @@ import { resolveTitle } from '@/app/tools/shows/lib/titleResolver';
 import { getTmdbConfig } from '@/app/tools/shows/lib/tmdbConfig';
 import type { ClassifyRequestBody } from '@/app/tools/shows/lib/classifyTypes';
 import type { ShowType } from '@/app/tools/shows/types';
+import { DEFAULT_CLASSIFY_GEMINI_MODEL, resolveGeminiModelId } from '@/app/lib/aiConfig';
 
 const ALLOWED_TYPES = new Set<string>(['anime', 'tv', 'movie', 'animated_movie', 'cartoon']);
 
@@ -16,6 +17,7 @@ export async function POST(req: NextRequest) {
   }
 
   const rawTitle = typeof body.title === 'string' ? body.title.trim() : '';
+  const modelId = resolveGeminiModelId(body.modelId, DEFAULT_CLASSIFY_GEMINI_MODEL);
   if (!rawTitle) {
     return NextResponse.json({ error: 'title is required.' }, { status: 400 });
   }
@@ -42,6 +44,7 @@ export async function POST(req: NextRequest) {
       typeHintWasUserSelected,
       tmdbConfig,
       geminiApiKey,
+      modelId,
     });
     return NextResponse.json(result);
   } catch (err) {

--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -3,7 +3,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { MoodEntry, ViewerPreferenceProfile } from '@/app/tools/shows/lib/recommendationContext';
 import type { Show } from '@/app/tools/shows/types';
 import { buildPrompt } from '@/app/tools/shows/lib/buildRecommendPrompt';
-import { callGemini, RECOMMEND_TEMPERATURE } from '@/app/lib/aiConfig';
+import {
+  callGemini,
+  DEFAULT_RECOMMEND_GEMINI_MODEL,
+  isGemini25Model,
+  RECOMMEND_TEMPERATURE,
+  resolveGeminiModelId,
+  type GeminiModelId,
+} from '@/app/lib/aiConfig';
 
 interface RecommendBody {
   moods: Record<string, MoodEntry>;
@@ -11,6 +18,7 @@ interface RecommendBody {
   profiles: Record<string, ViewerPreferenceProfile>;
   sharedMood?: string;
   excludeIds?: string[];
+  modelId?: GeminiModelId;
 }
 
 export async function POST(req: NextRequest) {
@@ -27,6 +35,7 @@ export async function POST(req: NextRequest) {
   }
 
   const { moods, candidates: allCandidates, profiles, sharedMood, excludeIds = [] } = body;
+  const modelId = resolveGeminiModelId(body.modelId, DEFAULT_RECOMMEND_GEMINI_MODEL);
 
   if (!moods || !allCandidates || !profiles) {
     return NextResponse.json(
@@ -48,7 +57,11 @@ export async function POST(req: NextRequest) {
 
   let raw: string;
   try {
-    raw = await callGemini(prompt, key, RECOMMEND_TEMPERATURE);
+    raw = await callGemini(prompt, key, {
+      modelId,
+      temperature: isGemini25Model(modelId) ? RECOMMEND_TEMPERATURE : undefined,
+      thinkingLevel: 'medium',
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/app/lib/aiConfig.ts
+++ b/app/lib/aiConfig.ts
@@ -1,27 +1,50 @@
-// Switch the model here. This affects every AI route in the app.
-//
-// Current free tier model IDs (as of April 2026):
-//   gemini-2.5-flash-lite       Stable. 15 RPM, 1000 RPD. Recommended for this app.
-//   gemini-2.5-flash            Stable. 10 RPM, 250 RPD. Better quality.
-//   gemini-2.5-pro              Stable. 5 RPM, 100 RPD. Best reasoning.
-//
-// Deprecated (do not use): gemini-2.0-flash, gemini-2.0-flash-lite (shut down June 1, 2026)
-// Verify current model IDs at: https://ai.google.dev/gemini-api/docs/models
+import {
+  DEFAULT_RECOMMEND_GEMINI_MODEL,
+  isGemini25Model,
+  isGemini3Model,
+  resolveGeminiModelId,
+  type GeminiModelId,
+} from './aiModels';
 
-export const GEMINI_MODEL = 'gemini-2.5-flash-lite';
+export * from './aiModels';
 
-// Lower temperature for deterministic tasks (classification, title lookup).
+// Lower temperature for deterministic tasks (classification, title lookup) on 2.5 models.
 export const CLASSIFY_TEMPERATURE = 0.2;
-// Moderate temperature for creative/recommendation tasks.
+// Moderate temperature for creative/recommendation tasks on 2.5 models.
 export const RECOMMEND_TEMPERATURE = 0.7;
 
-export const geminiEndpoint = (apiKey: string) =>
-  `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${apiKey}`;
+export type GeminiThinkingLevel = 'minimal' | 'low' | 'medium' | 'high';
 
-// Standard request body shape for Gemini text generation.
-// Includes role: "user" (required by 2.5+ models, was the cause of the 502 errors)
-// and responseMimeType: "application/json" so Gemini returns clean JSON we can parse directly.
-export function buildGeminiRequest(prompt: string, temperature = RECOMMEND_TEMPERATURE) {
+export interface GeminiRequestOptions {
+  modelId?: GeminiModelId;
+  temperature?: number;
+  thinkingLevel?: GeminiThinkingLevel;
+}
+
+export const geminiEndpoint = (
+  apiKey: string,
+  modelId: GeminiModelId = DEFAULT_RECOMMEND_GEMINI_MODEL,
+) => {
+  const resolvedModelId = resolveGeminiModelId(modelId, DEFAULT_RECOMMEND_GEMINI_MODEL);
+  return `https://generativelanguage.googleapis.com/v1beta/models/${resolvedModelId}:generateContent?key=${apiKey}`;
+};
+
+// Shared Gemini JSON request builder. The app sends plain user text and expects JSON;
+// no Gemini tools, grounding, URL context, code execution, file search, or function calling are configured here.
+export function buildGeminiRequest(prompt: string, options: GeminiRequestOptions = {}) {
+  const modelId = resolveGeminiModelId(options.modelId, DEFAULT_RECOMMEND_GEMINI_MODEL);
+  const generationConfig: Record<string, unknown> = {
+    responseMimeType: 'application/json',
+  };
+
+  if (isGemini25Model(modelId)) {
+    generationConfig.temperature = options.temperature ?? RECOMMEND_TEMPERATURE;
+  }
+
+  if (isGemini3Model(modelId) && options.thinkingLevel) {
+    generationConfig.thinkingConfig = { thinkingLevel: options.thinkingLevel };
+  }
+
   return {
     contents: [
       {
@@ -29,10 +52,7 @@ export function buildGeminiRequest(prompt: string, temperature = RECOMMEND_TEMPE
         parts: [{ text: prompt }],
       },
     ],
-    generationConfig: {
-      responseMimeType: 'application/json',
-      temperature,
-    },
+    generationConfig,
   };
 }
 
@@ -42,12 +62,13 @@ export function buildGeminiRequest(prompt: string, temperature = RECOMMEND_TEMPE
 export async function callGemini(
   prompt: string,
   apiKey: string,
-  temperature = RECOMMEND_TEMPERATURE,
+  options: GeminiRequestOptions = {},
 ): Promise<string> {
-  const res = await fetch(geminiEndpoint(apiKey), {
+  const modelId = resolveGeminiModelId(options.modelId, DEFAULT_RECOMMEND_GEMINI_MODEL);
+  const res = await fetch(geminiEndpoint(apiKey, modelId), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(buildGeminiRequest(prompt, temperature)),
+    body: JSON.stringify(buildGeminiRequest(prompt, { ...options, modelId })),
   });
 
   if (!res.ok) {

--- a/app/lib/aiModels.ts
+++ b/app/lib/aiModels.ts
@@ -1,0 +1,95 @@
+export const AVAILABLE_GEMINI_MODELS = [
+  {
+    id: 'gemini-3.5-flash',
+    name: 'Gemini 3.5 Flash',
+    cost: '$1.50 input / $9.00 output per 1M tokens',
+    note: 'Highest quality Flash option; best for difficult or nuanced runs.',
+  },
+  {
+    id: 'gemini-3.1-pro-preview',
+    name: 'Gemini 3.1 Pro Preview',
+    cost: '$2.00 input / $12.00 output per 1M tokens',
+    note: 'Most expensive reasoning option; use for testing or edge cases.',
+  },
+  {
+    id: 'gemini-3.1-flash-lite',
+    name: 'Gemini 3.1 Flash-Lite',
+    cost: '$0.25 input / $1.50 output per 1M tokens',
+    note: 'Default for classification; fast and cost-effective for lightweight JSON tasks.',
+  },
+  {
+    id: 'gemini-2.5-pro',
+    name: 'Gemini 2.5 Pro',
+    cost: '$1.25 input / $10.00 output per 1M tokens',
+    note: 'Strong reasoning option; useful for comparison runs.',
+  },
+  {
+    id: 'gemini-2.5-flash',
+    name: 'Gemini 2.5 Flash',
+    cost: '$0.30 input / $2.50 output per 1M tokens',
+    note: 'Default for recommendations; best price-performance for this app.',
+  },
+  {
+    id: 'gemini-2.5-flash-lite',
+    name: 'Gemini 2.5 Flash-Lite',
+    cost: '$0.10 input / $0.40 output per 1M tokens',
+    note: 'Cheapest option; best for high-volume lightweight work.',
+  },
+] as const;
+
+export type GeminiModelId = (typeof AVAILABLE_GEMINI_MODELS)[number]['id'];
+
+export const DEFAULT_CLASSIFY_GEMINI_MODEL: GeminiModelId = 'gemini-3.1-flash-lite';
+export const DEFAULT_RECOMMEND_GEMINI_MODEL: GeminiModelId = 'gemini-2.5-flash';
+
+export const SHOWS_CLASSIFY_MODEL_STORAGE_KEY = 'shows_classify_model';
+export const SHOWS_RECOMMEND_MODEL_STORAGE_KEY = 'shows_recommend_model';
+
+const GEMINI_MODEL_IDS = new Set<string>(AVAILABLE_GEMINI_MODELS.map((model) => model.id));
+
+export function isGeminiModelId(value: unknown): value is GeminiModelId {
+  return typeof value === 'string' && GEMINI_MODEL_IDS.has(value);
+}
+
+export function resolveGeminiModelId(value: unknown, fallback: GeminiModelId): GeminiModelId {
+  return isGeminiModelId(value) ? value : fallback;
+}
+
+export function geminiModelOptionLabel(model: (typeof AVAILABLE_GEMINI_MODELS)[number]): string {
+  return `${model.name} — ${model.cost}`;
+}
+
+export function getGeminiModelName(modelId: GeminiModelId): string {
+  return AVAILABLE_GEMINI_MODELS.find((model) => model.id === modelId)?.name ?? modelId;
+}
+
+export function readStoredGeminiModel(
+  storageKey: string,
+  fallback: GeminiModelId,
+): GeminiModelId {
+  if (typeof window === 'undefined') return fallback;
+
+  try {
+    return resolveGeminiModelId(window.localStorage.getItem(storageKey), fallback);
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveStoredGeminiModel(storageKey: string, modelId: GeminiModelId): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(storageKey, modelId);
+  } catch {
+    // Local model preferences are optional device settings.
+  }
+}
+
+export function isGemini25Model(modelId: GeminiModelId): boolean {
+  return modelId.startsWith('gemini-2.5-');
+}
+
+export function isGemini3Model(modelId: GeminiModelId): boolean {
+  return modelId.startsWith('gemini-3.');
+}

--- a/app/tools/shows/__tests__/recommendationContext.test.ts
+++ b/app/tools/shows/__tests__/recommendationContext.test.ts
@@ -43,12 +43,12 @@ function makeMember(uid: string, displayName: string): ShowList['members'][numbe
   return { uid, email: `${uid}@test.com`, displayName, role: 'member', joinedAt: ts() };
 }
 
-function makeRating(composite: number): MemberRating {
+function makeRating(composite: number, wouldRewatch: MemberRating['wouldRewatch'] = null): MemberRating {
   return {
     story: composite,
     characters: composite,
     vibes: composite,
-    wouldRewatch: null,
+    wouldRewatch,
     brainPower: null,
     ratedAt: null,
   };
@@ -210,13 +210,58 @@ describe('candidateShows', () => {
   const watching = makeShow({ id: 'w1', status: 'watching' });
   const planned = makeShow({ id: 'p1', status: 'planned' });
   const onHold = makeShow({ id: 'oh1', status: 'on_hold' });
-  const completed = makeShow({ id: 'c1', status: 'completed' });
+  const completed = makeShow({ id: 'c1', status: 'completed', ratings: { u1: makeRating(8, 'yes') } });
   const dropped = makeShow({ id: 'd1', status: 'dropped' });
   const all = [watching, planned, onHold, completed, dropped];
 
-  it('returns only watching/planned/on_hold when no presentUids', () => {
+  it('returns active queue shows plus completed shows marked rewatchable when no presentUids', () => {
     const result = candidateShows(all);
-    expect(result.map((s) => s.id)).toEqual(['w1', 'p1', 'oh1']);
+    expect(result.map((s) => s.id)).toEqual(['w1', 'p1', 'oh1', 'c1']);
+  });
+
+  it('excludes completed shows when relevant viewers did not mark yes or maybe to rewatch', () => {
+    const no = makeShow({ id: 'no', status: 'completed', ratings: { u1: makeRating(8, 'no') } });
+    const unrated = makeShow({ id: 'unrated', status: 'completed', ratings: {} });
+    const missing = makeShow({ id: 'missing', status: 'completed', ratings: { u2: makeRating(8, 'yes') } });
+    const result = candidateShows([no, unrated, missing], ['u1']);
+    expect(result.map((s) => s.id)).toEqual([]);
+  });
+
+  it('includes completed shows when a relevant viewer marked maybe to rewatch', () => {
+    const maybe = makeShow({ id: 'maybe', status: 'completed', ratings: { u1: makeRating(7, 'maybe') } });
+    const result = candidateShows([maybe], ['u1']);
+    expect(result.map((s) => s.id)).toEqual(['maybe']);
+  });
+
+  it('checks watchers instead of all ratings when presentUids is empty and watchers are set', () => {
+    const completed = makeShow({
+      id: 'completed',
+      status: 'completed',
+      watchers: ['u1'],
+      ratings: {
+        u1: makeRating(8, 'no'),
+        u2: makeRating(8, 'yes'),
+      },
+    });
+
+    const result = candidateShows([completed]);
+
+    expect(result.map((s) => s.id)).toEqual([]);
+  });
+
+  it('falls back to all ratings for completed legacy shows with no watchers and no presentUids', () => {
+    const completed = makeShow({
+      id: 'legacy-completed',
+      status: 'completed',
+      watchers: [],
+      ratings: {
+        u2: makeRating(8, 'yes'),
+      },
+    });
+
+    const result = candidateShows([completed]);
+
+    expect(result.map((s) => s.id)).toEqual(['legacy-completed']);
   });
 
   it('filters by present viewers when watchers are set', () => {

--- a/app/tools/shows/components/ShowForm.tsx
+++ b/app/tools/shows/components/ShowForm.tsx
@@ -8,6 +8,11 @@ import type { DisambiguationOption } from '../lib/classifyTypes';
 import VibeTagChip from './VibeTagChip';
 import ScoreBlock from './ScoreBlock';
 import { useShows } from '../ShowsContext';
+import {
+  DEFAULT_CLASSIFY_GEMINI_MODEL,
+  readStoredGeminiModel,
+  SHOWS_CLASSIFY_MODEL_STORAGE_KEY,
+} from '@/app/lib/aiModels';
 
 const SERVICES = [
   'Crunchyroll',
@@ -148,6 +153,10 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
 
   async function classify() {
     if (!title.trim()) return;
+    const modelId = readStoredGeminiModel(
+      SHOWS_CLASSIFY_MODEL_STORAGE_KEY,
+      DEFAULT_CLASSIFY_GEMINI_MODEL,
+    );
     setClassifying(true);
     setError('');
     clearDisambig();
@@ -159,6 +168,7 @@ export default function ShowForm({ show, listId, members, onClose }: Props) {
           title: title.trim(),
           typeHint: typeTouched ? type : null,
           typeHintWasUserSelected: typeTouched,
+          modelId,
         }),
       });
       if (!res.ok) {

--- a/app/tools/shows/lib/classifyTypes.ts
+++ b/app/tools/shows/lib/classifyTypes.ts
@@ -1,5 +1,6 @@
 import type { ShowType } from '../types';
 import type { VibeCategory } from './vibeCategories';
+import type { GeminiModelId } from '@/app/lib/aiModels';
 
 // ─── provider / source types ────────────────────────────────────────────────
 
@@ -91,6 +92,7 @@ export interface ClassifyRequestBody {
   title: string;
   typeHint?: ShowType | null;
   typeHintWasUserSelected?: boolean;
+  modelId?: GeminiModelId;
 }
 
 export interface ResolveRequestBody {

--- a/app/tools/shows/lib/recommendationContext.ts
+++ b/app/tools/shows/lib/recommendationContext.ts
@@ -112,8 +112,30 @@ export function buildViewerProfiles(
   return profiles;
 }
 
+function hasRelevantRewatchInterest(show: Show, presentUids?: string[]): boolean {
+  const scopedUids =
+    presentUids && presentUids.length > 0
+      ? presentUids
+      : show.watchers.length > 0
+        ? show.watchers
+        : Object.keys(show.ratings);
+
+  return scopedUids.some((uid) => {
+    const wouldRewatch = show.ratings[uid]?.wouldRewatch;
+    return wouldRewatch === 'yes' || wouldRewatch === 'maybe';
+  });
+}
+
+function isRecommendationEligible(show: Show, presentUids?: string[]): boolean {
+  if (show.status === 'watching' || show.status === 'planned' || show.status === 'on_hold') {
+    return true;
+  }
+  return show.status === 'completed' && hasRelevantRewatchInterest(show, presentUids);
+}
+
 /**
- * Returns shows eligible for recommendation (watching / planned / on_hold).
+ * Returns shows eligible for recommendation: active queue statuses plus completed
+ * shows that at least one relevant viewer marked as yes/maybe to rewatch.
  *
  * Tiered preference when presentUids is provided:
  *   Tier 1 — empty-watcher shows (legacy) + shows where ALL present viewers are watchers
@@ -121,9 +143,7 @@ export function buildViewerProfiles(
  *   Tier 3 — all eligible (fallback, ensures the picker is never empty)
  */
 export function candidateShows(shows: Show[], presentUids?: string[]): Show[] {
-  const eligible = shows.filter(
-    (s) => s.status === 'watching' || s.status === 'planned' || s.status === 'on_hold',
-  );
+  const eligible = shows.filter((s) => isRecommendationEligible(s, presentUids));
 
   if (!presentUids || presentUids.length === 0) return eligible;
 

--- a/app/tools/shows/lib/titleResolver.ts
+++ b/app/tools/shows/lib/titleResolver.ts
@@ -33,7 +33,14 @@ import type {
 import type { ShowType } from '../types';
 import type { VibeCategory } from './vibeCategories';
 import { VIBE_CATEGORIES } from './vibeCategories';
-import { callGemini, CLASSIFY_TEMPERATURE } from '../../../lib/aiConfig';
+import {
+  callGemini,
+  CLASSIFY_TEMPERATURE,
+  DEFAULT_CLASSIFY_GEMINI_MODEL,
+  isGemini25Model,
+  resolveGeminiModelId,
+  type GeminiModelId,
+} from '../../../lib/aiConfig';
 
 // ─── config ───────────────────────────────────────────────────────────────────
 
@@ -204,8 +211,10 @@ export function shouldDisambiguate(sorted: ScoredCandidate[]): boolean {
 export async function expandTitleWithGemini(
   userQuery: string,
   geminiKey: string,
+  modelId: GeminiModelId = DEFAULT_CLASSIFY_GEMINI_MODEL,
 ): Promise<GeminiExpansionResult> {
-  const cacheKey = `gemini:${normalizeTitleQuery(userQuery)}`;
+  const resolvedModelId = resolveGeminiModelId(modelId, DEFAULT_CLASSIFY_GEMINI_MODEL);
+  const cacheKey = `gemini:${resolvedModelId}:${normalizeTitleQuery(userQuery)}`;
   const cached = geminiCache.get(cacheKey);
   if (cached) return cached;
 
@@ -221,7 +230,11 @@ export async function expandTitleWithGemini(
     `- Return JSON only, no prose.`;
 
   try {
-    const raw = await callGemini(prompt, geminiKey, CLASSIFY_TEMPERATURE);
+    const raw = await callGemini(prompt, geminiKey, {
+      modelId: resolvedModelId,
+      temperature: isGemini25Model(resolvedModelId) ? CLASSIFY_TEMPERATURE : undefined,
+      thinkingLevel: 'low',
+    });
     const match = raw.match(/\{[\s\S]*\}/);
     if (!match) { geminiCache.set(cacheKey, { candidates: [] }); return { candidates: [] }; }
     const parsed = JSON.parse(match[0]) as GeminiExpansionResult;
@@ -287,6 +300,7 @@ export interface ResolveOptions {
   typeHintWasUserSelected?: boolean;
   tmdbConfig?: TmdbConfig;
   geminiApiKey?: string;
+  modelId?: GeminiModelId;
 }
 
 export async function resolveTitle(opts: ResolveOptions): Promise<ClassifyResponse> {
@@ -296,7 +310,9 @@ export async function resolveTitle(opts: ResolveOptions): Promise<ClassifyRespon
     typeHintWasUserSelected = false,
     tmdbConfig,
     geminiApiKey,
+    modelId = DEFAULT_CLASSIFY_GEMINI_MODEL,
   } = opts;
+  const resolvedModelId = resolveGeminiModelId(modelId, DEFAULT_CLASSIFY_GEMINI_MODEL);
 
   const normalized = normalizeTitleQuery(title);
   const variants = buildQueryVariants(normalized);
@@ -316,7 +332,7 @@ export async function resolveTitle(opts: ResolveOptions): Promise<ClassifyRespon
 
   // ── Step 4: Gemini expansion if no good candidates ───────────────────────
   if (!shouldDisambiguate(sorted) && ENABLE_GEMINI_TITLE_EXPANSION && geminiApiKey) {
-    const expansion = await expandTitleWithGemini(title, geminiApiKey);
+    const expansion = await expandTitleWithGemini(title, geminiApiKey, resolvedModelId);
     if (expansion.candidates.length > 0) {
       const expandedScored = await searchAllGeminiExpansions(
         expansion.candidates,

--- a/app/tools/shows/mood/page.tsx
+++ b/app/tools/shows/mood/page.tsx
@@ -10,6 +10,11 @@ import VibeTagChip from '../components/VibeTagChip';
 import { buildViewerProfiles, candidateShows } from '../lib/recommendationContext';
 import { formatScore, groupComposite } from '../lib/compositeScore';
 import type { Show } from '../types';
+import {
+  DEFAULT_RECOMMEND_GEMINI_MODEL,
+  readStoredGeminiModel,
+  SHOWS_RECOMMEND_MODEL_STORAGE_KEY,
+} from '@/app/lib/aiModels';
 
 interface RecommendResult {
   show: Show;
@@ -68,6 +73,10 @@ export default function MoodPage() {
       });
 
       const profiles = buildViewerProfiles(shows, presentMembers);
+      const modelId = readStoredGeminiModel(
+        SHOWS_RECOMMEND_MODEL_STORAGE_KEY,
+        DEFAULT_RECOMMEND_GEMINI_MODEL,
+      );
 
       const res = await fetch('/api/recommend', {
         method: 'POST',
@@ -78,6 +87,7 @@ export default function MoodPage() {
           profiles,
           sharedMood: sharedMood.trim() || undefined,
           excludeIds: exclude,
+          modelId,
         }),
       });
       if (!res.ok) {
@@ -166,6 +176,7 @@ export default function MoodPage() {
                 </li>
                 <li>Reads each person&apos;s notes and ratings separately.</li>
                 <li>Prefers shows relevant to the viewers watching tonight.</li>
+                <li>Eligible picks include Watching, Planned, On Hold, and rewatchable Completed shows.</li>
                 <li>Uses status, progress, and service as secondary context.</li>
                 <li>Does not simply pick the highest-rated show.</li>
               </ul>
@@ -176,8 +187,8 @@ export default function MoodPage() {
         {candidates.length === 0 && (
           <div className="rounded-xl border border-dashed border-border p-6 text-center">
             <p className="text-text-2">
-              Add some shows with status <strong>Watching</strong>, <strong>Planned</strong>, or{' '}
-              <strong>On Hold</strong> first.
+              Add some shows with status <strong>Watching</strong>, <strong>Planned</strong>,{' '}
+              <strong>On Hold</strong>, or rewatchable <strong>Completed</strong> first.
             </p>
           </div>
         )}

--- a/app/tools/shows/settings/page.tsx
+++ b/app/tools/shows/settings/page.tsx
@@ -6,6 +6,17 @@ import { Shield, Trash2, UserMinus, CrownIcon, LogOut } from 'lucide-react';
 import Nav from '@/components/Nav';
 import { db } from '../lib/db';
 import { useShows } from '../ShowsContext';
+import {
+  AVAILABLE_GEMINI_MODELS,
+  DEFAULT_CLASSIFY_GEMINI_MODEL,
+  DEFAULT_RECOMMEND_GEMINI_MODEL,
+  geminiModelOptionLabel,
+  resolveGeminiModelId,
+  saveStoredGeminiModel,
+  SHOWS_CLASSIFY_MODEL_STORAGE_KEY,
+  SHOWS_RECOMMEND_MODEL_STORAGE_KEY,
+  type GeminiModelId,
+} from '@/app/lib/aiModels';
 
 function ConfirmDialog({
   message,
@@ -63,12 +74,43 @@ export default function SettingsPage() {
   const [inviteEmail, setInviteEmail] = useState('');
   const [newName, setNewName] = useState(activeList?.name ?? '');
   const [knownEmails, setKnownEmails] = useState<string[]>([]);
+  const [classifyModelId, setClassifyModelId] = useState<GeminiModelId>(DEFAULT_CLASSIFY_GEMINI_MODEL);
+  const [recommendModelId, setRecommendModelId] = useState<GeminiModelId>(DEFAULT_RECOMMEND_GEMINI_MODEL);
 
   // Display name state
   const [displayNameInput, setDisplayNameInput] = useState(userProfile?.displayName ?? '');
   useEffect(() => {
     setDisplayNameInput(userProfile?.displayName ?? '');
   }, [userProfile?.displayName]);
+
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setClassifyModelId(
+      resolveGeminiModelId(
+        window.localStorage.getItem(SHOWS_CLASSIFY_MODEL_STORAGE_KEY),
+        DEFAULT_CLASSIFY_GEMINI_MODEL,
+      ),
+    );
+    setRecommendModelId(
+      resolveGeminiModelId(
+        window.localStorage.getItem(SHOWS_RECOMMEND_MODEL_STORAGE_KEY),
+        DEFAULT_RECOMMEND_GEMINI_MODEL,
+      ),
+    );
+  }, []);
+
+  function handleClassifyModelChange(value: string) {
+    const modelId = resolveGeminiModelId(value, DEFAULT_CLASSIFY_GEMINI_MODEL);
+    setClassifyModelId(modelId);
+    saveStoredGeminiModel(SHOWS_CLASSIFY_MODEL_STORAGE_KEY, modelId);
+  }
+
+  function handleRecommendModelChange(value: string) {
+    const modelId = resolveGeminiModelId(value, DEFAULT_RECOMMEND_GEMINI_MODEL);
+    setRecommendModelId(modelId);
+    saveStoredGeminiModel(SHOWS_RECOMMEND_MODEL_STORAGE_KEY, modelId);
+  }
 
   useEffect(() => {
     getDocs(query(collection(db, 'artifacts', 'trip-cost', 'users'), limit(100)))
@@ -152,6 +194,59 @@ export default function SettingsPage() {
             {feedback}
           </p>
         )}
+
+
+        {/* AI model selection */}
+        <div className="rounded-xl border border-border bg-surface-1 p-4 space-y-4">
+          <div>
+            <h2 className="font-semibold text-sm">AI model selection</h2>
+            <p className="text-xs text-text-3 mt-0.5">
+              Choose Gemini models for this device only. Settings are saved locally in this browser.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="shows-classify-model" className="block text-sm font-medium text-text">
+              Classification AI Model
+            </label>
+            <select
+              id="shows-classify-model"
+              value={classifyModelId}
+              onChange={(e) => handleClassifyModelChange(e.target.value)}
+              className="w-full rounded-xl bg-surface-2 border border-border px-3 py-2.5 text-sm text-text focus:outline-none focus:border-accent min-h-[44px]"
+            >
+              {AVAILABLE_GEMINI_MODELS.map((model) => (
+                <option key={model.id} value={model.id}>
+                  {geminiModelOptionLabel(model)}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-text-3">
+              Default: Gemini 3.1 Flash-Lite, optimized for title lookup and classification.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="shows-recommend-model" className="block text-sm font-medium text-text">
+              Recommendation AI Model
+            </label>
+            <select
+              id="shows-recommend-model"
+              value={recommendModelId}
+              onChange={(e) => handleRecommendModelChange(e.target.value)}
+              className="w-full rounded-xl bg-surface-2 border border-border px-3 py-2.5 text-sm text-text focus:outline-none focus:border-accent min-h-[44px]"
+            >
+              {AVAILABLE_GEMINI_MODELS.map((model) => (
+                <option key={model.id} value={model.id}>
+                  {geminiModelOptionLabel(model)}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-text-3">
+              Default: Gemini 2.5 Flash, optimized for quality versus cost for watch picks.
+            </p>
+          </div>
+        </div>
 
         {/* Display name */}
         <div className="rounded-xl border border-border bg-surface-1 p-4 space-y-3">


### PR DESCRIPTION
### Motivation
- Provide per-device control over which Gemini model is used for title classification and recommendations to balance cost, speed, and quality.
- Make AI request construction model-aware so 2.5 vs 3.x models receive appropriate temperature/thinking settings and requests include the selected model id.
- Surface model choices in the Shows settings so local preferences are persisted to the device and used by the UI.
- Improve recommendation eligibility to include rewatchable completed shows when relevant viewers marked them as rewatchable.

### Description
- Add `app/lib/aiModels.ts` containing available Gemini model metadata, typed `GeminiModelId`, defaults, storage keys, and helpers to read/save/resolve model ids.
- Refactor `app/lib/aiConfig.ts` to export model-aware helpers: `buildGeminiRequest`, `callGemini`, `geminiEndpoint`, and types for `GeminiRequestOptions` with conditional temperature and `thinkingLevel` behavior based on model family.
- Update Edge API routes to accept and resolve `modelId`: `app/api/classify/route.ts` forwards `modelId` to the title resolver, and `app/api/recommend/route.ts` passes model options into `callGemini` including conditional temperature and `thinkingLevel`.
- Wire UI to per-device model preferences: add model selection in `app/tools/shows/settings/page.tsx`, persist selections to `localStorage`, and read them from `ShowForm.tsx` and `mood/page.tsx` when calling `/api/classify` and `/api/recommend`.
- Make recommendation eligibility more nuanced in `app/tools/shows/lib/recommendationContext.ts` so completed shows are eligible only when relevant viewers marked `wouldRewatch` as `yes` or `maybe` and update `candidateShows` accordingly.
- Update tests and documentation: modify `app/tools/shows/__tests__/recommendationContext.test.ts` to reflect new eligibility rules, and update `AI_AGENTS.md`, `ARCHITECTURE.md`, and `README.md` to document the Shows tool and AI model selection.

### Testing
- Ran the shows unit tests with `vitest` (specifically `app/tools/shows/__tests__/recommendationContext.test.ts`) and all tests passed.
- Performed a TypeScript type check with `tsc --noEmit` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a288c18bdf083209f67428709a75310)