### PR TITLE
CalorieTracker: critical security & data-integrity fixes (#1, #2, #3, #4)

### DIFF
--- a/public/tools/CalorieTracker/BACKLOG.md
+++ b/public/tools/CalorieTracker/BACKLOG.md
@@ -144,19 +144,19 @@ green and add tests for new validators or pure functions.
 
 - [p] **#1 — XSS via user-named foods**
   `food/save.js:141-162`, `food/manager.js:99` — food names are user-controlled and rendered via template-literal `innerHTML`. Replace with `textContent` / DOM construction at every point where `f.name` or `d.nutrient` enters the DOM.
-  > pushed — escapeHtml helper in utils/ui.js; applied to data.js, manager.js, save.js, analysisUI.js; dropdown.js rebuilt with DOM construction + addEventListener; tests: 568 pass; commit: 0297bfb
+  > pushed — escapeHtml helper in utils/ui.js; applied to data.js, manager.js, save.js, analysisUI.js; dropdown.js rebuilt with DOM construction + addEventListener; tests: 568 pass; commit: 9fbc6d1
 
 - [p] **#2 — No max bounds on nutrient inputs**
   `index.html:166-202`, `events/wire.js:132` — user can save `99999999` kcal, breaking all downstream calculations. Add per-nutrient `max` HTML attributes and a JS validation gate before any Firestore write (kcal ≤ 10 000, macros ≤ 1 000 g, micros at 10× UL).
-  > pushed — HTML max attrs on all actual-* inputs + NUTRIENT_MAX_BOUNDS map in constants.js + clampNutrient gate in getStagedValues; tests: 568 pass; commit: 0297bfb
+  > pushed — HTML max attrs on all actual-* inputs + NUTRIENT_MAX_BOUNDS map in constants.js + clampNutrient gate in getStagedValues; tests: 568 pass; commit: 9fbc6d1
 
 - [p] **#3 — Date-change race condition**
   `services/data.js:142`, `ui/dashboard.js:148` — changing the date mid-fetch lets a stale response overwrite the UI with the wrong day's food items. Tag each in-flight request with the requested date string and discard any response that doesn't match the current selection.
-  > pushed — monotonic _dateChangeToken counter in wire.js; stale handlers bail before rendering; tests: 568 pass; commit: 0297bfb
+  > pushed — monotonic _dateChangeToken counter in wire.js; stale handlers bail before rendering; tests: 568 pass; commit: 9fbc6d1
 
 - [p] **#4 — Silent Firestore fetch failures default to empty `{}`**
   `services/firebase.js:121` — a network blip reads as "no saved targets," so users unknowingly run on system defaults with no indication. Surface a visible banner, retry with exponential backoff, and distinguish "load error" from "empty."
-  > pushed — fetch functions now throw on error; loadUserData retries 3× with exponential backoff and shows persistent load-error-banner; tests: 568 pass; commit: 0297bfb
+  > pushed — fetch functions now throw on error; loadUserData retries 3× with exponential backoff and shows persistent load-error-banner; tests: 568 pass; commit: 9fbc6d1
 
 - [ ] **#5 — Tab bar overflows ≤ 360 px with no scroll affordance**
   `styles.css:326-334` — five tabs at `flex: 0 0 auto` total ~450 px, silently clipping Profile & Settings on iPhone SE / small Android. The scrollbar is hidden with no visual indicator. Add scroll-shadow edge fades at both ends, or convert to a "more" overflow menu under 640 px.

--- a/public/tools/CalorieTracker/BACKLOG.md
+++ b/public/tools/CalorieTracker/BACKLOG.md
@@ -148,7 +148,7 @@ green and add tests for new validators or pure functions.
 
 - [p] **#2 — No max bounds on nutrient inputs**
   `index.html:166-202`, `events/wire.js:132` — user can save `99999999` kcal, breaking all downstream calculations. Add per-nutrient `max` HTML attributes and a JS validation gate before any Firestore write (kcal ≤ 10 000, macros ≤ 1 000 g, micros at 10× UL).
-  > pushed — HTML max attrs on actual-* and target-* inputs + NUTRIENT_MAX_BOUNDS in constants.js + clampNutrient in getStagedValues, wireSettingsEvents, collectManualOverrides; override grid inputs bounded; tests: 568 pass; commit: _pending-push_
+  > pushed — HTML max attrs on actual-* and target-* inputs + NUTRIENT_MAX_BOUNDS in constants.js + clampNutrient in getStagedValues, wireSettingsEvents, collectManualOverrides; override grid inputs bounded; tests: 568 pass; commit: 716326e
 
 - [p] **#3 — Date-change race condition**
   `services/data.js:142`, `ui/dashboard.js:148` — changing the date mid-fetch lets a stale response overwrite the UI with the wrong day's food items. Tag each in-flight request with the requested date string and discard any response that doesn't match the current selection.
@@ -156,7 +156,7 @@ green and add tests for new validators or pure functions.
 
 - [p] **#4 — Silent Firestore fetch failures default to empty `{}`**
   `services/firebase.js:121` — a network blip reads as "no saved targets," so users unknowingly run on system defaults with no indication. Surface a visible banner, retry with exponential backoff, and distinguish "load error" from "empty."
-  > pushed — all five initial-load fetches (targets, entries, weight, profile, goals) now throw on error; loadUserData retries 3× with backoff and shows persistent load-error-banner; tests: 568 pass; commit: _pending-push_
+  > pushed — all five initial-load fetches (targets, entries, weight, profile, goals) now throw on error; loadUserData retries 3× with backoff and shows persistent load-error-banner; tests: 568 pass; commit: 716326e
 
 - [ ] **#5 — Tab bar overflows ≤ 360 px with no scroll affordance**
   `styles.css:326-334` — five tabs at `flex: 0 0 auto` total ~450 px, silently clipping Profile & Settings on iPhone SE / small Android. The scrollbar is hidden with no visual indicator. Add scroll-shadow edge fades at both ends, or convert to a "more" overflow menu under 640 px.

--- a/public/tools/CalorieTracker/BACKLOG.md
+++ b/public/tools/CalorieTracker/BACKLOG.md
@@ -148,7 +148,7 @@ green and add tests for new validators or pure functions.
 
 - [p] **#2 — No max bounds on nutrient inputs**
   `index.html:166-202`, `events/wire.js:132` — user can save `99999999` kcal, breaking all downstream calculations. Add per-nutrient `max` HTML attributes and a JS validation gate before any Firestore write (kcal ≤ 10 000, macros ≤ 1 000 g, micros at 10× UL).
-  > pushed — HTML max attrs on all actual-* inputs + NUTRIENT_MAX_BOUNDS map in constants.js + clampNutrient gate in getStagedValues; tests: 568 pass; commit: 9fbc6d1
+  > pushed — HTML max attrs on actual-* and target-* inputs + NUTRIENT_MAX_BOUNDS in constants.js + clampNutrient in getStagedValues, wireSettingsEvents, collectManualOverrides; override grid inputs bounded; tests: 568 pass; commit: _pending-push_
 
 - [p] **#3 — Date-change race condition**
   `services/data.js:142`, `ui/dashboard.js:148` — changing the date mid-fetch lets a stale response overwrite the UI with the wrong day's food items. Tag each in-flight request with the requested date string and discard any response that doesn't match the current selection.
@@ -156,7 +156,7 @@ green and add tests for new validators or pure functions.
 
 - [p] **#4 — Silent Firestore fetch failures default to empty `{}`**
   `services/firebase.js:121` — a network blip reads as "no saved targets," so users unknowingly run on system defaults with no indication. Surface a visible banner, retry with exponential backoff, and distinguish "load error" from "empty."
-  > pushed — fetch functions now throw on error; loadUserData retries 3× with exponential backoff and shows persistent load-error-banner; tests: 568 pass; commit: 9fbc6d1
+  > pushed — all five initial-load fetches (targets, entries, weight, profile, goals) now throw on error; loadUserData retries 3× with backoff and shows persistent load-error-banner; tests: 568 pass; commit: _pending-push_
 
 - [ ] **#5 — Tab bar overflows ≤ 360 px with no scroll affordance**
   `styles.css:326-334` — five tabs at `flex: 0 0 auto` total ~450 px, silently clipping Profile & Settings on iPhone SE / small Android. The scrollbar is hidden with no visual indicator. Add scroll-shadow edge fades at both ends, or convert to a "more" overflow menu under 640 px.

--- a/public/tools/CalorieTracker/BACKLOG.md
+++ b/public/tools/CalorieTracker/BACKLOG.md
@@ -135,28 +135,28 @@ From `public/tools/CalorieTracker/`:
 npm test
 ```
 
-Baseline: **554 tests, 8 files, all passing.** Any session that changes logic must keep this
+Baseline: **568 tests, 9 files, all passing.** Any session that changes logic must keep this
 green and add tests for new validators or pure functions.
 
 ---
 
 ## CRITICAL — fix before broader rollout
 
-- [ ] **#1 — XSS via user-named foods**
+- [p] **#1 — XSS via user-named foods**
   `food/save.js:141-162`, `food/manager.js:99` — food names are user-controlled and rendered via template-literal `innerHTML`. Replace with `textContent` / DOM construction at every point where `f.name` or `d.nutrient` enters the DOM.
-  > Resolved in: _pending_
+  > pushed — escapeHtml helper in utils/ui.js; applied to data.js, manager.js, save.js, analysisUI.js; dropdown.js rebuilt with DOM construction + addEventListener; tests: 568 pass; commit: 0297bfb
 
-- [ ] **#2 — No max bounds on nutrient inputs**
+- [p] **#2 — No max bounds on nutrient inputs**
   `index.html:166-202`, `events/wire.js:132` — user can save `99999999` kcal, breaking all downstream calculations. Add per-nutrient `max` HTML attributes and a JS validation gate before any Firestore write (kcal ≤ 10 000, macros ≤ 1 000 g, micros at 10× UL).
-  > Resolved in: _pending_
+  > pushed — HTML max attrs on all actual-* inputs + NUTRIENT_MAX_BOUNDS map in constants.js + clampNutrient gate in getStagedValues; tests: 568 pass; commit: 0297bfb
 
-- [ ] **#3 — Date-change race condition**
+- [p] **#3 — Date-change race condition**
   `services/data.js:142`, `ui/dashboard.js:148` — changing the date mid-fetch lets a stale response overwrite the UI with the wrong day's food items. Tag each in-flight request with the requested date string and discard any response that doesn't match the current selection.
-  > Resolved in: _pending_
+  > pushed — monotonic _dateChangeToken counter in wire.js; stale handlers bail before rendering; tests: 568 pass; commit: 0297bfb
 
-- [ ] **#4 — Silent Firestore fetch failures default to empty `{}`**
+- [p] **#4 — Silent Firestore fetch failures default to empty `{}`**
   `services/firebase.js:121` — a network blip reads as "no saved targets," so users unknowingly run on system defaults with no indication. Surface a visible banner, retry with exponential backoff, and distinguish "load error" from "empty."
-  > Resolved in: _pending_
+  > pushed — fetch functions now throw on error; loadUserData retries 3× with exponential backoff and shows persistent load-error-banner; tests: 568 pass; commit: 0297bfb
 
 - [ ] **#5 — Tab bar overflows ≤ 360 px with no scroll affordance**
   `styles.css:326-334` — five tabs at `flex: 0 0 auto` total ~450 px, silently clipping Profile & Settings on iPhone SE / small Android. The scrollbar is hidden with no visual indicator. Add scroll-shadow edge fades at both ends, or convert to a "more" overflow menu under 640 px.
@@ -216,9 +216,9 @@ green and add tests for new validators or pure functions.
   There is no undo path after confirmation. Add a 5-second undo toast that re-adds the item before it is written to Firestore, giving users a quick recovery window.
   > Resolved in: _pending_
 
-- [p] **#46 — "Current weight required" nag fires regardless of weigh-in age**
+- [x] **#46 — "Current weight required" nag fires regardless of weigh-in age**
   `targets/targetEngine.js`, `analysis/engine.js`, `targets/targetUI.js`, `constants.js` — the notice showed unconditionally, on a debounced auto-calc that runs before data loads. Now the current weight is estimated forward from the last weigh-in via energy balance (`projectWeightForward`: calories-in − TDEE since the last weigh-in, water-corrected smoothed baseline, drift-capped); the hard "Current weight is required" notice shows only on an explicit Auto-Calculate when there is no weight data at all; and a soft, non-blocking notice appears only when the last weigh-in is older than `WEIGHT_FRESHNESS_THRESHOLD_DAYS` (21).
-  > pushed — energy-balance current-weight estimate + 21-day freshness gate; tests: 554 pass; commit: be6d028
+  > Resolved: energy-balance current-weight estimate + 21-day freshness gate; tests: 554 pass; merged be6d028
 
 ---
 
@@ -385,4 +385,4 @@ Run from `public/tools/CalorieTracker/`:
 node_modules/.bin/vitest run
 ```
 
-Baseline: **554 tests, 8 files, all passing.** Any session that changes logic files must keep this green. Add tests for new validators, the date-change cancellation token, and any new pure functions introduced.
+Baseline: **568 tests, 9 files, all passing.** Any session that changes logic files must keep this green. Add tests for new validators, the date-change cancellation token, and any new pure functions introduced.

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -18,7 +18,7 @@ import {
 } from './engine.js';
 import { buildEatingPatternTargetSeries } from '../targets/targetEngine.js';
 import { handleWeightUpload } from './weightUpload.js';
-import { debugLog, showMessage } from '../utils/ui.js';
+import { debugLog, showMessage, escapeHtml } from '../utils/ui.js';
 import { CONFIG } from '../config.js';
 import { getTodayInTimezone } from '../utils/time.js';
 import {
@@ -1343,7 +1343,7 @@ function renderMissingCaloriesSection(candidates) {
       ? `<details class="inline text-xs mt-1"><summary class="cursor-pointer text-accent">Interval math ▸</summary>
           <div class="mt-1 space-y-1 pl-1">
             ${r.intervalsUsed.map(i => `<div class="border-l-2 border-accent/30 pl-2">
-              <strong>${i.name}</strong> [${i.intervalStart} – ${i.intervalEnd}]:
+              <strong>${escapeHtml(i.name)}</strong> [${i.intervalStart} – ${i.intervalEnd}]:
               gap ${i.perDayResidual > 0 ? '+' : ''}${i.perDayResidual} kcal/day
               ${i.reportedIntake != null ? ` · logged ${i.reportedIntake} kcal` : ''}
               ${i.expectedExpenditure != null ? ` · TDEE-est ${i.expectedExpenditure} kcal` : ''}
@@ -1580,7 +1580,7 @@ function renderEstimateManagementSection() {
     const removeButtons = syntheticItems.map(fi => `
       <button class="estimate-remove-btn btn btn-secondary btn-sm"
               data-date="${dateStr}" data-item-id="${fi.id}"
-              title="Remove '${fi.name}' from this day">
+              title="Remove '${escapeHtml(fi.name)}' from this day">
         <i class="fas fa-trash-alt mr-1"></i>Remove
       </button>
     `).join('');

--- a/public/tools/CalorieTracker/constants.js
+++ b/public/tools/CalorieTracker/constants.js
@@ -131,6 +131,17 @@ export const DEFAULT_TARGETS = {
   omega3: 1.6
 };
 
+// Per-nutrient upper bounds for input validation (roughly 10× UL or physiological max).
+export const NUTRIENT_MAX_BOUNDS = {
+  calories: 10000, protein: 1000, carbs: 1000, fat: 1000,
+  fiber: 500, potassium: 50000, magnesium: 10000, sodium: 23000,
+  calcium: 25000, choline: 35000,
+  vitaminB12: 10000, folate: 10000, vitaminC: 20000, vitaminB6: 1000,
+  vitaminA: 30000, vitaminD: 1000, vitaminE: 10000, vitaminK: 10000,
+  selenium: 4000, iodine: 11000, phosphorus: 40000,
+  iron: 450, zinc: 400, omega3: 100,
+};
+
 // Maps text variants to canonical nutrient keys.
 // Ordered from most specific to least specific to avoid prefix conflicts.
 export const nutrientMap = {

--- a/public/tools/CalorieTracker/events/wire.js
+++ b/public/tools/CalorieTracker/events/wire.js
@@ -162,6 +162,11 @@ function wireSettingsEvents() {
   }
 }
 
+// Token to detect stale date-change renders: each date-change increments this
+// counter; if a second change fires before the first finishes, the first's
+// post-render steps bail out so they don't overwrite the newer date's data.
+let _dateChangeToken = 0;
+
 /**
  * Wire up main control events including date and day activity level
  */
@@ -170,13 +175,16 @@ function wireMainControls() {
     // Date input change handler
     if (state.dom.dateInput) {
       state.dom.dateInput.addEventListener('change', async () => {
+        const token = ++_dateChangeToken;
         try {
           await loadDailyFoodItems();
+          if (token !== _dateChangeToken) return;
           loadDayActivityForDate();
           updateDashboard();
           updateChart();
           debugLog('wire-date', 'Date changed and UI updated');
         } catch (error) {
+          if (token !== _dateChangeToken) return;
           handleError('wire-date-change', error, 'Failed to handle date change');
         }
       });

--- a/public/tools/CalorieTracker/events/wire.js
+++ b/public/tools/CalorieTracker/events/wire.js
@@ -19,7 +19,7 @@ import { saveTargets, saveDailyEntry } from '../services/firebase.js';
 import { allNutrients } from '../constants.js';
 import { updateDashboard, activateTab } from '../ui/dashboard.js';
 import { updateChart } from '../ui/chart.js';
-import { debugLog, handleError } from '../utils/ui.js';
+import { debugLog, handleError, clampNutrient } from '../utils/ui.js';
 import {
   ACTIVITY_TYPES,
   estimateSessionCalories,
@@ -125,18 +125,18 @@ function wireSettingsEvents() {
         try {
           const newTargets = {};
           
-          // Get all nutrient targets
+          // Get all nutrient targets (clamped to safe bounds)
           allNutrients.forEach(nutrient => {
             const input = document.getElementById(`target-${nutrient}`);
             if (input) {
-              newTargets[nutrient] = parseFloat(input.value) || 0;
+              newTargets[nutrient] = clampNutrient(nutrient, parseFloat(input.value) || 0);
             }
           });
-          
-          // Get banking-specific settings
+
+          // Get banking-specific settings (fat floor uses same bound as fat macro)
           const fatMinInput = document.getElementById('target-fatMinimum');
           if (fatMinInput) {
-            newTargets.fatMinimum = parseFloat(fatMinInput.value) || 50;
+            newTargets.fatMinimum = clampNutrient('fat', parseFloat(fatMinInput.value) || 50);
           }
 
           await saveTargets(newTargets);

--- a/public/tools/CalorieTracker/food/dropdown.js
+++ b/public/tools/CalorieTracker/food/dropdown.js
@@ -100,11 +100,31 @@ export function performFoodSearch(searchTerm) {
 export function showFoodDropdown(matches) {
   const dropdownContainer = document.getElementById('food-dropdown');
   state.selectedDropdownIndex = -1;
-  dropdownContainer.innerHTML = matches.map((f, idx) => `
-    <div class="food-dropdown-item" data-food-name="${f.name}" onclick="selectFoodItem('${(f.name || '').replace(/'/g, "\\'")}')" data-index="${idx}">
-      <div class="font-medium">${f.name}</div>
-      <div class="text-xs text-gray-500">Cal: ${f.calories || 0} | P: ${f.protein || 0} / C: ${f.carbs || 0} / F: ${f.fat || 0}</div>
-    </div>`).join('');
+  // Build with DOM nodes + textContent rather than innerHTML: food names are
+  // user-controlled and would otherwise be an XSS vector (and break a quoted
+  // inline onclick handler).
+  dropdownContainer.replaceChildren();
+  matches.forEach((f, idx) => {
+    const name = f.name || '';
+
+    const itemEl = document.createElement('div');
+    itemEl.className = 'food-dropdown-item';
+    itemEl.dataset.foodName = name;
+    itemEl.dataset.index = String(idx);
+    itemEl.addEventListener('click', () => window.selectFoodItem(name));
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'font-medium';
+    nameEl.textContent = name;
+
+    const macroEl = document.createElement('div');
+    macroEl.className = 'text-xs text-gray-500';
+    macroEl.textContent =
+      `Cal: ${f.calories || 0} | P: ${f.protein || 0} / C: ${f.carbs || 0} / F: ${f.fat || 0}`;
+
+    itemEl.append(nameEl, macroEl);
+    dropdownContainer.appendChild(itemEl);
+  });
   dropdownContainer.classList.remove('hidden');
   state.foodDropdownVisible = true;
 }

--- a/public/tools/CalorieTracker/food/manager.js
+++ b/public/tools/CalorieTracker/food/manager.js
@@ -9,7 +9,7 @@ import { allNutrients } from '../constants.js';
 import { showConfirmationModal } from '../ui/modals.js';
 import { saveDailyEntry, deleteFoodItem } from '../services/firebase.js';
 import { updateFoodItemsList, getCurrentDailyEntry } from '../services/data.js';
-import { showMessage, handleError } from '../utils/ui.js';
+import { showMessage, handleError, escapeHtml } from '../utils/ui.js';
 import { hideFoodDropdown } from './dropdown.js';
 import { updateDashboard } from '../ui/dashboard.js';
 import { updateChart } from '../ui/chart.js';
@@ -99,7 +99,7 @@ export function openFoodManager() {
   container.innerHTML = list.map(([id, f]) => `
     <div class="flex justify-between items-center p-3 border-b border-default">
       <div>
-        <div class="font-medium">${f.name}</div>
+        <div class="font-medium">${escapeHtml(f.name)}</div>
         <div class="text-sm text-muted">Cal: ${f.calories || 0} | P: ${f.protein || 0} / C: ${f.carbs || 0} / F: ${f.fat || 0} | Qty: ${f.quantity ?? 0}</div>
       </div>
       <div class="flex gap-2">

--- a/public/tools/CalorieTracker/food/save.js
+++ b/public/tools/CalorieTracker/food/save.js
@@ -6,7 +6,7 @@
 
 import { state } from '../state/store.js';
 import { allNutrients } from '../constants.js';
-import { showMessage, handleError, formatNutrientName } from '../utils/ui.js';
+import { showMessage, handleError, formatNutrientName, escapeHtml } from '../utils/ui.js';
 import { showConfirmationModal, closeDuplicateDialog } from '../ui/modals.js';
 import { db } from '../services/firebase.js';
 import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
@@ -139,7 +139,7 @@ function showDuplicateDialog(existingFood, newValues, foodName) {
   });
 
   container.innerHTML = `
-    <h3 class="text-lg font-semibold mb-4">Food item "${foodName}" already exists with different values:</h3>
+    <h3 class="text-lg font-semibold mb-4">Food item "${escapeHtml(foodName)}" already exists with different values:</h3>
     <div class="overflow-x-auto mb-6">
       <table class="min-w-full bg-white border border-gray-300">
         <thead class="bg-gray-50">

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -165,40 +165,40 @@
                   <label for="actual-quantity" class="block text-sm font-medium text-secondary mb-1">Qty</label>
                   <input id="actual-quantity" type="number" step="0.01" min="0" value="1">
                 </div>
-                <div><label for="actual-calories" class="block text-sm font-medium text-primary mb-1">Calories</label><input type="number" step="any" id="actual-calories"></div>
-                <div><label for="actual-protein"  class="block text-sm font-medium text-primary mb-1">Protein (g)</label><input type="number" step="any" id="actual-protein"></div>
-                <div><label for="actual-carbs"    class="block text-sm font-medium text-primary mb-1">Carbs (g)</label><input type="number" step="any" id="actual-carbs"></div>
-                <div><label for="actual-fat"      class="block text-sm font-medium text-primary mb-1">Fat (g)</label><input type="number" step="any" id="actual-fat"></div>
+                <div><label for="actual-calories" class="block text-sm font-medium text-primary mb-1">Calories</label><input type="number" step="any" min="0" max="10000" id="actual-calories"></div>
+                <div><label for="actual-protein"  class="block text-sm font-medium text-primary mb-1">Protein (g)</label><input type="number" step="any" min="0" max="1000" id="actual-protein"></div>
+                <div><label for="actual-carbs"    class="block text-sm font-medium text-primary mb-1">Carbs (g)</label><input type="number" step="any" min="0" max="1000" id="actual-carbs"></div>
+                <div><label for="actual-fat"      class="block text-sm font-medium text-primary mb-1">Fat (g)</label><input type="number" step="any" min="0" max="1000" id="actual-fat"></div>
 
                 <h4 class="text-lg font-semibold text-secondary pt-4 staging-sticky">Daily Vitamins</h4>
-                <div><label for="actual-vitaminB12" class="block text-sm font-medium text-primary mb-1">Vitamin B12 (mcg)</label><input type="number" step="any" id="actual-vitaminB12"></div>
-                <div><label for="actual-folate"     class="block text-sm font-medium text-primary mb-1">Folate (mcg)</label><input type="number" step="any" id="actual-folate"></div>
-                <div><label for="actual-vitaminC"   class="block text-sm font-medium text-primary mb-1">Vitamin C (mg)</label><input type="number" step="any" id="actual-vitaminC"></div>
-                <div><label for="actual-vitaminB6"  class="block text-sm font-medium text-primary mb-1">Vitamin B6 (mg)</label><input type="number" step="any" id="actual-vitaminB6"></div>
+                <div><label for="actual-vitaminB12" class="block text-sm font-medium text-primary mb-1">Vitamin B12 (mcg)</label><input type="number" step="any" min="0" max="10000" id="actual-vitaminB12"></div>
+                <div><label for="actual-folate"     class="block text-sm font-medium text-primary mb-1">Folate (mcg)</label><input type="number" step="any" min="0" max="10000" id="actual-folate"></div>
+                <div><label for="actual-vitaminC"   class="block text-sm font-medium text-primary mb-1">Vitamin C (mg)</label><input type="number" step="any" min="0" max="20000" id="actual-vitaminC"></div>
+                <div><label for="actual-vitaminB6"  class="block text-sm font-medium text-primary mb-1">Vitamin B6 (mg)</label><input type="number" step="any" min="0" max="1000" id="actual-vitaminB6"></div>
 
                 <h4 class="text-lg font-semibold text-secondary pt-4 staging-sticky">Averaged Vitamins</h4>
-                <div><label for="actual-vitaminA" class="block text-sm font-medium text-primary mb-1">Vitamin A (mcg)</label><input type="number" step="any" id="actual-vitaminA"></div>
-                <div><label for="actual-vitaminD" class="block text-sm font-medium text-primary mb-1">Vitamin D (mcg)</label><input type="number" step="any" id="actual-vitaminD"></div>
-                <div><label for="actual-vitaminE" class="block text-sm font-medium text-primary mb-1">Vitamin E (mg)</label><input type="number" step="any" id="actual-vitaminE"></div>
-                <div><label for="actual-vitaminK" class="block text-sm font-medium text-primary mb-1">Vitamin K (mcg)</label><input type="number" step="any" id="actual-vitaminK"></div>
+                <div><label for="actual-vitaminA" class="block text-sm font-medium text-primary mb-1">Vitamin A (mcg)</label><input type="number" step="any" min="0" max="30000" id="actual-vitaminA"></div>
+                <div><label for="actual-vitaminD" class="block text-sm font-medium text-primary mb-1">Vitamin D (mcg)</label><input type="number" step="any" min="0" max="1000" id="actual-vitaminD"></div>
+                <div><label for="actual-vitaminE" class="block text-sm font-medium text-primary mb-1">Vitamin E (mg)</label><input type="number" step="any" min="0" max="10000" id="actual-vitaminE"></div>
+                <div><label for="actual-vitaminK" class="block text-sm font-medium text-primary mb-1">Vitamin K (mcg)</label><input type="number" step="any" min="0" max="10000" id="actual-vitaminK"></div>
 
                 <h4 class="text-lg font-semibold text-secondary pt-4 staging-sticky">Daily Minerals</h4>
-                <div><label for="actual-iron"      class="block text-sm font-medium text-primary mb-1">Iron (mg)</label><input type="number" step="any" id="actual-iron"></div>
-                <div><label for="actual-calcium"   class="block text-sm font-medium text-primary mb-1">Calcium (mg)</label><input type="number" step="any" id="actual-calcium"></div>
-                <div><label for="actual-magnesium" class="block text-sm font-medium text-primary mb-1">Magnesium (mg)</label><input type="number" step="any" id="actual-magnesium"></div>
-                <div><label for="actual-zinc"      class="block text-sm font-medium text-primary mb-1">Zinc (mg)</label><input type="number" step="any" id="actual-zinc"></div>
-                <div><label for="actual-potassium" class="block text-sm font-medium text-primary mb-1">Potassium (mg)</label><input type="number" step="any" id="actual-potassium"></div>
-                <div><label for="actual-sodium"    class="block text-sm font-medium text-primary mb-1">Sodium (mg)</label><input type="number" step="any" id="actual-sodium"></div>
+                <div><label for="actual-iron"      class="block text-sm font-medium text-primary mb-1">Iron (mg)</label><input type="number" step="any" min="0" max="450" id="actual-iron"></div>
+                <div><label for="actual-calcium"   class="block text-sm font-medium text-primary mb-1">Calcium (mg)</label><input type="number" step="any" min="0" max="25000" id="actual-calcium"></div>
+                <div><label for="actual-magnesium" class="block text-sm font-medium text-primary mb-1">Magnesium (mg)</label><input type="number" step="any" min="0" max="10000" id="actual-magnesium"></div>
+                <div><label for="actual-zinc"      class="block text-sm font-medium text-primary mb-1">Zinc (mg)</label><input type="number" step="any" min="0" max="400" id="actual-zinc"></div>
+                <div><label for="actual-potassium" class="block text-sm font-medium text-primary mb-1">Potassium (mg)</label><input type="number" step="any" min="0" max="50000" id="actual-potassium"></div>
+                <div><label for="actual-sodium"    class="block text-sm font-medium text-primary mb-1">Sodium (mg)</label><input type="number" step="any" min="0" max="23000" id="actual-sodium"></div>
 
                 <h4 class="text-lg font-semibold text-secondary pt-4 staging-sticky">Averaged Minerals</h4>
-                <div><label for="actual-selenium"   class="block text-sm font-medium text-primary mb-1">Selenium (mcg)</label><input type="number" step="any" id="actual-selenium"></div>
-                <div><label for="actual-iodine"     class="block text-sm font-medium text-primary mb-1">Iodine (mcg)</label><input type="number" step="any" id="actual-iodine"></div>
-                <div><label for="actual-phosphorus" class="block text-sm font-medium text-primary mb-1">Phosphorus (mg)</label><input type="number" step="any" id="actual-phosphorus"></div>
+                <div><label for="actual-selenium"   class="block text-sm font-medium text-primary mb-1">Selenium (mcg)</label><input type="number" step="any" min="0" max="4000" id="actual-selenium"></div>
+                <div><label for="actual-iodine"     class="block text-sm font-medium text-primary mb-1">Iodine (mcg)</label><input type="number" step="any" min="0" max="11000" id="actual-iodine"></div>
+                <div><label for="actual-phosphorus" class="block text-sm font-medium text-primary mb-1">Phosphorus (mg)</label><input type="number" step="any" min="0" max="40000" id="actual-phosphorus"></div>
 
                 <h4 class="text-lg font-semibold text-secondary pt-4 staging-sticky">Optional</h4>
-                <div><label for="actual-omega3"  class="block text-sm font-medium text-primary mb-1">Omega-3 (g)</label><input type="number" step="any" id="actual-omega3"></div>
-                <div><label for="actual-fiber"   class="block text-sm font-medium text-primary mb-1">Fiber (g)</label><input type="number" step="any" id="actual-fiber"></div>
-                <div><label for="actual-choline" class="block text-sm font-medium text-primary mb-1">Choline (mg)</label><input type="number" step="any" id="actual-choline"></div>
+                <div><label for="actual-omega3"  class="block text-sm font-medium text-primary mb-1">Omega-3 (g)</label><input type="number" step="any" min="0" max="100" id="actual-omega3"></div>
+                <div><label for="actual-fiber"   class="block text-sm font-medium text-primary mb-1">Fiber (g)</label><input type="number" step="any" min="0" max="500" id="actual-fiber"></div>
+                <div><label for="actual-choline" class="block text-sm font-medium text-primary mb-1">Choline (mg)</label><input type="number" step="any" min="0" max="35000" id="actual-choline"></div>
               </div>
             </div>
           </details>

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -529,10 +529,10 @@
           <div class="settings-section">
             <h3 class="text-lg font-semibold text-secondary mb-4">Macros</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-calories" class="block text-sm font-medium text-primary mb-1">Calories</label><input type="number" step="any" id="target-calories"></div>
-              <div><label for="target-protein"  class="block text-sm font-medium text-primary mb-1">Protein (g)</label><input type="number" step="any" id="target-protein"></div>
-              <div><label for="target-carbs"    class="block text-sm font-medium text-primary mb-1">Carbs (g)</label><input type="number" step="any" id="target-carbs"></div>
-              <div><label for="target-fat"      class="block text-sm font-medium text-primary mb-1">Fat (g)</label><input type="number" step="any" id="target-fat"></div>
+              <div><label for="target-calories" class="block text-sm font-medium text-primary mb-1">Calories</label><input type="number" step="any" min="0" max="10000" id="target-calories"></div>
+              <div><label for="target-protein"  class="block text-sm font-medium text-primary mb-1">Protein (g)</label><input type="number" step="any" min="0" max="1000" id="target-protein"></div>
+              <div><label for="target-carbs"    class="block text-sm font-medium text-primary mb-1">Carbs (g)</label><input type="number" step="any" min="0" max="1000" id="target-carbs"></div>
+              <div><label for="target-fat"      class="block text-sm font-medium text-primary mb-1">Fat (g)</label><input type="number" step="any" min="0" max="1000" id="target-fat"></div>
             </div>
           </div>
 
@@ -541,7 +541,7 @@
             <div class="grid grid-cols-1 gap-4">
               <div>
                 <label for="target-fatMinimum" class="block text-sm font-medium text-primary mb-1">Minimum Fat (g)</label>
-                <input type="number" step="any" id="target-fatMinimum" title="Minimum daily fat intake in grams (default: 50)">
+                <input type="number" step="any" min="0" max="1000" id="target-fatMinimum" title="Minimum daily fat intake in grams (default: 50)">
               </div>
             </div>
           </div>
@@ -549,50 +549,50 @@
           <div class="settings-section">
             <h3 class="text-lg font-semibold text-secondary mb-4">Daily Vitamins (Water-Soluble)</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-vitaminB12" class="block text-sm font-medium text-primary mb-1">Vitamin B12 (mcg)</label><input type="number" step="any" id="target-vitaminB12"></div>
-              <div><label for="target-folate"     class="block text-sm font-medium text-primary mb-1">Folate (mcg)</label><input type="number" step="any" id="target-folate"></div>
-              <div><label for="target-vitaminC"   class="block text-sm font-medium text-primary mb-1">Vitamin C (mg)</label><input type="number" step="any" id="target-vitaminC"></div>
-              <div><label for="target-vitaminB6"  class="block text-sm font-medium text-primary mb-1">Vitamin B6 (mg)</label><input type="number" step="any" id="target-vitaminB6"></div>
+              <div><label for="target-vitaminB12" class="block text-sm font-medium text-primary mb-1">Vitamin B12 (mcg)</label><input type="number" step="any" min="0" max="10000" id="target-vitaminB12"></div>
+              <div><label for="target-folate"     class="block text-sm font-medium text-primary mb-1">Folate (mcg)</label><input type="number" step="any" min="0" max="10000" id="target-folate"></div>
+              <div><label for="target-vitaminC"   class="block text-sm font-medium text-primary mb-1">Vitamin C (mg)</label><input type="number" step="any" min="0" max="20000" id="target-vitaminC"></div>
+              <div><label for="target-vitaminB6"  class="block text-sm font-medium text-primary mb-1">Vitamin B6 (mg)</label><input type="number" step="any" min="0" max="1000" id="target-vitaminB6"></div>
             </div>
           </div>
 
           <div class="settings-section">
             <h3 class="text-lg font-semibold text-secondary mb-4">Averaged Vitamins (Fat-Soluble)</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-vitaminA" class="block text-sm font-medium text-primary mb-1">Vitamin A (mcg)</label><input type="number" step="any" id="target-vitaminA"></div>
-              <div><label for="target-vitaminD" class="block text-sm font-medium text-primary mb-1">Vitamin D (mcg)</label><input type="number" step="any" id="target-vitaminD"></div>
-              <div><label for="target-vitaminE" class="block text-sm font-medium text-primary mb-1">Vitamin E (mg)</label><input type="number" step="any" id="target-vitaminE"></div>
-              <div><label for="target-vitaminK" class="block text-sm font-medium text-primary mb-1">Vitamin K (mcg)</label><input type="number" step="any" id="target-vitaminK"></div>
+              <div><label for="target-vitaminA" class="block text-sm font-medium text-primary mb-1">Vitamin A (mcg)</label><input type="number" step="any" min="0" max="30000" id="target-vitaminA"></div>
+              <div><label for="target-vitaminD" class="block text-sm font-medium text-primary mb-1">Vitamin D (mcg)</label><input type="number" step="any" min="0" max="1000" id="target-vitaminD"></div>
+              <div><label for="target-vitaminE" class="block text-sm font-medium text-primary mb-1">Vitamin E (mg)</label><input type="number" step="any" min="0" max="10000" id="target-vitaminE"></div>
+              <div><label for="target-vitaminK" class="block text-sm font-medium text-primary mb-1">Vitamin K (mcg)</label><input type="number" step="any" min="0" max="10000" id="target-vitaminK"></div>
             </div>
           </div>
 
           <div class="settings-section">
             <h3 class="text-lg font-semibold text-secondary mb-4">Daily Minerals</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-iron"      class="block text-sm font-medium text-primary mb-1">Iron (mg)</label><input type="number" step="any" id="target-iron"></div>
-              <div><label for="target-calcium"   class="block text-sm font-medium text-primary mb-1">Calcium (mg)</label><input type="number" step="any" id="target-calcium"></div>
-              <div><label for="target-magnesium" class="block text-sm font-medium text-primary mb-1">Magnesium (mg)</label><input type="number" step="any" id="target-magnesium"></div>
-              <div><label for="target-zinc"      class="block text-sm font-medium text-primary mb-1">Zinc (mg)</label><input type="number" step="any" id="target-zinc"></div>
-              <div><label for="target-potassium" class="block text-sm font-medium text-primary mb-1">Potassium (mg)</label><input type="number" step="any" id="target-potassium"></div>
-              <div><label for="target-sodium"    class="block text-sm font-medium text-primary mb-1">Sodium (mg)</label><input type="number" step="any" id="target-sodium"></div>
+              <div><label for="target-iron"      class="block text-sm font-medium text-primary mb-1">Iron (mg)</label><input type="number" step="any" min="0" max="450" id="target-iron"></div>
+              <div><label for="target-calcium"   class="block text-sm font-medium text-primary mb-1">Calcium (mg)</label><input type="number" step="any" min="0" max="25000" id="target-calcium"></div>
+              <div><label for="target-magnesium" class="block text-sm font-medium text-primary mb-1">Magnesium (mg)</label><input type="number" step="any" min="0" max="10000" id="target-magnesium"></div>
+              <div><label for="target-zinc"      class="block text-sm font-medium text-primary mb-1">Zinc (mg)</label><input type="number" step="any" min="0" max="400" id="target-zinc"></div>
+              <div><label for="target-potassium" class="block text-sm font-medium text-primary mb-1">Potassium (mg)</label><input type="number" step="any" min="0" max="50000" id="target-potassium"></div>
+              <div><label for="target-sodium"    class="block text-sm font-medium text-primary mb-1">Sodium (mg)</label><input type="number" step="any" min="0" max="23000" id="target-sodium"></div>
             </div>
           </div>
 
           <div class="settings-section">
             <h3 class="text-lg font-semibold text-secondary mb-4">Averaged Minerals</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-selenium"   class="block text-sm font-medium text-primary mb-1">Selenium (mcg)</label><input type="number" step="any" id="target-selenium"></div>
-              <div><label for="target-iodine"     class="block text-sm font-medium text-primary mb-1">Iodine (mcg)</label><input type="number" step="any" id="target-iodine"></div>
-              <div><label for="target-phosphorus" class="block text-sm font-medium text-primary mb-1">Phosphorus (mg)</label><input type="number" step="any" id="target-phosphorus"></div>
+              <div><label for="target-selenium"   class="block text-sm font-medium text-primary mb-1">Selenium (mcg)</label><input type="number" step="any" min="0" max="4000" id="target-selenium"></div>
+              <div><label for="target-iodine"     class="block text-sm font-medium text-primary mb-1">Iodine (mcg)</label><input type="number" step="any" min="0" max="11000" id="target-iodine"></div>
+              <div><label for="target-phosphorus" class="block text-sm font-medium text-primary mb-1">Phosphorus (mg)</label><input type="number" step="any" min="0" max="40000" id="target-phosphorus"></div>
             </div>
           </div>
 
           <div class="settings-section">
             <h3 class="text-lg font-semibold text-secondary mb-4">Optional Nutrients</h3>
             <div class="grid grid-cols-1 gap-4">
-              <div><label for="target-omega3"  class="block text-sm font-medium text-primary mb-1">Omega-3 (g)</label><input type="number" step="any" id="target-omega3"></div>
-              <div><label for="target-fiber"   class="block text-sm font-medium text-primary mb-1">Fiber (g)</label><input type="number" step="any" id="target-fiber"></div>
-              <div><label for="target-choline" class="block text-sm font-medium text-primary mb-1">Choline (mg)</label><input type="number" step="any" id="target-choline"></div>
+              <div><label for="target-omega3"  class="block text-sm font-medium text-primary mb-1">Omega-3 (g)</label><input type="number" step="any" min="0" max="100" id="target-omega3"></div>
+              <div><label for="target-fiber"   class="block text-sm font-medium text-primary mb-1">Fiber (g)</label><input type="number" step="any" min="0" max="500" id="target-fiber"></div>
+              <div><label for="target-choline" class="block text-sm font-medium text-primary mb-1">Choline (mg)</label><input type="number" step="any" min="0" max="35000" id="target-choline"></div>
             </div>
           </div>
 

--- a/public/tools/CalorieTracker/package.json
+++ b/public/tools/CalorieTracker/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "serve": "vite --host 0.0.0.0 --port 3000",
-    "test": "node_modules/.bin/vitest run analysis/weightParser.test.js state/schema.test.js targets/targetEngine.test.js analysis/engine.test.js exercise/met.test.js ui/nutrientHelpers.test.js ui/banking.test.js staging/parser.test.js"
+    "test": "node_modules/.bin/vitest run analysis/weightParser.test.js state/schema.test.js targets/targetEngine.test.js analysis/engine.test.js exercise/met.test.js ui/nutrientHelpers.test.js ui/banking.test.js staging/parser.test.js utils/ui.test.js"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -4,7 +4,7 @@
  */
 import { state, cacheDom, coerceQuantity } from '../state/store.js';
 import { getTodayInTimezone } from '../utils/time.js';
-import { handleError, debugLog } from '../utils/ui.js';
+import { handleError, debugLog, escapeHtml } from '../utils/ui.js';
 import {
   fetchTargets,
   fetchRecentEntries,
@@ -66,6 +66,36 @@ export function ensureDateInput() {
   }
 }
 
+// Retry a function with exponential backoff. Returns the result on success, throws after all attempts.
+async function retryWithBackoff(fn, { attempts = 3, baseMs = 1000 } = {}) {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (i === attempts - 1) throw e;
+      await new Promise(r => setTimeout(r, baseMs * 2 ** i));
+    }
+  }
+}
+
+function showLoadErrorBanner(msg) {
+  let banner = document.getElementById('load-error-banner');
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'load-error-banner';
+    banner.className = 'bg-red-600 text-primary text-center py-3 px-4 text-sm font-medium';
+    const mainContent = document.getElementById('main-content');
+    if (mainContent) mainContent.prepend(banner);
+  }
+  banner.textContent = msg;
+  banner.classList.remove('hidden');
+}
+
+function hideLoadErrorBanner() {
+  const banner = document.getElementById('load-error-banner');
+  if (banner) banner.classList.add('hidden');
+}
+
 /**
  * Orchestrates the loading of all user-specific data from Firebase.
  * This function is called on initial load and when the user changes.
@@ -75,12 +105,12 @@ export async function loadUserData() {
     debugLog('data-load', 'No user ID available, skipping data load');
     return; // Do nothing if there's no user.
   }
-  
+
   if (!state.dom.dateInput) {
     debugLog('data-load', 'DOM not cached, caching now');
     cacheDom(); // Ensure DOM is cached.
   }
-  
+
   ensureDateInput();
 
   // Show loader while fetching data.
@@ -89,16 +119,20 @@ export async function loadUserData() {
 
   try {
     debugLog('data-load', 'Starting parallel data fetch for user', state.userId);
-    
-    // Fetch all necessary data in parallel for better performance.
-    // Profile and goals return {} for first-time users (no document yet).
+
+    // Fetch all necessary data in parallel with retry + backoff.
+    // fetchTargets/fetchUserProfile/fetchGoalSettings now throw on network error
+    // instead of silently returning {}. The retry gives transient failures a
+    // chance to recover; a persistent failure surfaces a banner.
     const [targets, entries, weightEntries, rawProfile, rawGoals] = await Promise.all([
-      fetchTargets(),
-      fetchRecentEntries(),
-      fetchWeightEntries(),
-      fetchUserProfile(),
-      fetchGoalSettings(),
+      retryWithBackoff(() => fetchTargets()),
+      retryWithBackoff(() => fetchRecentEntries()),
+      retryWithBackoff(() => fetchWeightEntries()),
+      retryWithBackoff(() => fetchUserProfile()),
+      retryWithBackoff(() => fetchGoalSettings()),
     ]);
+
+    hideLoadErrorBanner();
 
     state.baselineTargets = targets;
     state.weightEntries = weightEntries;
@@ -147,11 +181,12 @@ export async function loadUserData() {
     else if (window.__populateProfileForm) window.__populateProfileForm();
     updateDashboard();
     updateChart();
-    
+
     debugLog('data-load', 'User data loading complete');
 
   } catch (e) {
-    handleError('load-user-data', e, 'Error loading data. Please refresh and try again.');
+    handleError('load-user-data', e, 'Error loading data.');
+    showLoadErrorBanner('Data could not be loaded. Check your connection and refresh the page.');
   }
 
   // Hide loader and show main content.
@@ -242,7 +277,8 @@ function renderFoodItemsContent(container) {
 
   // Generate food items HTML with improved styling
   const itemsHtml = state.dailyFoodItems.map((item, index) => {
-    const name = item.name || '(blank)';
+    // Food names are user-controlled; escape before interpolating into innerHTML (XSS).
+    const name = escapeHtml(item.name || '(blank)');
     const isSubtraction = (item.calories || 0) < 0;
     const qty = parseFloat(item.quantity ?? 0) || 0;
     const nameDisplay = qty > 0 ? `${name} × ${qty}` : name;

--- a/public/tools/CalorieTracker/services/firebase.js
+++ b/public/tools/CalorieTracker/services/firebase.js
@@ -118,7 +118,8 @@ export async function fetchTargets() {
     debugLog('firebase-fetch', 'Targets fetched successfully');
     return result;
   } catch (e) {
-    return handleError('targets-fetch', e, 'Failed to fetch targets.') || {};
+    handleError('targets-fetch', e, 'Failed to fetch targets.');
+    throw e;
   }
 }
 
@@ -358,7 +359,8 @@ export async function fetchUserProfile() {
     debugLog('firebase-fetch', 'User profile fetched');
     return result;
   } catch (e) {
-    return handleError('profile-fetch', e, 'Failed to fetch user profile.') || {};
+    handleError('profile-fetch', e, 'Failed to fetch user profile.');
+    throw e;
   }
 }
 
@@ -400,7 +402,8 @@ export async function fetchGoalSettings() {
     debugLog('firebase-fetch', 'Goal settings fetched');
     return result;
   } catch (e) {
-    return handleError('goals-fetch', e, 'Failed to fetch goal settings.') || {};
+    handleError('goals-fetch', e, 'Failed to fetch goal settings.');
+    throw e;
   }
 }
 

--- a/public/tools/CalorieTracker/services/firebase.js
+++ b/public/tools/CalorieTracker/services/firebase.js
@@ -238,10 +238,11 @@ export async function fetchRecentEntries() {
       map.set(d.id, data);
     });
     debugLog('firebase-fetch', 'Recent entries fetched successfully', map.size);
+    return map;
   } catch (e) {
     handleError('fetch-recent-entries', e, 'Failed to fetch recent entries.');
+    throw e;
   }
-  return map;
 }
 
 /**
@@ -534,10 +535,11 @@ export async function fetchWeightEntries() {
     const qs = await getDocs(qy);
     qs.forEach(d => map.set(d.id, d.data()));
     debugLog('firebase-weight', `Fetched ${map.size} weight entries`);
+    return map;
   } catch (e) {
     handleError('weight-fetch', e, 'Failed to fetch weight entries.');
+    throw e;
   }
-  return map;
 }
 
 // ---------- ESTIMATE MANAGEMENT ----------

--- a/public/tools/CalorieTracker/staging/parser.js
+++ b/public/tools/CalorieTracker/staging/parser.js
@@ -4,7 +4,7 @@
  */
 
 import { nutrientMap, allNutrients, SCHEMA_VERSIONS } from '../constants.js';
-import { showMessage, formatNutrientName } from '../utils/ui.js';
+import { showMessage, formatNutrientName, clampNutrient } from '../utils/ui.js';
 import { state } from '../state/store.js';
 import { saveDailyEntry, saveTargets } from '../services/firebase.js';
 import { clearStagingArea, updateFoodItemsList, getCurrentDailyEntry } from '../services/data.js';
@@ -103,7 +103,7 @@ export function getStagedValues() {
   const vals = {};
   allNutrients.forEach(n => {
     const input = document.getElementById(`actual-${n}`);
-    if (input) vals[n] = parseFloat(input.value) || 0;
+    if (input) vals[n] = clampNutrient(n, parseFloat(input.value) || 0);
   });
   return vals;
 }

--- a/public/tools/CalorieTracker/targets/targetUI.js
+++ b/public/tools/CalorieTracker/targets/targetUI.js
@@ -10,12 +10,12 @@
  */
 
 import { state } from '../state/store.js';
-import { showMessage, handleError } from '../utils/ui.js';
+import { showMessage, handleError, clampNutrient } from '../utils/ui.js';
 import { saveUserProfile, saveGoalSettings, saveTargets } from '../services/firebase.js';
 import { generateTargets, applyManualOverrides } from './targetEngine.js';
 import { runAnalysis } from '../analysis/engine.js';
 import { getTodayInTimezone } from '../utils/time.js';
-import { WEIGHT_FRESHNESS_THRESHOLD_DAYS } from '../constants.js';
+import { WEIGHT_FRESHNESS_THRESHOLD_DAYS, NUTRIENT_MAX_BOUNDS } from '../constants.js';
 
 // Cache the last engine result for reference (Apply Targets always recomputes fresh)
 let _lastResult = null;
@@ -280,7 +280,7 @@ function collectManualOverrides() {
     const inp = document.getElementById(`ovr-val-${key}`);
     if (chk?.checked && inp) {
       const n = parseFloat(inp.value);
-      if (!isNaN(n)) overrides[key] = n;
+      if (!isNaN(n)) overrides[key] = clampNutrient(key, n);
     }
   }
   return overrides;
@@ -477,7 +477,8 @@ function renderTargetPreview(result, currentOverrides) {
             data-key="${key}" ${hasOvr ? 'checked' : ''}>
           <label for="ovr-chk-${key}" class="text-xs text-muted cursor-pointer" style="min-width:8rem">${label}</label>
           <span class="text-xs text-secondary flex-1 text-right">auto: ${generated}</span>
-          <input type="number" step="any" id="ovr-val-${key}"
+          <input type="number" step="any" min="0" ${NUTRIENT_MAX_BOUNDS[key] != null ? `max="${NUTRIENT_MAX_BOUNDS[key]}"` : ''}
+            id="ovr-val-${key}"
             class="input w-24 text-xs"
             data-key="${key}"
             value="${ovrVal}"

--- a/public/tools/CalorieTracker/utils/ui.js
+++ b/public/tools/CalorieTracker/utils/ui.js
@@ -57,3 +57,39 @@ export const formatNutrientName = (name) =>
   name.replace(/([A-Z])/g, ' $1').trim()
     .replace(/^vitamin/i, 'Vitamin ')
     .replace(/^omega/i, 'Omega-');
+
+/**
+ * Escapes HTML-special characters so user-controlled strings (e.g. food names)
+ * can be safely interpolated into `innerHTML`. Food names are user input and
+ * must never be rendered as raw HTML — doing so is an XSS vector. Prefer
+ * `textContent`/DOM nodes where practical; use this for template-literal blocks
+ * that remain string-based.
+ * @param {*} value - The value to escape (coerced to string; null/undefined → '').
+ * @returns {string} The escaped string.
+ */
+export const escapeHtml = (value) =>
+  String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+import { NUTRIENT_MAX_BOUNDS } from '../constants.js';
+
+/**
+ * Clamps a nutrient value to [0, max] and warns the user if the raw value
+ * exceeded the bound. Returns the clamped number.
+ * @param {string} nutrient - The canonical nutrient key (e.g. 'calories').
+ * @param {number} raw - The raw parsed value.
+ * @returns {number} The value clamped to [0, NUTRIENT_MAX_BOUNDS[nutrient]].
+ */
+export function clampNutrient(nutrient, raw) {
+  if (Number.isNaN(raw)) return 0;
+  const max = NUTRIENT_MAX_BOUNDS[nutrient];
+  if (max != null && raw > max) {
+    showMessage(`${formatNutrientName(nutrient)} clamped to ${max} (entered ${raw}).`, true);
+    return max;
+  }
+  return Math.max(0, raw);
+}

--- a/public/tools/CalorieTracker/utils/ui.test.js
+++ b/public/tools/CalorieTracker/utils/ui.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ui.js → config.js calls getComputedStyle(document.documentElement) at module
+// load time. Stub the required DOM globals before importing the module under test.
+globalThis.document ??= { documentElement: {} };
+globalThis.getComputedStyle ??= () => ({ getPropertyValue: () => '' });
+
+const { escapeHtml, clampNutrient } = await import('./ui.js');
+
+describe('escapeHtml', () => {
+  it('escapes angle brackets', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('escapes double and single quotes', () => {
+    expect(escapeHtml('"hello" & \'world\'')).toBe('&quot;hello&quot; &amp; &#39;world&#39;');
+  });
+
+  it('escapes ampersands', () => {
+    expect(escapeHtml('a&b')).toBe('a&amp;b');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+
+  it('coerces numbers to string', () => {
+    expect(escapeHtml(42)).toBe('42');
+  });
+
+  it('leaves safe strings unchanged', () => {
+    expect(escapeHtml('Chicken Breast')).toBe('Chicken Breast');
+  });
+
+  it('handles XSS payload in food name', () => {
+    const xss = '<img src=x onerror=alert(1)>';
+    expect(escapeHtml(xss)).toBe('&lt;img src=x onerror=alert(1)&gt;');
+  });
+});
+
+describe('clampNutrient', () => {
+  it('returns 0 for NaN', () => {
+    expect(clampNutrient('calories', NaN)).toBe(0);
+  });
+
+  it('clamps negative values to 0', () => {
+    expect(clampNutrient('protein', -5)).toBe(0);
+  });
+
+  it('passes through in-range values', () => {
+    expect(clampNutrient('calories', 2000)).toBe(2000);
+    expect(clampNutrient('protein', 150)).toBe(150);
+  });
+
+  it('clamps values exceeding max bounds', () => {
+    expect(clampNutrient('calories', 99999)).toBe(10000);
+    expect(clampNutrient('protein', 5000)).toBe(1000);
+    expect(clampNutrient('fat', 2000)).toBe(1000);
+  });
+
+  it('handles nutrients without explicit bounds', () => {
+    expect(clampNutrient('unknownNutrient', 5000)).toBe(5000);
+  });
+
+  it('allows exact boundary values', () => {
+    expect(clampNutrient('calories', 10000)).toBe(10000);
+    expect(clampNutrient('protein', 1000)).toBe(1000);
+  });
+
+  it('clamps zero correctly', () => {
+    expect(clampNutrient('calories', 0)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the four **CRITICAL** items from the [CalorieTracker backlog](public/tools/CalorieTracker/BACKLOG.md) (Group A — Security & Data Integrity):

- **#1 — XSS via user-named foods:** Added `escapeHtml()` helper in `utils/ui.js` and applied it to all `innerHTML` sites that interpolate user-controlled food names (`data.js`, `manager.js`, `save.js`, `analysisUI.js`). Rebuilt the food dropdown (`dropdown.js`) with DOM construction + `addEventListener` instead of inline `onclick` handlers with broken quote escaping.

- **#2 — No max bounds on nutrient inputs:** Added per-nutrient `max`/`min` HTML attributes on **all** nutrient inputs — staging (`actual-*`), settings baseline targets (`target-*`), `target-fatMinimum`, and dynamically generated override grid inputs (`ovr-val-*`). Added `NUTRIENT_MAX_BOUNDS` map to `constants.js` and a `clampNutrient()` JS validation gate applied in three write paths: `getStagedValues()`, `wireSettingsEvents()`, and `collectManualOverrides()`.

- **#3 — Date-change race condition:** Added a monotonic `_dateChangeToken` counter in `wire.js` so stale date-change handlers bail before rendering outdated data.

- **#4 — Silent Firestore fetch failures:** All five initial-load fetches (`fetchTargets`, `fetchRecentEntries`, `fetchWeightEntries`, `fetchUserProfile`, `fetchGoalSettings`) now throw on error instead of silently returning `{}`/empty Map. `loadUserData` retries 3× with exponential backoff and shows a persistent `load-error-banner` on failure, distinguishing "load error" from "empty first-time user." Non-critical helpers (`loadSavedFoodItems`, `fetchFoodItems`, `fetchAllEntries`) are unchanged.

## Backlog bookkeeping

- #46 flipped `[p]` → `[x]` (commit `be6d028` merged to `main`).
- #1–#4 marked `[p]` with commits `9fbc6d1` and `716326e`.
- Test baseline: 568 tests / 9 files, all passing.

## Test plan

- [ ] Save a food named ``'&lt;img src=x onerror=alert(1)&gt;'`` — confirm it renders as inert text
- [ ] Enter `99999999` kcal in staging calories field — confirm it clamps to 10000 with a warning toast
- [ ] Enter `99999999` in a Settings baseline target field — confirm it clamps on save
- [ ] Check an override checkbox and enter an out-of-range value — confirm it clamps on Apply
- [ ] Rapidly switch dates back and forth — confirm the food log always matches the selected date
- [ ] Disconnect network, reload the app — confirm a red error banner appears instead of silently loading empty defaults
- [ ] Run `npm test` from `public/tools/CalorieTracker/` — all 568 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7vuriB9QKAGyxrWuUUCUP