### PR TITLE
CalorieTracker: tab bar scroll affordance, TDEE/impute floor fixes (#5, #6)

### DIFF
--- a/public/tools/CalorieTracker/BACKLOG.md
+++ b/public/tools/CalorieTracker/BACKLOG.md
@@ -160,13 +160,13 @@ green and add tests for new validators or pure functions.
 
 - [p] **#5 — Tab bar overflows ≤ 360 px with no scroll affordance**
   `styles.css:326-334` — five tabs at `flex: 0 0 auto` total ~450 px, silently clipping Profile & Settings on iPhone SE / small Android. The scrollbar is hidden with no visual indicator. Add scroll-shadow edge fades at both ends, or convert to a "more" overflow menu under 640 px.
-  > pushed — tab-bar-wrap with CSS gradient pseudo-element scroll shadows; JS scroll/resize listener toggles scroll-left/scroll-right classes; compact tab padding at ≤480 px; tests: 568 pass; commit: 3d44b6b
+  > pushed — tab-bar-wrap with CSS gradient pseudo-element scroll shadows; JS scroll/resize listener toggles scroll-left/scroll-right classes; compact tab padding at ≤480 px; tests: 568 pass; commit: ca9a264
 
 - [p] **#6 — TDEE plausibility floor is physiologically impossible; impute floor also low**
   `analysis/engine.js:30` `TDEE_PLAUSIBLE_MIN: 1200` — below BMR for any adult with any activity. Raise to 1 400 kcal.
   `analysis/engine.js:48` `IMPUTE_CAL_MIN: 600` — below basal for most users. Raise to 800 kcal.
   Both are single constant changes with an existing test that must be updated.
-  > pushed — TDEE_PLAUSIBLE_MIN 1200→1400, IMPUTE_CAL_MIN 600→800; vacation calorie bounds now use config constants; test updated; tests: 568 pass; commit: 3d44b6b
+  > pushed — TDEE_PLAUSIBLE_MIN 1200→1400, IMPUTE_CAL_MIN 600→800; vacation calorie bounds now use config constants; test updated; tests: 568 pass; commit: ca9a264
 
 ---
 

--- a/public/tools/CalorieTracker/BACKLOG.md
+++ b/public/tools/CalorieTracker/BACKLOG.md
@@ -142,31 +142,31 @@ green and add tests for new validators or pure functions.
 
 ## CRITICAL — fix before broader rollout
 
-- [p] **#1 — XSS via user-named foods**
+- [x] **#1 — XSS via user-named foods**
   `food/save.js:141-162`, `food/manager.js:99` — food names are user-controlled and rendered via template-literal `innerHTML`. Replace with `textContent` / DOM construction at every point where `f.name` or `d.nutrient` enters the DOM.
-  > pushed — escapeHtml helper in utils/ui.js; applied to data.js, manager.js, save.js, analysisUI.js; dropdown.js rebuilt with DOM construction + addEventListener; tests: 568 pass; commit: 9fbc6d1
+  > Resolved: escapeHtml helper in utils/ui.js; applied to data.js, manager.js, save.js, analysisUI.js; dropdown.js rebuilt with DOM construction + addEventListener; tests: 568 pass; merged 9fbc6d1
 
-- [p] **#2 — No max bounds on nutrient inputs**
+- [x] **#2 — No max bounds on nutrient inputs**
   `index.html:166-202`, `events/wire.js:132` — user can save `99999999` kcal, breaking all downstream calculations. Add per-nutrient `max` HTML attributes and a JS validation gate before any Firestore write (kcal ≤ 10 000, macros ≤ 1 000 g, micros at 10× UL).
-  > pushed — HTML max attrs on actual-* and target-* inputs + NUTRIENT_MAX_BOUNDS in constants.js + clampNutrient in getStagedValues, wireSettingsEvents, collectManualOverrides; override grid inputs bounded; tests: 568 pass; commit: 716326e
+  > Resolved: HTML max attrs on actual-* and target-* inputs + NUTRIENT_MAX_BOUNDS in constants.js + clampNutrient in getStagedValues, wireSettingsEvents, collectManualOverrides; override grid inputs bounded; tests: 568 pass; merged 716326e
 
-- [p] **#3 — Date-change race condition**
+- [x] **#3 — Date-change race condition**
   `services/data.js:142`, `ui/dashboard.js:148` — changing the date mid-fetch lets a stale response overwrite the UI with the wrong day's food items. Tag each in-flight request with the requested date string and discard any response that doesn't match the current selection.
-  > pushed — monotonic _dateChangeToken counter in wire.js; stale handlers bail before rendering; tests: 568 pass; commit: 9fbc6d1
+  > Resolved: monotonic _dateChangeToken counter in wire.js; stale handlers bail before rendering; tests: 568 pass; merged 9fbc6d1
 
-- [p] **#4 — Silent Firestore fetch failures default to empty `{}`**
+- [x] **#4 — Silent Firestore fetch failures default to empty `{}`**
   `services/firebase.js:121` — a network blip reads as "no saved targets," so users unknowingly run on system defaults with no indication. Surface a visible banner, retry with exponential backoff, and distinguish "load error" from "empty."
-  > pushed — all five initial-load fetches (targets, entries, weight, profile, goals) now throw on error; loadUserData retries 3× with backoff and shows persistent load-error-banner; tests: 568 pass; commit: 716326e
+  > Resolved: all five initial-load fetches (targets, entries, weight, profile, goals) now throw on error; loadUserData retries 3× with backoff and shows persistent load-error-banner; tests: 568 pass; merged 716326e
 
-- [ ] **#5 — Tab bar overflows ≤ 360 px with no scroll affordance**
+- [p] **#5 — Tab bar overflows ≤ 360 px with no scroll affordance**
   `styles.css:326-334` — five tabs at `flex: 0 0 auto` total ~450 px, silently clipping Profile & Settings on iPhone SE / small Android. The scrollbar is hidden with no visual indicator. Add scroll-shadow edge fades at both ends, or convert to a "more" overflow menu under 640 px.
-  > Resolved in: _pending_
+  > pushed — tab-bar-wrap with CSS gradient pseudo-element scroll shadows; JS scroll/resize listener toggles scroll-left/scroll-right classes; compact tab padding at ≤480 px; tests: 568 pass; commit: 3d44b6b
 
-- [ ] **#6 — TDEE plausibility floor is physiologically impossible; impute floor also low**
+- [p] **#6 — TDEE plausibility floor is physiologically impossible; impute floor also low**
   `analysis/engine.js:30` `TDEE_PLAUSIBLE_MIN: 1200` — below BMR for any adult with any activity. Raise to 1 400 kcal.
   `analysis/engine.js:48` `IMPUTE_CAL_MIN: 600` — below basal for most users. Raise to 800 kcal.
   Both are single constant changes with an existing test that must be updated.
-  > Resolved in: _pending_
+  > pushed — TDEE_PLAUSIBLE_MIN 1200→1400, IMPUTE_CAL_MIN 600→800; vacation calorie bounds now use config constants; test updated; tests: 568 pass; commit: 3d44b6b
 
 ---
 

--- a/public/tools/CalorieTracker/analysis/engine.js
+++ b/public/tools/CalorieTracker/analysis/engine.js
@@ -27,7 +27,7 @@ export const ANALYSIS_CONFIG = {
 
   // TDEE block
   TDEE_BLOCK_DAYS: 14,
-  TDEE_PLAUSIBLE_MIN: 1200,
+  TDEE_PLAUSIBLE_MIN: 1400,
   TDEE_PLAUSIBLE_MAX: 4500,
 
   // Multi-horizon TDEE estimates (days)
@@ -45,7 +45,7 @@ export const ANALYSIS_CONFIG = {
   // Calorie imputation
   IMPUTE_LAG_DAYS: 14,
   IMPUTE_MIN_FUTURE_WEIGHTS: 7,
-  IMPUTE_CAL_MIN: 600,
+  IMPUTE_CAL_MIN: 800,
   IMPUTE_CAL_MAX: 6000,
 
   // Plateau detection
@@ -1405,7 +1405,8 @@ export function estimateVacationCalories(
   }
 
   const raw = baseTdee * cfg.tdeeMultiplier + cfg.calorieOffset + weekdayAdjust;
-  const bounded = Math.max(600, Math.min(6000, Math.round(raw)));
+  const C = ANALYSIS_CONFIG;
+  const bounded = Math.max(C.IMPUTE_CAL_MIN, Math.min(C.IMPUTE_CAL_MAX, Math.round(raw)));
   const tdeeSource = bmrModel?.source === 'fitted' ? 'empirical TDEE' : 'profile TDEE';
   const offsetStr = weekdayAdjust !== 0
     ? ` and weekday pattern offset (${weekdayAdjust > 0 ? '+' : ''}${weekdayAdjust} kcal)`

--- a/public/tools/CalorieTracker/analysis/engine.test.js
+++ b/public/tools/CalorieTracker/analysis/engine.test.js
@@ -1153,14 +1153,14 @@ describe('estimateVacationCalories', () => {
     expect(result.calories).toBe(2000);
   });
 
-  it('bounds calories between 600 and 6000', () => {
+  it('bounds calories between IMPUTE_CAL_MIN (800) and IMPUTE_CAL_MAX (6000)', () => {
     const highBmr = { error: null, source: 'fitted', observedTdee: 5500 };
     const heavy = estimateVacationCalories('heavy', highBmr, '2024-06-01');
     expect(heavy.calories).toBeLessThanOrEqual(6000);
 
     const lowBmr = { error: null, source: 'fitted', observedTdee: 700 };
     const light = estimateVacationCalories('light', lowBmr, '2024-06-01');
-    expect(light.calories).toBeGreaterThanOrEqual(600);
+    expect(light.calories).toBeGreaterThanOrEqual(800);
   });
 });
 

--- a/public/tools/CalorieTracker/events/wire.js
+++ b/public/tools/CalorieTracker/events/wire.js
@@ -340,6 +340,18 @@ function wireTabs() {
         tabBtns[next].focus();
         activateTab(tabBtns[next].dataset.tab);
       });
+
+      const wrap = tabBar.closest('.tab-bar-wrap');
+      if (wrap) {
+        const updateShadows = () => {
+          const { scrollLeft, scrollWidth, clientWidth } = tabBar;
+          wrap.classList.toggle('scroll-left', scrollLeft > 2);
+          wrap.classList.toggle('scroll-right', scrollLeft + clientWidth < scrollWidth - 2);
+        };
+        tabBar.addEventListener('scroll', updateShadows, { passive: true });
+        window.addEventListener('resize', updateShadows);
+        updateShadows();
+      }
     }
 
     debugLog('wire', 'Tab events wired');

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -49,13 +49,15 @@
         </div>
       </header>
 
-      <nav class="tab-bar" role="tablist" aria-label="App sections">
-        <button id="tab-btn-today"     class="tab-btn active" data-tab="today"     role="tab" aria-selected="true"  aria-controls="tab-today">Today</button>
-        <button id="tab-btn-nutrients" class="tab-btn"        data-tab="nutrients" role="tab" aria-selected="false" aria-controls="tab-nutrients">Nutrients</button>
-        <button id="tab-btn-energy"    class="tab-btn"        data-tab="energy"    role="tab" aria-selected="false" aria-controls="tab-energy">Energy</button>
-        <button id="tab-btn-profile"   class="tab-btn"        data-tab="profile"   role="tab" aria-selected="false" aria-controls="tab-profile">Profile &amp; Goals</button>
-        <button id="tab-btn-settings"  class="tab-btn"        data-tab="settings"  role="tab" aria-selected="false" aria-controls="tab-settings">Settings</button>
-      </nav>
+      <div class="tab-bar-wrap">
+        <nav class="tab-bar" role="tablist" aria-label="App sections">
+          <button id="tab-btn-today"     class="tab-btn active" data-tab="today"     role="tab" aria-selected="true"  aria-controls="tab-today">Today</button>
+          <button id="tab-btn-nutrients" class="tab-btn"        data-tab="nutrients" role="tab" aria-selected="false" aria-controls="tab-nutrients">Nutrients</button>
+          <button id="tab-btn-energy"    class="tab-btn"        data-tab="energy"    role="tab" aria-selected="false" aria-controls="tab-energy">Energy</button>
+          <button id="tab-btn-profile"   class="tab-btn"        data-tab="profile"   role="tab" aria-selected="false" aria-controls="tab-profile">Profile &amp; Goals</button>
+          <button id="tab-btn-settings"  class="tab-btn"        data-tab="settings"  role="tab" aria-selected="false" aria-controls="tab-settings">Settings</button>
+        </nav>
+      </div>
 
       <!-- Compact macro progress bar (Today tab only) -->
       <div id="today-macro-header" class="macro-summary-bar hidden" aria-live="polite"></div>

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -330,8 +330,35 @@ input:focus, textarea:focus, select:focus {
   -ms-overflow-style: none;
   border-top: 1px solid hsl(var(--border));
   background: hsl(var(--surface-1));
+  position: relative;
 }
 .tab-bar::-webkit-scrollbar { display: none; }
+
+.tab-bar-wrap {
+  position: relative;
+}
+.tab-bar-wrap::before,
+.tab-bar-wrap::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 32px;
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0;
+  transition: opacity .2s;
+}
+.tab-bar-wrap::before {
+  left: 0;
+  background: linear-gradient(to right, hsl(var(--surface-1)), transparent);
+}
+.tab-bar-wrap::after {
+  right: 0;
+  background: linear-gradient(to left, hsl(var(--surface-1)), transparent);
+}
+.tab-bar-wrap.scroll-left::before  { opacity: 1; }
+.tab-bar-wrap.scroll-right::after  { opacity: 1; }
 
 .tab-btn {
   flex: 0 0 auto;
@@ -356,6 +383,10 @@ input:focus, textarea:focus, select:focus {
   color: hsl(var(--accent));
   border-bottom-color: hsl(var(--accent));
   font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .tab-btn { padding: .5rem .625rem; font-size: .8125rem; }
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

- **#5 — Tab bar overflow scroll affordance:** Wrapped the tab bar in a `.tab-bar-wrap` container with CSS gradient pseudo-element scroll shadows that fade in/out at the overflowing edge(s). A lightweight JS scroll/resize listener toggles `scroll-left`/`scroll-right` classes. Added compact tab padding (`0.5rem 0.625rem`) at ≤480 px so "Profile & Goals" and "Settings" are no longer clipped on iPhone SE / small Android.
- **#6 — TDEE and impute plausibility floors:** Raised `TDEE_PLAUSIBLE_MIN` from 1200→1400 kcal (1200 is below BMR for any active adult) and `IMPUTE_CAL_MIN` from 600→800 kcal (600 is below basal for most users). Also fixed `estimateVacationCalories` to reference `ANALYSIS_CONFIG` constants instead of hardcoded 600/6000 bounds. Updated test assertion to match the new 800 floor.
- **Reconciled #1–#4** as merged (commits 9fbc6d1 and 716326e confirmed on `origin/main`).

Backlog: `public/tools/CalorieTracker/BACKLOG.md`

## Test plan

- [x] All 568 tests pass (9 files, Vitest)
- [ ] Verify tab bar scroll shadows appear on narrow viewports (≤360 px)
- [ ] Verify tab buttons are fully reachable via horizontal scroll on small screens
- [ ] Verify arrow-key tab navigation still works
- [ ] Confirm TDEE analysis rejects values below 1400 kcal
- [ ] Confirm vacation calorie estimates are bounded at 800–6000 kcal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011K4RHdMic5hG6HVtjuFshb

---
_Generated by [Claude Code](https://claude.ai/code/session_011K4RHdMic5hG6HVtjuFshb)_