### PR TITLE
CalorieTracker: duplicate detection, sync notice, delete undo (#14, #15, #16)

### DIFF
--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -147,7 +147,7 @@ cd public/tools/CalorieTracker
 npm test
 ```
 
-Baseline: **568 tests, 9 files, all passing.**
+Baseline: **575 tests, 9 files, all passing.**
 
 Use targeted testing judgment:
 
@@ -190,49 +190,49 @@ Use targeted testing judgment:
 
 ## HIGH — math / accuracy
 
-- [p] **#7 — EWMA span = 10 (α ≈ 0.182) under-smooths noisy daily weigh-ins**
+- [x] **#7 — EWMA span = 10 (α ≈ 0.182) under-smooths noisy daily weigh-ins**
   `analysis/engine.js:20` — a 2 lb water spike at this alpha persists ~5 days in the trend line. Hacker's Diet uses α ≈ 0.1 (span ≈ 20). Consider raising span to 14 (α ≈ 0.133) or exposing as a user preference. At minimum, add a comment in `ANALYSIS_CONFIG` explaining the trade-off (faster response vs. more noise).
-  > pushed — block comment explaining span 10 trade-off vs Hacker's Diet span 20, and how OLS water-correction compensates; tests: 568 pass; commit: 6ec05bd
+  > Resolved: block comment explaining span 10 trade-off vs Hacker's Diet span 20, and how OLS water-correction compensates; tests: 568 pass; merged 6ec05bd
 
-- [p] **#8 — PAL grid ranges are empirically tuned with no documented rationale**
+- [x] **#8 — PAL grid ranges are empirically tuned with no documented rationale**
   `analysis/engine.js:36-43` — the upper bound of 1.85 at 400 kcal/day exercise could double-count activity if the user's baseline already reflects training. Add a block comment explaining the empirical origin (or basis in literature), and reconsider whether 1.75 is a safer maximum.
-  > pushed — block comment citing WHO/FAO/UNU 2001 and IOM DRI 2005, explaining 1.85 ceiling avoids double-counting for recreational exercisers; tests: 568 pass; commit: 6ec05bd
+  > Resolved: block comment citing WHO/FAO/UNU 2001 and IOM DRI 2005, explaining 1.85 ceiling avoids double-counting for recreational exercisers; tests: 568 pass; merged 6ec05bd
 
-- [p] **#9 — `MIN_DAYS_FOR_WATER_REGRESSION = 20` silently excludes most users**
+- [x] **#9 — `MIN_DAYS_FOR_WATER_REGRESSION = 20` silently excludes most users**
   `analysis/engine.js:26` — most users won't have 20 days of complete sodium + carbs + weight data; they fall back to the bucket method with no notice. Consider lowering the threshold to 14 days (if sodium/carb coverage ≥ 70%) and surface which correction method is active in the Energy tab UI.
-  > pushed — lowered threshold from 20→14 (sufficient degrees of freedom for 2–3 predictor OLS); water correction method was already surfaced in Energy tab confidence card; tests: 568 pass; commit: 6ec05bd
+  > Resolved: lowered threshold from 20→14 (sufficient degrees of freedom for 2–3 predictor OLS); water correction method was already surfaced in Energy tab confidence card; tests: 568 pass; merged 6ec05bd
 
-- [p] **#10 — True-up fallback to inside-interval blocks is not user-visible**
+- [x] **#10 — True-up fallback to inside-interval blocks is not user-visible**
   `analysis/engine.js:1761-1772` — when outside-interval TDEE blocks are scarce, the engine silently falls back to inside-interval data (which can be distorted by the very missing days being estimated). Add a caveat in the Energy tab when fallback mode is active ("estimate uses weeks that contain gaps").
-  > pushed — tdeeRefSource field added to each interval; analysisUI interval-math detail shows ref source with warning labels for inside-interval and hardcoded fallback; tests: 568 pass; commit: 6ec05bd
+  > Resolved: tdeeRefSource field added to each interval; analysisUI interval-math detail shows ref source with warning labels for inside-interval and hardcoded fallback; tests: 568 pass; merged 6ec05bd
 
-- [p] **#11 — Sodium "UL" is the CDRR target, not a Tolerable Upper Intake Level**
+- [x] **#11 — Sodium "UL" is the CDRR target, not a Tolerable Upper Intake Level**
   `targets/nutritionReferences.js:185-206` — NASEM did not establish a true UL for sodium; 2 300 mg is the Chronic Disease Risk Reduction target. Mislabeling it "UL" causes users to see "over UL" warnings at moderate sodium intakes. Add a comment: `// CDRR target — no established UL per NASEM`. Consider whether the warning copy in the UI should reflect this distinction.
-  > pushed — CDRR comment block on sodium entry; null-UL entries annotated with NASEM rationale; target warning + Nutrients tab row/summary badges distinguish CDRR from UL for sodium; tests: 568 pass; commit: 6ec05bd
+  > Resolved: CDRR comment block on sodium entry; null-UL entries annotated with NASEM rationale; target warning + Nutrients tab row/summary badges distinguish CDRR from UL for sodium; tests: 568 pass; merged 6ec05bd
 
-- [p] **#12 — Body-fat % outside realistic bounds accepted without warning**
+- [x] **#12 — Body-fat % outside realistic bounds accepted without warning**
   `analysis/engine.js:647`, `targets/targetEngine.js:141` — the valid range is `[5, 60]` but no validation message is shown if a user enters 3% or 70%. Add an inline warning (not a hard block) in the Profile & Goals form for out-of-range values.
-  > pushed — hidden warning element in HTML; validateBodyFatInput() in targetUI.js shows tiered warnings for <5%, <8%, >50%, >60%; Cunningham bounds now inclusive (>=5, <=60); tests: 568 pass; commit: 6ec05bd
+  > Resolved: hidden warning element in HTML; validateBodyFatInput() in targetUI.js shows tiered warnings for <5%, <8%, >50%, >60%; Cunningham bounds now inclusive (>=5, <=60); tests: 568 pass; merged 6ec05bd
 
-- [p] **#13 — Carb-clamp-to-zero in auto-generated targets has no user warning**
+- [x] **#13 — Carb-clamp-to-zero in auto-generated targets has no user warning**
   `targets/targetEngine.js:566-569` — when protein + fat exceed the calorie total, carbs silently clamp to 0. The override path already has a warning at lines 758-782; apply the same warning to the auto-generated path so users know their goal macro split is infeasible.
-  > pushed — protein+fat vs calorie check after computeCarbsTarget in generateTargets; warning mirrors the manual-override path format; tests: 568 pass; commit: 6ec05bd
+  > Resolved: protein+fat vs calorie check after computeCarbsTarget in generateTargets; warning mirrors the manual-override path format; tests: 568 pass; merged 6ec05bd
 
 ---
 
 ## HIGH — functionality
 
-- [ ] **#14 — No duplicate detection in paste-and-parse staging**
+- [p] **#14 — No duplicate detection in paste-and-parse staging**
   Pasting the same nutrition label twice yields two food entries with identical names and values. Hash on `name + kcal` (or similar fingerprint) and prompt the user to confirm before adding an apparent duplicate.
-  > Resolved in: _pending_
+  > pushed — findDailyDuplicate checks name+calories before addStagedNutrientsToDailyLog; confirmation modal on match; 7 new tests; tests: 575 pass; commit: _pending_
 
-- [ ] **#15 — No realtime sync / no offline note**
+- [p] **#15 — No realtime sync / no offline note**
   Only one-shot `getDoc`/`getDocs` calls — a second device's edits never appear without a page reload. Either migrate `dailyEntries/{today}` to `onSnapshot()` for live sync, or document the single-device limitation prominently in the UI (currently only in README Known Limitations).
-  > Resolved in: _pending_
+  > pushed — dismissible sync-notice banner above food list after data load; localStorage remembers dismissal; tests: 575 pass; commit: _pending_
 
-- [ ] **#16 — Deleting a food item or exercise session is irreversible**
+- [p] **#16 — Deleting a food item or exercise session is irreversible**
   There is no undo path after confirmation. Add a 5-second undo toast that re-adds the item before it is written to Firestore, giving users a quick recovery window.
-  > Resolved in: _pending_
+  > pushed — showUndoToast in utils/ui.js; removeFoodItem and removeExerciseSessionById use 5s undo toast instead of confirmation modal; Firestore write deferred until undo window closes; rollback on save error; tests: 575 pass; commit: _pending_
 
 - [x] **#46 — "Current weight required" nag fires regardless of weigh-in age**
   `targets/targetEngine.js`, `analysis/engine.js`, `targets/targetUI.js`, `constants.js` — the notice showed unconditionally, on a debounced auto-calc that runs before data loads. Now the current weight is estimated forward from the last weigh-in via energy balance (`projectWeightForward`: calories-in − TDEE since the last weigh-in, water-corrected smoothed baseline, drift-capped); the hard "Current weight is required" notice shows only on an explicit Auto-Calculate when there is no weight data at all; and a soft, non-blocking notice appears only when the last weigh-in is older than `WEIGHT_FRESHNESS_THRESHOLD_DAYS` (21).
@@ -404,4 +404,4 @@ cd public/tools/CalorieTracker
 npm test
 ```
 
-Baseline: **568 tests, 9 files, all passing.** Any session that changes logic files must keep this green. Add tests for new validators, the date-change cancellation token, and any new pure functions introduced.
+Baseline: **575 tests, 9 files, all passing.** Any session that changes logic files must keep this green. Add tests for new validators, the date-change cancellation token, and any new pure functions introduced.

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -232,7 +232,7 @@ Use targeted testing judgment:
 
 - [p] **#16 — Deleting a food item or exercise session is irreversible**
   There is no undo path after confirmation. Add a 5-second undo toast that re-adds the item before it is written to Firestore, giving users a quick recovery window.
-  > pushed — showUndoToast in utils/ui.js; removeFoodItem and removeExerciseSessionById use 5s undo toast instead of confirmation modal; Firestore write deferred until undo window closes; rollback on save error; tests: 575 pass; commit: dc02f4f
+  > pushed — showUndoToast in utils/ui.js; removeFoodItem and removeExerciseSessionById use 5s undo toast instead of confirmation modal; Firestore write deferred until undo window closes; rapid successive deletes flush the previous pending commit before showing the new toast; rollback on save error; tests: 575 pass; commit: dc02f4f
 
 - [x] **#46 — "Current weight required" nag fires regardless of weigh-in age**
   `targets/targetEngine.js`, `analysis/engine.js`, `targets/targetUI.js`, `constants.js` — the notice showed unconditionally, on a debounced auto-calc that runs before data loads. Now the current weight is estimated forward from the last weigh-in via energy balance (`projectWeightForward`: calories-in − TDEE since the last weigh-in, water-corrected smoothed baseline, drift-capped); the hard "Current weight is required" notice shows only on an explicit Auto-Calculate when there is no weight data at all; and a soft, non-blocking notice appears only when the last weigh-in is older than `WEIGHT_FRESHNESS_THRESHOLD_DAYS` (21).

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -232,7 +232,7 @@ Use targeted testing judgment:
 
 - [p] **#16 — Deleting a food item or exercise session is irreversible**
   There is no undo path after confirmation. Add a 5-second undo toast that re-adds the item before it is written to Firestore, giving users a quick recovery window.
-  > pushed — showUndoToast in utils/ui.js; removeFoodItem and removeExerciseSessionById use 5s undo toast instead of confirmation modal; Firestore write deferred until undo window closes; rapid successive deletes flush the previous pending commit before showing the new toast; rollback on save error; tests: 575 pass; commit: dc02f4f
+  > pushed — showUndoToast + exported flushPendingUndo in utils/ui.js; removeFoodItem and removeExerciseSessionById flush any pending undo commit before mutating shared state, then show 5s undo toast; Firestore write deferred until undo window closes; rollback on save error; tests: 575 pass; commit: dc02f4f
 
 - [x] **#46 — "Current weight required" nag fires regardless of weigh-in age**
   `targets/targetEngine.js`, `analysis/engine.js`, `targets/targetUI.js`, `constants.js` — the notice showed unconditionally, on a debounced auto-calc that runs before data loads. Now the current weight is estimated forward from the last weigh-in via energy balance (`projectWeightForward`: calories-in − TDEE since the last weigh-in, water-corrected smoothed baseline, drift-capped); the hard "Current weight is required" notice shows only on an explicit Auto-Calculate when there is no weight data at all; and a soft, non-blocking notice appears only when the last weigh-in is older than `WEIGHT_FRESHNESS_THRESHOLD_DAYS` (21).

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -224,15 +224,15 @@ Use targeted testing judgment:
 
 - [p] **#14 — No duplicate detection in paste-and-parse staging**
   Pasting the same nutrition label twice yields two food entries with identical names and values. Hash on `name + kcal` (or similar fingerprint) and prompt the user to confirm before adding an apparent duplicate.
-  > pushed — findDailyDuplicate checks name+calories before addStagedNutrientsToDailyLog; confirmation modal on match; 7 new tests; tests: 575 pass; commit: _pending_
+  > pushed — findDailyDuplicate checks name+calories before addStagedNutrientsToDailyLog; confirmation modal on match; 7 new tests; tests: 575 pass; commit: dc02f4f
 
 - [p] **#15 — No realtime sync / no offline note**
   Only one-shot `getDoc`/`getDocs` calls — a second device's edits never appear without a page reload. Either migrate `dailyEntries/{today}` to `onSnapshot()` for live sync, or document the single-device limitation prominently in the UI (currently only in README Known Limitations).
-  > pushed — dismissible sync-notice banner above food list after data load; localStorage remembers dismissal; tests: 575 pass; commit: _pending_
+  > pushed — dismissible sync-notice banner above food list after data load; localStorage remembers dismissal; tests: 575 pass; commit: dc02f4f
 
 - [p] **#16 — Deleting a food item or exercise session is irreversible**
   There is no undo path after confirmation. Add a 5-second undo toast that re-adds the item before it is written to Firestore, giving users a quick recovery window.
-  > pushed — showUndoToast in utils/ui.js; removeFoodItem and removeExerciseSessionById use 5s undo toast instead of confirmation modal; Firestore write deferred until undo window closes; rollback on save error; tests: 575 pass; commit: _pending_
+  > pushed — showUndoToast in utils/ui.js; removeFoodItem and removeExerciseSessionById use 5s undo toast instead of confirmation modal; Firestore write deferred until undo window closes; rollback on save error; tests: 575 pass; commit: dc02f4f
 
 - [x] **#46 — "Current weight required" nag fires regardless of weigh-in age**
   `targets/targetEngine.js`, `analysis/engine.js`, `targets/targetUI.js`, `constants.js` — the notice showed unconditionally, on a debounced auto-calc that runs before data loads. Now the current weight is estimated forward from the last weigh-in via energy balance (`projectWeightForward`: calories-in − TDEE since the last weigh-in, water-corrected smoothed baseline, drift-capped); the hard "Current weight is required" notice shows only on an explicit Auto-Calculate when there is no weight data at all; and a soft, non-blocking notice appears only when the last weigh-in is older than `WEIGHT_FRESHNESS_THRESHOLD_DAYS` (21).

--- a/public/tools/CalorieTracker/events/wire.js
+++ b/public/tools/CalorieTracker/events/wire.js
@@ -19,7 +19,7 @@ import { saveTargets, saveDailyEntry } from '../services/firebase.js';
 import { allNutrients } from '../constants.js';
 import { updateDashboard, activateTab } from '../ui/dashboard.js';
 import { updateChart } from '../ui/chart.js';
-import { debugLog, handleError, clampNutrient } from '../utils/ui.js';
+import { debugLog, handleError, clampNutrient, flushPendingUndo } from '../utils/ui.js';
 import {
   ACTIVITY_TYPES,
   estimateSessionCalories,
@@ -175,6 +175,7 @@ function wireMainControls() {
     // Date input change handler
     if (state.dom.dateInput) {
       state.dom.dateInput.addEventListener('change', async () => {
+        flushPendingUndo();
         const token = ++_dateChangeToken;
         try {
           await loadDailyFoodItems();
@@ -195,6 +196,7 @@ function wireMainControls() {
     if (dayActivitySelect) {
       dayActivitySelect.addEventListener('change', async (e) => {
         try {
+          flushPendingUndo();
           const dateStr = state.dom.dateInput?.value;
           if (!dateStr) return;
 

--- a/public/tools/CalorieTracker/food/manager.js
+++ b/public/tools/CalorieTracker/food/manager.js
@@ -9,7 +9,7 @@ import { allNutrients } from '../constants.js';
 import { showConfirmationModal } from '../ui/modals.js';
 import { saveDailyEntry, deleteFoodItem } from '../services/firebase.js';
 import { updateFoodItemsList, getCurrentDailyEntry } from '../services/data.js';
-import { showMessage, handleError, escapeHtml } from '../utils/ui.js';
+import { showMessage, handleError, escapeHtml, showUndoToast } from '../utils/ui.js';
 import { hideFoodDropdown } from './dropdown.js';
 import { updateDashboard } from '../ui/dashboard.js';
 import { updateChart } from '../ui/chart.js';
@@ -50,42 +50,57 @@ export function selectFoodItem(foodName) {
 }
 
 /**
- * Removes a food item from the daily log for the current day.
+ * Removes a food item from the daily log with a 5-second undo window.
  * @param {number} index - The index of the item in the `state.dailyFoodItems` array.
  */
-export async function removeFoodItem(index) {
+export function removeFoodItem(index) {
   if (index < 0 || index >= state.dailyFoodItems.length) return;
 
   const itemToRemove = state.dailyFoodItems[index];
-  showConfirmationModal(`Remove "${itemToRemove.name || '(blank)'}"? This will subtract its nutrients from today's totals.`, async () => {
-    try {
-      const dateStr = state.dom.dateInput.value;
-      // getCurrentDailyEntry always returns a v2-shaped entry (creates one if needed).
-      const todayEntry = getCurrentDailyEntry();
+  const dateStr = state.dom.dateInput.value;
+  const todayEntry = getCurrentDailyEntry();
 
-      // Subtract the nutrients of the removed item from the daily total.
-      allNutrients.forEach(n => {
-        const currentTotal = parseFloat(todayEntry[n]) || 0;
-        const qty = parseFloat(itemToRemove.quantity ?? 0) || 0;
-        const itemValue = qty * (parseFloat(itemToRemove[n]) || 0);
-        todayEntry[n] = Math.max(0, currentTotal - itemValue);
-      });
+  const savedTotals = {};
+  allNutrients.forEach(n => { savedTotals[n] = parseFloat(todayEntry[n]) || 0; });
 
-      // Remove the item from the local array and update the entry.
-      state.dailyFoodItems.splice(index, 1);
+  allNutrients.forEach(n => {
+    const qty = parseFloat(itemToRemove.quantity ?? 0) || 0;
+    const itemValue = qty * (parseFloat(itemToRemove[n]) || 0);
+    todayEntry[n] = Math.max(0, (parseFloat(todayEntry[n]) || 0) - itemValue);
+  });
+
+  state.dailyFoodItems.splice(index, 1);
+  todayEntry.foodItems = state.dailyFoodItems;
+
+  updateDashboard();
+  updateChart();
+  updateFoodItemsList();
+
+  showUndoToast(
+    `Removed "${itemToRemove.name || '(blank)'}"`,
+    () => {
+      allNutrients.forEach(n => { todayEntry[n] = savedTotals[n]; });
+      state.dailyFoodItems.splice(index, 0, itemToRemove);
       todayEntry.foodItems = state.dailyFoodItems;
-
-      await saveDailyEntry(dateStr, todayEntry);
-      showMessage(`Removed "${itemToRemove.name || '(blank)'}" and updated totals.`);
-
-      // Refresh the UI to reflect the changes.
       updateDashboard();
       updateChart();
       updateFoodItemsList();
-    } catch (e) {
-      handleError('remove-food-item', e, 'Failed to remove food item.');
+      showMessage('Deletion undone.');
+    },
+    async () => {
+      try {
+        await saveDailyEntry(dateStr, todayEntry);
+      } catch (e) {
+        allNutrients.forEach(n => { todayEntry[n] = savedTotals[n]; });
+        state.dailyFoodItems.splice(index, 0, itemToRemove);
+        todayEntry.foodItems = state.dailyFoodItems;
+        updateDashboard();
+        updateChart();
+        updateFoodItemsList();
+        handleError('remove-food-item', e, 'Failed to remove food item.');
+      }
     }
-  });
+  );
 }
 
 /**

--- a/public/tools/CalorieTracker/food/manager.js
+++ b/public/tools/CalorieTracker/food/manager.js
@@ -9,7 +9,7 @@ import { allNutrients } from '../constants.js';
 import { showConfirmationModal } from '../ui/modals.js';
 import { saveDailyEntry, deleteFoodItem } from '../services/firebase.js';
 import { updateFoodItemsList, getCurrentDailyEntry } from '../services/data.js';
-import { showMessage, handleError, escapeHtml, showUndoToast } from '../utils/ui.js';
+import { showMessage, handleError, escapeHtml, showUndoToast, flushPendingUndo } from '../utils/ui.js';
 import { hideFoodDropdown } from './dropdown.js';
 import { updateDashboard } from '../ui/dashboard.js';
 import { updateChart } from '../ui/chart.js';
@@ -55,6 +55,8 @@ export function selectFoodItem(foodName) {
  */
 export function removeFoodItem(index) {
   if (index < 0 || index >= state.dailyFoodItems.length) return;
+
+  flushPendingUndo();
 
   const itemToRemove = state.dailyFoodItems[index];
   const dateStr = state.dom.dateInput.value;

--- a/public/tools/CalorieTracker/food/manager.js
+++ b/public/tools/CalorieTracker/food/manager.js
@@ -7,7 +7,7 @@
 import { state } from '../state/store.js';
 import { allNutrients } from '../constants.js';
 import { showConfirmationModal } from '../ui/modals.js';
-import { saveDailyEntry, deleteFoodItem } from '../services/firebase.js';
+import { saveDailyEntrySnapshot, deleteFoodItem } from '../services/firebase.js';
 import { updateFoodItemsList, getCurrentDailyEntry } from '../services/data.js';
 import { showMessage, handleError, escapeHtml, showUndoToast, flushPendingUndo } from '../utils/ui.js';
 import { hideFoodDropdown } from './dropdown.js';
@@ -61,14 +61,13 @@ export function removeFoodItem(index) {
   const itemToRemove = state.dailyFoodItems[index];
   const dateStr = state.dom.dateInput.value;
   const todayEntry = getCurrentDailyEntry();
+  const removedIndex = index;
 
-  const savedTotals = {};
-  allNutrients.forEach(n => { savedTotals[n] = parseFloat(todayEntry[n]) || 0; });
-
+  const removedDelta = {};
   allNutrients.forEach(n => {
     const qty = parseFloat(itemToRemove.quantity ?? 0) || 0;
-    const itemValue = qty * (parseFloat(itemToRemove[n]) || 0);
-    todayEntry[n] = Math.max(0, (parseFloat(todayEntry[n]) || 0) - itemValue);
+    removedDelta[n] = qty * (parseFloat(itemToRemove[n]) || 0);
+    todayEntry[n] = Math.max(0, (parseFloat(todayEntry[n]) || 0) - removedDelta[n]);
   });
 
   state.dailyFoodItems.splice(index, 1);
@@ -81,9 +80,11 @@ export function removeFoodItem(index) {
   showUndoToast(
     `Removed "${itemToRemove.name || '(blank)'}"`,
     () => {
-      allNutrients.forEach(n => { todayEntry[n] = savedTotals[n]; });
-      state.dailyFoodItems.splice(index, 0, itemToRemove);
-      todayEntry.foodItems = state.dailyFoodItems;
+      allNutrients.forEach(n => { todayEntry[n] = (parseFloat(todayEntry[n]) || 0) + removedDelta[n]; });
+      const targetItems = Array.isArray(todayEntry.foodItems) ? todayEntry.foodItems : state.dailyFoodItems;
+      targetItems.splice(Math.min(removedIndex, targetItems.length), 0, itemToRemove);
+      todayEntry.foodItems = targetItems;
+      if (state.dom.dateInput?.value === dateStr) state.dailyFoodItems = targetItems;
       updateDashboard();
       updateChart();
       updateFoodItemsList();
@@ -91,11 +92,13 @@ export function removeFoodItem(index) {
     },
     async () => {
       try {
-        await saveDailyEntry(dateStr, todayEntry);
+        await saveDailyEntrySnapshot(dateStr, todayEntry);
       } catch (e) {
-        allNutrients.forEach(n => { todayEntry[n] = savedTotals[n]; });
-        state.dailyFoodItems.splice(index, 0, itemToRemove);
-        todayEntry.foodItems = state.dailyFoodItems;
+        allNutrients.forEach(n => { todayEntry[n] = (parseFloat(todayEntry[n]) || 0) + removedDelta[n]; });
+        const targetItems = Array.isArray(todayEntry.foodItems) ? todayEntry.foodItems : state.dailyFoodItems;
+        targetItems.splice(Math.min(removedIndex, targetItems.length), 0, itemToRemove);
+        todayEntry.foodItems = targetItems;
+        if (state.dom.dateInput?.value === dateStr) state.dailyFoodItems = targetItems;
         updateDashboard();
         updateChart();
         updateFoodItemsList();

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -817,6 +817,12 @@
     <p id="message-text"></p>
   </div>
 
+  <!-- Undo toast -->
+  <div id="undo-toast" class="undo-toast hidden">
+    <span id="undo-toast-text"></span>
+    <button id="undo-toast-btn" class="undo-toast-btn">Undo</button>
+  </div>
+
   <!-- Entry script -->
   <script type="module" src="./main.js"></script>
 </body>

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -4,7 +4,7 @@
  */
 import { state, cacheDom, coerceQuantity } from '../state/store.js';
 import { getTodayInTimezone } from '../utils/time.js';
-import { handleError, debugLog, escapeHtml, showUndoToast, showMessage } from '../utils/ui.js';
+import { handleError, debugLog, escapeHtml, showUndoToast, showMessage, flushPendingUndo } from '../utils/ui.js';
 import {
   fetchTargets,
   fetchRecentEntries,
@@ -601,9 +601,12 @@ function removeExerciseSessionById(sessionId) {
 
   if (!Array.isArray(entry.exerciseSessions)) return;
 
-  const original = [...entry.exerciseSessions];
   const removed = entry.exerciseSessions.find(s => s.id === sessionId);
   if (!removed) return;
+
+  flushPendingUndo();
+
+  const original = [...entry.exerciseSessions];
 
   entry.exerciseSessions = entry.exerciseSessions.filter(s => s.id !== sessionId);
   state.dailyEntries.set(dateStr, entry);

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -4,7 +4,7 @@
  */
 import { state, cacheDom, coerceQuantity } from '../state/store.js';
 import { getTodayInTimezone } from '../utils/time.js';
-import { handleError, debugLog, escapeHtml } from '../utils/ui.js';
+import { handleError, debugLog, escapeHtml, showUndoToast, showMessage } from '../utils/ui.js';
 import {
   fetchTargets,
   fetchRecentEntries,
@@ -75,6 +75,30 @@ async function retryWithBackoff(fn, { attempts = 3, baseMs = 1000 } = {}) {
       if (i === attempts - 1) throw e;
       await new Promise(r => setTimeout(r, baseMs * 2 ** i));
     }
+  }
+}
+
+const SYNC_NOTICE_KEY = 'ct-sync-notice-dismissed';
+
+function showSyncNotice() {
+  if (localStorage.getItem(SYNC_NOTICE_KEY)) return;
+  let notice = document.getElementById('sync-notice');
+  if (notice) return;
+
+  notice = document.createElement('div');
+  notice.id = 'sync-notice';
+  notice.className = 'sync-notice';
+  notice.innerHTML =
+    '<span>Data saves to the cloud but does not sync in real-time between devices. Refresh to see edits made elsewhere.</span>' +
+    '<button class="sync-notice-dismiss" aria-label="Dismiss">&times;</button>';
+  notice.querySelector('button').addEventListener('click', () => {
+    notice.remove();
+    localStorage.setItem(SYNC_NOTICE_KEY, '1');
+  });
+
+  const container = document.getElementById('food-items-list');
+  if (container?.parentElement) {
+    container.parentElement.insertBefore(notice, container);
   }
 }
 
@@ -181,6 +205,8 @@ export async function loadUserData() {
     else if (window.__populateProfileForm) window.__populateProfileForm();
     updateDashboard();
     updateChart();
+
+    showSyncNotice();
 
     debugLog('data-load', 'User data loading complete');
 
@@ -566,33 +592,47 @@ export async function persistExerciseSession(session) {
 }
 
 /**
- * Remove an exercise session by id for the current date.
+ * Remove an exercise session by id for the current date with a 5-second undo window.
  * Exposed as window.removeExerciseSession.
- *
- * Rolls back the in-memory state and re-renders if the cloud save fails so the
- * UI never shows removal as successful when the data was not actually deleted.
  */
-async function removeExerciseSessionById(sessionId) {
+function removeExerciseSessionById(sessionId) {
   const dateStr = state.dom.dateInput?.value || getTodayInTimezone();
   const entry   = getCurrentDailyEntry();
 
   if (!Array.isArray(entry.exerciseSessions)) return;
 
   const original = [...entry.exerciseSessions];
+  const removed = entry.exerciseSessions.find(s => s.id === sessionId);
+  if (!removed) return;
+
   entry.exerciseSessions = entry.exerciseSessions.filter(s => s.id !== sessionId);
   state.dailyEntries.set(dateStr, entry);
+  updateExerciseSessionsList();
+  updateDashboard();
 
-  try {
-    await saveDailyEntry(dateStr, entry);
-    updateExerciseSessionsList();
-    updateDashboard();
-  } catch (err) {
-    // Restore state and re-render to show the session is still present
-    entry.exerciseSessions = original;
-    state.dailyEntries.set(dateStr, entry);
-    handleError('remove-exercise-session', err, 'Failed to remove exercise session from the cloud.');
-    updateExerciseSessionsList();
-  }
+  const label = removed.activityType || 'session';
+
+  showUndoToast(
+    `Removed exercise ${label}`,
+    () => {
+      entry.exerciseSessions = original;
+      state.dailyEntries.set(dateStr, entry);
+      updateExerciseSessionsList();
+      updateDashboard();
+      showMessage('Deletion undone.');
+    },
+    async () => {
+      try {
+        await saveDailyEntry(dateStr, entry);
+      } catch (err) {
+        entry.exerciseSessions = original;
+        state.dailyEntries.set(dateStr, entry);
+        handleError('remove-exercise-session', err, 'Failed to remove exercise session from the cloud.');
+        updateExerciseSessionsList();
+        updateDashboard();
+      }
+    }
+  );
 }
 
 // Expose session remove to inline onclick handlers (edit is handled in wire.js)

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -10,6 +10,7 @@ import {
   fetchRecentEntries,
   loadSavedFoodItems,
   saveDailyEntry,
+  saveDailyEntrySnapshot,
   fetchWeightEntries,
   fetchUserProfile,
   fetchGoalSettings,
@@ -80,8 +81,25 @@ async function retryWithBackoff(fn, { attempts = 3, baseMs = 1000 } = {}) {
 
 const SYNC_NOTICE_KEY = 'ct-sync-notice-dismissed';
 
+function isSyncNoticeDismissed() {
+  try {
+    return localStorage.getItem(SYNC_NOTICE_KEY) === '1';
+  } catch (e) {
+    debugLog('sync-notice', 'Unable to read dismissal state', e);
+    return false;
+  }
+}
+
+function dismissSyncNotice() {
+  try {
+    localStorage.setItem(SYNC_NOTICE_KEY, '1');
+  } catch (e) {
+    debugLog('sync-notice', 'Unable to persist dismissal state', e);
+  }
+}
+
 function showSyncNotice() {
-  if (localStorage.getItem(SYNC_NOTICE_KEY)) return;
+  if (isSyncNoticeDismissed()) return;
   let notice = document.getElementById('sync-notice');
   if (notice) return;
 
@@ -93,7 +111,7 @@ function showSyncNotice() {
     '<button class="sync-notice-dismiss" aria-label="Dismiss">&times;</button>';
   notice.querySelector('button').addEventListener('click', () => {
     notice.remove();
-    localStorage.setItem(SYNC_NOTICE_KEY, '1');
+    dismissSyncNotice();
   });
 
   const container = document.getElementById('food-items-list');
@@ -573,6 +591,8 @@ export function updateExerciseSessionsList() {
  * UI is only updated after a confirmed cloud save.
  */
 export async function persistExerciseSession(session) {
+  flushPendingUndo();
+
   const dateStr = state.dom.dateInput?.value || getTodayInTimezone();
   const entry   = getCurrentDailyEntry();
 
@@ -606,7 +626,7 @@ function removeExerciseSessionById(sessionId) {
 
   flushPendingUndo();
 
-  const original = [...entry.exerciseSessions];
+  const removedIndex = entry.exerciseSessions.findIndex(s => s.id === sessionId);
 
   entry.exerciseSessions = entry.exerciseSessions.filter(s => s.id !== sessionId);
   state.dailyEntries.set(dateStr, entry);
@@ -618,7 +638,7 @@ function removeExerciseSessionById(sessionId) {
   showUndoToast(
     `Removed exercise ${label}`,
     () => {
-      entry.exerciseSessions = original;
+      entry.exerciseSessions.splice(Math.min(removedIndex, entry.exerciseSessions.length), 0, removed);
       state.dailyEntries.set(dateStr, entry);
       updateExerciseSessionsList();
       updateDashboard();
@@ -626,9 +646,9 @@ function removeExerciseSessionById(sessionId) {
     },
     async () => {
       try {
-        await saveDailyEntry(dateStr, entry);
+        await saveDailyEntrySnapshot(dateStr, entry);
       } catch (err) {
-        entry.exerciseSessions = original;
+        entry.exerciseSessions.splice(Math.min(removedIndex, entry.exerciseSessions.length), 0, removed);
         state.dailyEntries.set(dateStr, entry);
         handleError('remove-exercise-session', err, 'Failed to remove exercise session from the cloud.');
         updateExerciseSessionsList();
@@ -647,6 +667,8 @@ window.removeExerciseSession = removeExerciseSessionById;
 
 let quantityUpdateTimer;
 window.updateItemQuantity = (id, value) => {
+  flushPendingUndo();
+
   const q = parseFloat(value);
   const item = state.dailyFoodItems.find(x => x.id === id);
   if (!item) return;

--- a/public/tools/CalorieTracker/services/firebase.js
+++ b/public/tools/CalorieTracker/services/firebase.js
@@ -151,6 +151,33 @@ export async function saveDailyEntry(dateStr, entry) {
 }
 
 /**
+ * Saves or updates a daily nutrition entry using the entry's own foodItems array.
+ * This is safe for deferred or historical-day writes because it does not read
+ * state.dailyFoodItems, which may belong to a different selected date.
+ * @param {string} dateStr - The date of the entry in 'YYYY-MM-DD' format.
+ * @param {object} entry - The complete entry data to save.
+ */
+export async function saveDailyEntrySnapshot(dateStr, entry) {
+  if (!state.userId) return showMessage('Cannot save entry. Not authenticated.', true);
+  try {
+    const foodItems = Array.isArray(entry.foodItems)
+      ? entry.foodItems.map(it => ({
+          ...it,
+          id: it.id || safeId(),
+          quantity: coerceQuantity(it).quantity,
+        }))
+      : [];
+    const toSave = prepareEntryForSave({ ...entry, foodItems });
+    await setDoc(doc(db, `artifacts/${appId}/users/${state.userId}/dailyEntries`, dateStr), toSave);
+    state.dailyEntries.set(dateStr, toSave);
+    debugLog('firebase-save', 'Daily entry snapshot saved successfully', dateStr);
+  } catch (e) {
+    handleError('daily-entry-snapshot-save', e, 'Failed to save entry.');
+    throw e;
+  }
+}
+
+/**
  * Saves a pre-built daily entry that already contains its own foodItems array.
  * Unlike saveDailyEntry(), this does NOT overwrite foodItems with state.dailyFoodItems,
  * making it safe to call for historical days without corrupting today's food log.

--- a/public/tools/CalorieTracker/staging/parser.js
+++ b/public/tools/CalorieTracker/staging/parser.js
@@ -4,7 +4,7 @@
  */
 
 import { nutrientMap, allNutrients, SCHEMA_VERSIONS } from '../constants.js';
-import { showMessage, formatNutrientName, clampNutrient } from '../utils/ui.js';
+import { showMessage, formatNutrientName, clampNutrient, flushPendingUndo } from '../utils/ui.js';
 import { state } from '../state/store.js';
 import { saveDailyEntry, saveTargets } from '../services/firebase.js';
 import { clearStagingArea, updateFoodItemsList, getCurrentDailyEntry } from '../services/data.js';
@@ -124,6 +124,8 @@ function findDailyDuplicate(name, calories) {
  * Core add-to-log logic, extracted so the duplicate confirmation can call it.
  */
 async function commitStagedToLog(staged, qty, foodName) {
+  flushPendingUndo();
+
   const dateStr = state.dom.dateInput.value;
   const todayEntry = getCurrentDailyEntry();
 
@@ -168,6 +170,8 @@ export async function addStagedNutrientsToDailyLog() {
  * Subtracts the staged nutrient values from the current day's log.
  */
 export async function subtractStagedNutrientsFromDailyLog() {
+  flushPendingUndo();
+
   const staged = getStagedValues();
   const dateStr = state.dom.dateInput.value;
   // getCurrentDailyEntry always returns a v2-shaped entry (creates one if needed).

--- a/public/tools/CalorieTracker/staging/parser.js
+++ b/public/tools/CalorieTracker/staging/parser.js
@@ -220,6 +220,8 @@ export function handleStagingAction(mode) {
 
   if (mode === 'replace') {
     showConfirmationModal(`Replace all of ${dateStr} with staged values? This will overwrite existing data for this day.`, async () => {
+      flushPendingUndo();
+
       const qty = parseFloat(document.getElementById('actual-quantity')?.value) || PARSER_CONFIG.DEFAULT_QUANTITY;
       // Start with v2 defaults so the replaced entry retains schema compliance.
       const newEntry = {

--- a/public/tools/CalorieTracker/staging/parser.js
+++ b/public/tools/CalorieTracker/staging/parser.js
@@ -109,20 +109,26 @@ export function getStagedValues() {
 }
 
 /**
- * Adds the staged nutrient values to the current day's log.
+ * Checks whether a food item with the same name and calorie value already
+ * exists in today's log.  Returns the duplicate if found, otherwise null.
  */
-export async function addStagedNutrientsToDailyLog() {
-  const staged = getStagedValues();
-  const dateStr = state.dom.dateInput.value;
-  // getCurrentDailyEntry always returns a v2-shaped entry (creates one if needed).
-  const todayEntry = getCurrentDailyEntry();
-  const qty = parseFloat(document.getElementById('actual-quantity')?.value) || PARSER_CONFIG.DEFAULT_QUANTITY;
+function findDailyDuplicate(name, calories) {
+  const lowerName = name.toLowerCase();
+  return state.dailyFoodItems.find(
+    item => (item.name || '').toLowerCase() === lowerName
+         && Math.round(parseFloat(item.calories) || 0) === Math.round(parseFloat(calories) || 0)
+  ) || null;
+}
 
-  // Add staged values to the existing daily totals with quantity.
+/**
+ * Core add-to-log logic, extracted so the duplicate confirmation can call it.
+ */
+async function commitStagedToLog(staged, qty, foodName) {
+  const dateStr = state.dom.dateInput.value;
+  const todayEntry = getCurrentDailyEntry();
+
   allNutrients.forEach(n => todayEntry[n] = (parseFloat(todayEntry[n]) || 0) + (qty * (staged[n] || 0)));
 
-  // Create a food item record for this addition.
-  const foodName = document.getElementById('food-item-input')?.value.trim() || '(Staged Entry)';
   const foodItem = { id: crypto.randomUUID(), name: foodName, quantity: qty, timestamp: new Date().toISOString(), ...staged };
   state.dailyFoodItems.push(foodItem);
 
@@ -130,10 +136,32 @@ export async function addStagedNutrientsToDailyLog() {
   showMessage("Staged nutrients added to today's log!");
   clearStagingArea();
 
-  // Refresh UI.
   updateDashboard();
   updateChart();
   updateFoodItemsList();
+}
+
+/**
+ * Adds the staged nutrient values to the current day's log.
+ * Prompts for confirmation when a duplicate name+calories entry already exists.
+ */
+export async function addStagedNutrientsToDailyLog() {
+  const staged = getStagedValues();
+  const qty = parseFloat(document.getElementById('actual-quantity')?.value) || PARSER_CONFIG.DEFAULT_QUANTITY;
+  const foodName = document.getElementById('food-item-input')?.value.trim() || '(Staged Entry)';
+
+  const dup = findDailyDuplicate(foodName, staged.calories);
+  if (dup) {
+    const dupQty = parseFloat(dup.quantity ?? 0) || 0;
+    const dupCals = Math.round(dupQty * (parseFloat(dup.calories) || 0));
+    showConfirmationModal(
+      `"${foodName}" (${dupCals} cal) is already in today's log. Add it again?`,
+      () => commitStagedToLog(staged, qty, foodName)
+    );
+    return;
+  }
+
+  await commitStagedToLog(staged, qty, foodName);
 }
 
 /**

--- a/public/tools/CalorieTracker/staging/parser.test.js
+++ b/public/tools/CalorieTracker/staging/parser.test.js
@@ -102,6 +102,58 @@ describe('quantity editing on subtraction item', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Duplicate detection — mirrors findDailyDuplicate from parser.js
+// ---------------------------------------------------------------------------
+
+function isDailyDuplicate(existingItems, name, calories) {
+  const lowerName = name.toLowerCase();
+  return existingItems.some(
+    item => (item.name || '').toLowerCase() === lowerName
+         && Math.round(parseFloat(item.calories) || 0) === Math.round(parseFloat(calories) || 0)
+  );
+}
+
+describe('daily duplicate detection', () => {
+  const existing = [
+    { name: 'Chicken Breast', calories: 165, protein: 31, quantity: 1 },
+    { name: 'Brown Rice', calories: 215, protein: 5, quantity: 1 },
+  ];
+
+  it('detects exact name+calorie match', () => {
+    expect(isDailyDuplicate(existing, 'Chicken Breast', 165)).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isDailyDuplicate(existing, 'chicken breast', 165)).toBe(true);
+    expect(isDailyDuplicate(existing, 'BROWN RICE', 215)).toBe(true);
+  });
+
+  it('does not flag different calories', () => {
+    expect(isDailyDuplicate(existing, 'Chicken Breast', 200)).toBe(false);
+  });
+
+  it('does not flag different name', () => {
+    expect(isDailyDuplicate(existing, 'Salmon', 165)).toBe(false);
+  });
+
+  it('rounds calories for comparison', () => {
+    expect(isDailyDuplicate(existing, 'Chicken Breast', 165.4)).toBe(true);
+    expect(isDailyDuplicate(existing, 'Chicken Breast', 164.6)).toBe(true);
+    expect(isDailyDuplicate(existing, 'Chicken Breast', 163.4)).toBe(false);
+  });
+
+  it('returns false for empty log', () => {
+    expect(isDailyDuplicate([], 'Chicken Breast', 165)).toBe(false);
+  });
+
+  it('handles blank names', () => {
+    const withBlank = [{ name: '', calories: 100, quantity: 1 }];
+    expect(isDailyDuplicate(withBlank, '', 100)).toBe(true);
+    expect(isDailyDuplicate(withBlank, '(Staged Entry)', 100)).toBe(false);
+  });
+});
+
 describe('add and subtract are symmetric at same qty', () => {
   it('add and subtract of same nutrients at same qty cancel to zero effective total', () => {
     const staged = { calories: 250, protein: 30, carbs: 40, fat: 8 };

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -943,3 +943,68 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
   .food-item-bottom  { flex-direction: column; align-items: stretch; }
   .food-item-qty     { width: 100%; }
 }
+
+/* ── Undo toast ────────────────────────────────────────────── */
+.undo-toast {
+  position: fixed;
+  bottom: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  padding: .75rem 1.25rem;
+  background: hsl(var(--surface-2));
+  color: hsl(var(--text));
+  border: 1px solid hsl(var(--border));
+  border-radius: .75rem;
+  box-shadow: var(--shadow-2);
+  z-index: 60;
+  font-size: .875rem;
+  animation: undo-slide-up .2s ease-out;
+}
+.undo-toast.hidden { display: none; }
+.undo-toast-btn {
+  padding: .25rem .75rem;
+  background: hsl(var(--accent));
+  color: hsl(var(--bg));
+  border: none;
+  border-radius: .375rem;
+  font-weight: 600;
+  font-size: .8125rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.undo-toast-btn:hover { opacity: .85; }
+@keyframes undo-slide-up {
+  from { transform: translateX(-50%) translateY(1rem); opacity: 0; }
+  to   { transform: translateX(-50%) translateY(0);    opacity: 1; }
+}
+
+/* ── Sync notice ───────────────────────────────────────────── */
+.sync-notice {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .5rem .75rem;
+  margin-bottom: .75rem;
+  background: hsl(var(--info) / .12);
+  border: 1px solid hsl(var(--info) / .25);
+  border-radius: .5rem;
+  font-size: .75rem;
+  color: hsl(var(--text-2));
+  line-height: 1.35;
+}
+.sync-notice.hidden { display: none; }
+.sync-notice-dismiss {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: hsl(var(--text-3));
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 .25rem;
+  flex-shrink: 0;
+}
+.sync-notice-dismiss:hover { color: hsl(var(--text)); }

--- a/public/tools/CalorieTracker/utils/ui.js
+++ b/public/tools/CalorieTracker/utils/ui.js
@@ -79,9 +79,11 @@ import { NUTRIENT_MAX_BOUNDS } from '../constants.js';
 
 let _undoTimer = null;
 let _pendingCommit = null;
+let _pendingCleanup = null;
 
 export function flushPendingUndo() {
   if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
+  if (_pendingCleanup) { const cleanup = _pendingCleanup; _pendingCleanup = null; cleanup(); }
   if (_pendingCommit) { const fn = _pendingCommit; _pendingCommit = null; fn(); }
 }
 
@@ -103,10 +105,13 @@ export function showUndoToast(text, onUndo, onCommit, duration = 5000) {
   label.textContent = text;
   toast.classList.remove('hidden');
 
+  let freshBtn;
+
   const cleanup = () => {
     toast.classList.add('hidden');
-    btn.removeEventListener('click', handleUndo);
+    freshBtn?.removeEventListener('click', handleUndo);
     if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
+    if (_pendingCleanup === cleanup) _pendingCleanup = null;
   };
 
   const handleUndo = () => {
@@ -116,8 +121,9 @@ export function showUndoToast(text, onUndo, onCommit, duration = 5000) {
   };
 
   btn.replaceWith(btn.cloneNode(true));
-  const freshBtn = document.getElementById('undo-toast-btn');
+  freshBtn = document.getElementById('undo-toast-btn');
   freshBtn.addEventListener('click', handleUndo);
+  _pendingCleanup = cleanup;
 
   _undoTimer = setTimeout(() => {
     const fn = _pendingCommit;

--- a/public/tools/CalorieTracker/utils/ui.js
+++ b/public/tools/CalorieTracker/utils/ui.js
@@ -80,7 +80,7 @@ import { NUTRIENT_MAX_BOUNDS } from '../constants.js';
 let _undoTimer = null;
 let _pendingCommit = null;
 
-function flushPendingUndo() {
+export function flushPendingUndo() {
   if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
   if (_pendingCommit) { const fn = _pendingCommit; _pendingCommit = null; fn(); }
 }

--- a/public/tools/CalorieTracker/utils/ui.js
+++ b/public/tools/CalorieTracker/utils/ui.js
@@ -77,6 +77,44 @@ export const escapeHtml = (value) =>
 
 import { NUTRIENT_MAX_BOUNDS } from '../constants.js';
 
+let _undoTimer = null;
+
+/**
+ * Shows a 5-second undo toast. If the user clicks Undo, onUndo runs and the
+ * pending action is cancelled. Otherwise onCommit fires after the delay.
+ */
+export function showUndoToast(text, onUndo, onCommit, duration = 5000) {
+  const toast = document.getElementById('undo-toast');
+  const label = document.getElementById('undo-toast-text');
+  const btn   = document.getElementById('undo-toast-btn');
+  if (!toast || !label || !btn) return;
+
+  if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
+
+  label.textContent = text;
+  toast.classList.remove('hidden');
+
+  const cleanup = () => {
+    toast.classList.add('hidden');
+    btn.removeEventListener('click', handleUndo);
+    if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
+  };
+
+  const handleUndo = () => {
+    cleanup();
+    onUndo();
+  };
+
+  btn.replaceWith(btn.cloneNode(true));
+  const freshBtn = document.getElementById('undo-toast-btn');
+  freshBtn.addEventListener('click', handleUndo);
+
+  _undoTimer = setTimeout(() => {
+    cleanup();
+    onCommit();
+  }, duration);
+}
+
 /**
  * Clamps a nutrient value to [0, max] and warns the user if the raw value
  * exceeded the bound. Returns the clamped number.

--- a/public/tools/CalorieTracker/utils/ui.js
+++ b/public/tools/CalorieTracker/utils/ui.js
@@ -78,10 +78,18 @@ export const escapeHtml = (value) =>
 import { NUTRIENT_MAX_BOUNDS } from '../constants.js';
 
 let _undoTimer = null;
+let _pendingCommit = null;
+
+function flushPendingUndo() {
+  if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
+  if (_pendingCommit) { const fn = _pendingCommit; _pendingCommit = null; fn(); }
+}
 
 /**
  * Shows a 5-second undo toast. If the user clicks Undo, onUndo runs and the
  * pending action is cancelled. Otherwise onCommit fires after the delay.
+ * If a previous undo toast is still pending, its onCommit runs immediately
+ * before the new toast is shown.
  */
 export function showUndoToast(text, onUndo, onCommit, duration = 5000) {
   const toast = document.getElementById('undo-toast');
@@ -89,8 +97,9 @@ export function showUndoToast(text, onUndo, onCommit, duration = 5000) {
   const btn   = document.getElementById('undo-toast-btn');
   if (!toast || !label || !btn) return;
 
-  if (_undoTimer) { clearTimeout(_undoTimer); _undoTimer = null; }
+  flushPendingUndo();
 
+  _pendingCommit = onCommit;
   label.textContent = text;
   toast.classList.remove('hidden');
 
@@ -101,6 +110,7 @@ export function showUndoToast(text, onUndo, onCommit, duration = 5000) {
   };
 
   const handleUndo = () => {
+    _pendingCommit = null;
     cleanup();
     onUndo();
   };
@@ -110,8 +120,10 @@ export function showUndoToast(text, onUndo, onCommit, duration = 5000) {
   freshBtn.addEventListener('click', handleUndo);
 
   _undoTimer = setTimeout(() => {
+    const fn = _pendingCommit;
+    _pendingCommit = null;
     cleanup();
-    onCommit();
+    if (fn) fn();
   }, duration);
 }
 


### PR DESCRIPTION
## Summary

- **#14 — Duplicate detection in paste-and-parse staging:** `addStagedNutrientsToDailyLog` now checks existing daily food items for matching name + calories before adding. If a duplicate is found, a confirmation modal asks the user before proceeding. 7 new pure-function tests for the matching logic.
- **#15 — Sync notice in UI:** A dismissible info banner appears above the food items list after data loads, informing users that data saves to the cloud but does not sync in real-time between devices. Dismissal is persisted in localStorage.
- **#16 — Delete undo for food items and exercise sessions:** `removeFoodItem` and `removeExerciseSessionById` now use a 5-second undo toast instead of a confirmation modal. The item is removed from local state immediately for responsive UI, but the Firestore write is deferred until the undo window closes. Clicking Undo restores the item; save failures also roll back automatically.

Also reconciles items #7–#13 to `[x]` (merged to main).

Backlog: `backlogs/calorie-tracker.md`

## Checks
- `cd public/tools/CalorieTracker && npm test` — 575 tests, 9 files, all passing

## Files changed
- `public/tools/CalorieTracker/staging/parser.js` — duplicate detection logic
- `public/tools/CalorieTracker/staging/parser.test.js` — 7 new tests
- `public/tools/CalorieTracker/food/manager.js` — undo toast for food item deletion
- `public/tools/CalorieTracker/services/data.js` — undo toast for exercise deletion, sync notice
- `public/tools/CalorieTracker/utils/ui.js` — `showUndoToast` utility
- `public/tools/CalorieTracker/index.html` — undo toast markup
- `public/tools/CalorieTracker/styles.css` — undo toast + sync notice styles
- `backlogs/calorie-tracker.md` — reconcile #7–#13 to [x], mark #14–#16 as [p]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuhMYDn9itfHo5TJeTboCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuhMYDn9itfHo5TJeTboCS)_