### PR TITLE
CalorieTracker: Session G mobile UX improvements (#26, #27, #28, #29, #30, #31)

### DIFF
--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -266,49 +266,49 @@ Use targeted testing judgment:
 
 ## HIGH — accessibility
 
-- [p] **#22 — Tab keyboard navigation missing arrow-key support**
+- [x] **#22 — Tab keyboard navigation missing arrow-key support**
   `index.html:52-58` — ARIA roles are present but no Left/Right key handler exists. WAI-ARIA Authoring Practices requires arrow-key navigation within a tablist. Add a `keydown` listener on the tab bar.
-  > pushed — arrow-key handler already existed; added tabindex roving (active=0, inactive=-1) per WAI-ARIA APG; tests: 575 pass; commit: ea11d84
+  > Resolved: arrow-key handler with tabindex roving (active=0, inactive=-1) per WAI-ARIA APG; tests: 575 pass; merged ea11d84
 
-- [p] **#23 — Muted text contrast borderline in dark theme**
+- [x] **#23 — Muted text contrast borderline in dark theme**
   `shared-styles.css:42-43` — `--text-3: 220 9% 46%` on `--bg: 220 43% 8%` computes to roughly 5.2:1 (passes AA large text, fails WCAG AA for body text). Increase lightness by ~6 points.
-  > pushed — --text-3 lightness increased from 46% to 52% in dark theme; tests: 575 pass; commit: ea11d84
+  > Resolved: --text-3 lightness increased from 46% to 52% in dark theme; tests: 575 pass; merged ea11d84
 
-- [p] **#24 — Nutrient status conveyed by color only**
+- [x] **#24 — Nutrient status conveyed by color only**
   Red/amber/green tags have no text label or icon fallback for colorblind users. Add a short text indicator (e.g., "low", "ok", "over") or a distinct icon per state.
-  > pushed — added text status badges (low/near/ok) to each nutrient row via nt-status-bad/warn/good classes; tests: 575 pass; commit: ea11d84
+  > Resolved: text status badges (low/near/ok) on each nutrient row via nt-status-bad/warn/good classes; tests: 575 pass; merged ea11d84
 
-- [p] **#25 — No `aria-describedby` linking form errors to inputs**
+- [x] **#25 — No `aria-describedby` linking form errors to inputs**
   Error messages render in modals or adjacent divs with no programmatic link to the field that caused them, so screen readers don't associate the two.
-  > pushed — aria-describedby on login (email/password), exercise (duration), body-fat inputs; inline .form-error elements with role=alert; tests: 575 pass; commit: ea11d84
+  > Resolved: aria-describedby on login (email/password), exercise (duration), body-fat inputs; inline .form-error elements with role=alert; tests: 575 pass; merged ea11d84
 
 ---
 
 ## HIGH — mobile / visual
 
-- [ ] **#26 — Today's calorie KPI is buried below the input column on mobile**
+- [p] **#26 — Today's calorie KPI is buried below the input column on mobile**
   The macro summary bar (`index.html:61`) has 0.75 rem values (`styles.css:385`), is easy to miss, and doesn't show "remaining" prominently. Bump value font to 0.875–0.95 rem and make the remaining-calories figure the largest item in the bar — it's the question users open the app to answer.
-  > Resolved in: _pending_
+  > pushed — macro values bumped to .875rem; calories cell shows prominent "X left" remaining figure with .macro-remaining class at 1rem; tests: 575 pass; commit: PENDING
 
-- [ ] **#27 — Fixed pixel chart height (400 px desktop / 280 px mobile)**
+- [p] **#27 — Fixed pixel chart height (400 px desktop / 280 px mobile)**
   `styles.css:535` — use `clamp(220px, 50vw, 420px)` and ensure Chart.js is initialized with `responsive: true, maintainAspectRatio: false` so the chart fills its container fluidly.
-  > Resolved in: _pending_
+  > pushed — chart-container uses clamp(220px, 50vw, 420px); mobile override removed; Chart.js already had responsive:true, maintainAspectRatio:false; tests: 575 pass; commit: PENDING
 
-- [ ] **#28 — Modals not safe at 320 px**
+- [p] **#28 — Modals not safe at 320 px**
   Food Manager (`index.html:650`) and Exercise (`index.html:692`) modals use `max-w-4xl` and `p-4` outer padding. Add `min-width: 280px` and test at 320–360 px viewports.
-  > Resolved in: _pending_
+  > pushed — modal-content min-width:280px; ≤360px media query reduces padding to 1rem and drops min-width; tests: 575 pass; commit: PENDING
 
-- [ ] **#29 — Nutrient form `max-h-[45vh]` clips on small phones**
+- [p] **#29 — Nutrient form `max-h-[45vh]` clips on small phones**
   The collapsible nutrient input section uses a fixed viewport-height cap that leaves bottom inputs behind a tiny scroll area on 360 px phones. Remove or raise the cap conditionally on narrow viewports.
-  > Resolved in: _pending_
+  > pushed — max-h-[45vh] raised to 65vh at ≤480px viewport; tests: 575 pass; commit: PENDING
 
-- [ ] **#30 — No empty states**
+- [p] **#30 — No empty states**
   Food items list, Nutrients tab, and Exercise session list all render as blank divs when empty. Add a one-line placeholder with an icon and a CTA (e.g., "No foods logged yet — add your first item above").
-  > Resolved in: _pending_
+  > pushed — exercise empty state enhanced with icon and CTA; food list and nutrients tab already had empty states; tests: 575 pass; commit: PENDING
 
-- [ ] **#31 — No save confirmation feedback**
+- [p] **#31 — No save confirmation feedback**
   Save buttons show no "Saved ✓" state. Users tap repeatedly because there is no signal that the write succeeded. Add a 1.5-second transient checkmark or toast per save action.
-  > Resolved in: _pending_
+  > pushed — flashSaveConfirmation() in utils/ui.js; applied to add-to-log, save-food, save-profile, apply-targets buttons; .btn-saved CSS class; tests: 575 pass; commit: PENDING
 
 ---
 

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -288,27 +288,27 @@ Use targeted testing judgment:
 
 - [p] **#26 — Today's calorie KPI is buried below the input column on mobile**
   The macro summary bar (`index.html:61`) has 0.75 rem values (`styles.css:385`), is easy to miss, and doesn't show "remaining" prominently. Bump value font to 0.875–0.95 rem and make the remaining-calories figure the largest item in the bar — it's the question users open the app to answer.
-  > pushed — macro values bumped to .875rem; calories cell shows prominent "X left" remaining figure with .macro-remaining class at 1rem; tests: 575 pass; commit: PENDING
+  > pushed — macro values bumped to .875rem; calories cell shows prominent "X left" remaining figure with .macro-remaining class at 1rem; tests: 575 pass; commit: 5f8d8a0
 
 - [p] **#27 — Fixed pixel chart height (400 px desktop / 280 px mobile)**
   `styles.css:535` — use `clamp(220px, 50vw, 420px)` and ensure Chart.js is initialized with `responsive: true, maintainAspectRatio: false` so the chart fills its container fluidly.
-  > pushed — chart-container uses clamp(220px, 50vw, 420px); mobile override removed; Chart.js already had responsive:true, maintainAspectRatio:false; tests: 575 pass; commit: PENDING
+  > pushed — chart-container uses clamp(220px, 50vw, 420px); mobile override removed; Chart.js already had responsive:true, maintainAspectRatio:false; tests: 575 pass; commit: 5f8d8a0
 
 - [p] **#28 — Modals not safe at 320 px**
   Food Manager (`index.html:650`) and Exercise (`index.html:692`) modals use `max-w-4xl` and `p-4` outer padding. Add `min-width: 280px` and test at 320–360 px viewports.
-  > pushed — modal-content min-width:280px; ≤360px media query reduces padding to 1rem and drops min-width; tests: 575 pass; commit: PENDING
+  > pushed — modal-content min-width:280px; ≤360px media query reduces padding to 1rem and drops min-width; tests: 575 pass; commit: 5f8d8a0
 
 - [p] **#29 — Nutrient form `max-h-[45vh]` clips on small phones**
   The collapsible nutrient input section uses a fixed viewport-height cap that leaves bottom inputs behind a tiny scroll area on 360 px phones. Remove or raise the cap conditionally on narrow viewports.
-  > pushed — max-h-[45vh] raised to 65vh at ≤480px viewport; tests: 575 pass; commit: PENDING
+  > pushed — max-h-[45vh] raised to 65vh at ≤480px viewport; tests: 575 pass; commit: 5f8d8a0
 
 - [p] **#30 — No empty states**
   Food items list, Nutrients tab, and Exercise session list all render as blank divs when empty. Add a one-line placeholder with an icon and a CTA (e.g., "No foods logged yet — add your first item above").
-  > pushed — exercise empty state enhanced with icon and CTA; food list and nutrients tab already had empty states; tests: 575 pass; commit: PENDING
+  > pushed — exercise empty state enhanced with icon and CTA; food list and nutrients tab already had empty states; tests: 575 pass; commit: 5f8d8a0
 
 - [p] **#31 — No save confirmation feedback**
   Save buttons show no "Saved ✓" state. Users tap repeatedly because there is no signal that the write succeeded. Add a 1.5-second transient checkmark or toast per save action.
-  > pushed — flashSaveConfirmation() in utils/ui.js; applied to add-to-log, save-food, save-profile, apply-targets buttons; .btn-saved CSS class; tests: 575 pass; commit: PENDING
+  > pushed — flashSaveConfirmation() in utils/ui.js; applied to add-to-log, save-food, save-profile, apply-targets buttons; .btn-saved CSS class; tests: 575 pass; commit: 5f8d8a0
 
 ---
 

--- a/public/tools/CalorieTracker/food/save.js
+++ b/public/tools/CalorieTracker/food/save.js
@@ -6,7 +6,7 @@
 
 import { state, parseQty } from '../state/store.js';
 import { allNutrients } from '../constants.js';
-import { showMessage, handleError, formatNutrientName, escapeHtml } from '../utils/ui.js';
+import { showMessage, handleError, formatNutrientName, escapeHtml, flashSaveConfirmation } from '../utils/ui.js';
 import { showConfirmationModal, closeDuplicateDialog } from '../ui/modals.js';
 import { db } from '../services/firebase.js';
 import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
@@ -74,6 +74,7 @@ async function processSaveFoodItem(foodName, stagedValues) {
     }
 
     showMessage(`✅ "${foodName}" saved to database! Ready to add to today's log.`, false, SAVE_CONFIG.SUCCESS_MESSAGE_DURATION);
+    flashSaveConfirmation(document.getElementById('save-food-item-btn'));
     
   } catch (e) {
     handleError('save-food-item', e, 'Failed to save food item');

--- a/public/tools/CalorieTracker/services/data.js
+++ b/public/tools/CalorieTracker/services/data.js
@@ -537,7 +537,12 @@ export function updateExerciseSessionsList() {
   const sessions = Array.isArray(entry.exerciseSessions) ? entry.exerciseSessions : [];
 
   if (sessions.length === 0) {
-    container.innerHTML = `<p class="text-xs text-muted py-1">No sessions logged — use a Day Activity Level above or add a session.</p>`;
+    container.innerHTML = `
+      <div class="text-center py-4 text-muted">
+        <i class="fas fa-running text-lg mb-1 opacity-50"></i>
+        <p class="text-xs">No exercise sessions logged today.</p>
+        <p class="text-xs mt-1">Tap "Add Session" to log your workout.</p>
+      </div>`;
     return;
   }
 

--- a/public/tools/CalorieTracker/staging/parser.js
+++ b/public/tools/CalorieTracker/staging/parser.js
@@ -4,7 +4,7 @@
  */
 
 import { nutrientMap, allNutrients, SCHEMA_VERSIONS } from '../constants.js';
-import { showMessage, formatNutrientName, clampNutrient, flushPendingUndo } from '../utils/ui.js';
+import { showMessage, formatNutrientName, clampNutrient, flushPendingUndo, flashSaveConfirmation } from '../utils/ui.js';
 import { state, parseQty } from '../state/store.js';
 import { saveDailyEntry, saveTargets } from '../services/firebase.js';
 import { clearStagingArea, updateFoodItemsList, getCurrentDailyEntry } from '../services/data.js';
@@ -140,6 +140,7 @@ async function commitStagedToLog(staged, qty, foodName) {
 
   await saveDailyEntry(dateStr, todayEntry);
   showMessage("Staged nutrients added to today's log!");
+  flashSaveConfirmation(document.getElementById('add-day-btn'));
   clearStagingArea();
 
   updateDashboard();

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -413,11 +413,15 @@ input:focus, textarea:focus, select:focus {
 }
 
 .macro-cell-value {
-  font-size: .75rem;
+  font-size: .875rem;
   font-weight: 700;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.macro-cell-value.macro-remaining {
+  font-size: 1rem;
+  font-weight: 800;
 }
 
 .macro-cell .hbar {
@@ -565,7 +569,7 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
    ============================================================ */
 .chart-container {
   position: relative;
-  height: 400px;
+  height: clamp(220px, 50vw, 420px);
   margin: 20px 0;
 }
 
@@ -604,6 +608,16 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
 }
 
 /* ============================================================
+   SAVE CONFIRMATION
+   ============================================================ */
+.btn-saved {
+  background: hsl(var(--success, 142 71% 45%)) !important;
+  color: #fff !important;
+  pointer-events: none;
+  transition: background .2s;
+}
+
+/* ============================================================
    MODALS
    ============================================================ */
 .modal-backdrop {
@@ -614,6 +628,10 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
   background: hsl(var(--surface-1));
   border: 1px solid hsl(var(--border));
   box-shadow: var(--shadow-2);
+  min-width: 280px;
+}
+@media (max-width: 360px) {
+  .modal-content { padding: 1rem !important; min-width: 0; }
 }
 
 /* ============================================================
@@ -939,11 +957,12 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
     padding: .4rem .75rem;
     grid-template-columns: repeat(2, 1fr);
   }
-  .macro-cell-value  { font-size: .7rem; }
+  .macro-cell-value  { font-size: .8rem; }
+  .macro-cell-value.macro-remaining { font-size: .9rem; }
 
   .settings-panel    { padding: 1rem .75rem; }
   .settings-section  { padding: 1rem .75rem; border-radius: .75rem; }
-  .chart-container   { height: 280px; }
+  /* chart-container uses clamp() — no fixed override needed */
   /* Collapse status grid to 2 cols on small phones */
   .nutrient-status-grid { grid-template-columns: repeat(2, 1fr); }
   /* Slightly larger chips for touch targets */
@@ -951,6 +970,9 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
   .nutrient-filter-chip { min-height: 40px; }
   /* Hide sub-detail on very small screens to save space */
   .nt-sub-detail     { padding-left: 0; }
+
+  /* Raise nutrient input scroll cap on small phones */
+  .max-h-\[45vh\] { max-height: 65vh; }
 
   /* Food item qty input: full width below the macros line */
   .food-item-bottom  { flex-direction: column; align-items: stretch; }

--- a/public/tools/CalorieTracker/targets/targetUI.js
+++ b/public/tools/CalorieTracker/targets/targetUI.js
@@ -10,7 +10,7 @@
  */
 
 import { state } from '../state/store.js';
-import { showMessage, handleError, clampNutrient } from '../utils/ui.js';
+import { showMessage, handleError, clampNutrient, flashSaveConfirmation } from '../utils/ui.js';
 import { saveUserProfile, saveGoalSettings, saveTargets } from '../services/firebase.js';
 import { generateTargets, applyManualOverrides } from './targetEngine.js';
 import { runAnalysis } from '../analysis/engine.js';
@@ -511,6 +511,7 @@ async function handleSaveProfile() {
     _setAutosaveStatus('saved');
     setTimeout(() => _setAutosaveStatus(''), 3000);
     showMessage('Profile and goals saved!');
+    flashSaveConfirmation(document.getElementById('save-profile-btn'));
     try {
       const { updateDashboard } = await import('../ui/dashboard.js');
       const { updateChart } = await import('../ui/chart.js');
@@ -567,10 +568,14 @@ async function handleApplyTargets() {
     updateChart();
 
     showMessage('Targets applied and saved to baseline!');
+    if (btn) {
+      btn.disabled = false;
+      flashSaveConfirmation(btn);
+    }
   } catch (err) {
     handleError('apply-targets', err, 'Failed to apply targets.');
   } finally {
-    if (btn) {
+    if (btn && !btn.classList.contains('btn-saved')) {
       btn.disabled = false;
       btn.innerHTML = '<i class="fas fa-check mr-2"></i>Apply to Baseline Targets';
     }

--- a/public/tools/CalorieTracker/targets/targetUI.js
+++ b/public/tools/CalorieTracker/targets/targetUI.js
@@ -570,6 +570,7 @@ async function handleApplyTargets() {
     showMessage('Targets applied and saved to baseline!');
     if (btn) {
       btn.disabled = false;
+      btn.innerHTML = '<i class="fas fa-check mr-2"></i>Apply to Baseline Targets';
       flashSaveConfirmation(btn);
     }
   } catch (err) {

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -727,22 +727,27 @@ function renderTodayMacroHeader(bankingData) {
     return acc;
   }, { cal: 0, pro: 0, fat: 0, carb: 0 });
 
-  const cell = (label, actual, target) => {
+  const cell = (label, actual, target, isCalorie) => {
     const pct = Math.max(0, Math.min(150, target > 0 ? (actual / target) * 100 : 0));
     const cls = pct >= 100 ? 'good' : pct >= 66 ? 'warn' : 'bad';
+    const remaining = Math.round(target - actual);
+    const remainingText = isCalorie
+      ? `<span class="macro-cell-value macro-remaining ${remaining < 0 ? 'text-negative' : ''}">${remaining} left</span>`
+      : '';
     return `
       <div class="macro-cell">
         <span class="macro-cell-label">${label}</span>
+        ${remainingText}
         <span class="macro-cell-value ${pct > 110 ? 'text-negative' : ''}">${Math.round(actual)}/${Math.round(target)}</span>
         <div class="hbar"><div class="hbar-fill ${cls}" style="width:${pct.toFixed(1)}%"></div></div>
       </div>`;
   };
 
   el.innerHTML =
-    cell('Cal',     totals.cal,  todayKcalTarget) +
-    cell('Protein', totals.pro,  finalProteinG)   +
-    cell('Fat',     totals.fat,  finalFatG)        +
-    cell('Carbs',   totals.carb, finalCarbsG);
+    cell('Cal',     totals.cal,  todayKcalTarget, true)  +
+    cell('Protein', totals.pro,  finalProteinG,   false) +
+    cell('Fat',     totals.fat,  finalFatG,        false) +
+    cell('Carbs',   totals.carb, finalCarbsG,      false);
 }
 
 /**

--- a/public/tools/CalorieTracker/utils/ui.js
+++ b/public/tools/CalorieTracker/utils/ui.js
@@ -166,3 +166,21 @@ export function clampNutrient(nutrient, raw) {
   }
   return Math.max(0, raw);
 }
+
+/**
+ * Briefly shows a checkmark confirmation on a button after a save action.
+ * Stores the original content and restores it after duration.
+ */
+export function flashSaveConfirmation(btn, duration = 1500) {
+  if (!btn) return;
+  const original = btn.innerHTML;
+  const wasDisabled = btn.disabled;
+  btn.innerHTML = '<i class="fas fa-check mr-1"></i>Saved';
+  btn.disabled = true;
+  btn.classList.add('btn-saved');
+  setTimeout(() => {
+    btn.innerHTML = original;
+    btn.disabled = wasDisabled;
+    btn.classList.remove('btn-saved');
+  }, duration);
+}


### PR DESCRIPTION
# CalorieTracker: Session G — Mobile UX

## Items addressed

- **#26 — Calorie KPI prominence**: Macro summary values bumped from .75rem to .875rem; calories cell now shows a prominent "X left" remaining figure at 1rem with `macro-remaining` class, making remaining calories the largest and most visible element.
- **#27 — Fluid chart height**: Replaced fixed `400px` desktop / `280px` mobile with `clamp(220px, 50vw, 420px)` for smooth scaling. Chart.js already had `responsive: true, maintainAspectRatio: false`.
- **#28 — Modals safe at 320px**: Added `min-width: 280px` to `.modal-content`; at ≤360px viewports, padding reduces to 1rem and min-width drops to allow the modal to fit.
- **#29 — Nutrient form scroll clip**: `max-h-[45vh]` raised to `65vh` at ≤480px viewports so bottom inputs are reachable on small phones.
- **#30 — Empty states**: Exercise sessions list enhanced with icon and CTA ("Tap Add Session to log your workout"). Food items list and Nutrients tab already had empty states.
- **#31 — Save confirmation feedback**: New `flashSaveConfirmation()` utility in `utils/ui.js` briefly shows a green "Saved ✓" state on buttons for 1.5s. Applied to add-to-log (+), save-food, save-profile, and apply-targets buttons. `.btn-saved` CSS class provides visual feedback.

## Backlog reconciliation

- Items #22–#25 (Session F) confirmed merged to main — flipped from `[p]` to `[x]`.

## Checks

- `cd public/tools/CalorieTracker && npm test` — **575 tests, 9 files, all passing**

See `backlogs/calorie-tracker.md` for full backlog state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrWz7ryUh7dWttyh6KgdXR)_