### PR TITLE
CalorieTracker: Session H+I polish — tooltips, spinners, icons, UX, typography (#33-#45)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,8 @@ Several tools use Firebase Auth + Firestore. See `SECURITY.md` for auth flows an
 - [ ] `npm run lint` clean
 - [ ] `npm run build` succeeds
 - [ ] UI changes include screenshots
-- [ ] Updated docs if fundamentals changed (README, AGENTS, ARCHITECTURE, SECURITY)
+- [ ] Updated docs if fundamentals changed (README, AGENTS, ARCHITECTURE, SECURITY, BACKLOG)
+- [ ] Doc update confirmed: any structural, routing, auth, data model, or backlog change has matching doc updates in the same PR
 - [ ] Manual test: home page and affected pages work
 
 ## Definition of Done

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -320,35 +320,35 @@ Use targeted testing judgment:
 
 - [p] **#33 — Chart tooltip colors hardcoded, ignoring theme tokens**
   `ui/chart.js:27-38` — tooltip background and text colors are hardcoded dark values. Read `--surface-2` and `--text` CSS variables so tooltips adapt if the theme ever changes.
-  > pushed — getTooltipConfig() reads --surface-1/--text/--border at render time; applied to chart.js and both analysisUI.js charts; tests: 575 pass; commit: 635a289
+  > pushed — getTooltipConfig() reads --surface-1/--text/--border at render time; applied to chart.js and both analysisUI.js charts; tests: 575 pass; commit: 635a289; PR #130
 
 - [p] **#34 — Auto-target → Apply is a two-step flow with long scroll on mobile**
   "Auto-Calculate" and "Apply to Baseline Targets" are far apart vertically on mobile. Combine into a single confirm-and-apply action with a collapsible diff view showing what changed.
-  > pushed — Apply button moved above explanation; explanation and manual overrides in collapsible details; scroll targets preview section; tests: 575 pass; commit: 13bc5d5
+  > pushed — Apply button moved above explanation; explanation and manual overrides in collapsible details; scroll targets preview section; tests: 575 pass; commit: 13bc5d5; PR #130
 
 - [p] **#35 — Exercise modal has too many visible fields for quick logging**
   `index.html:691-790` — RPE, distance, steps, wearable calories, and manual calories are all visible at once. Default to duration + intensity only; progressively disclose the rest.
-  > pushed — RPE, wearable cal, manual cal, and notes wrapped in collapsible details "More options"; duration+intensity+activity stay visible; tests: 575 pass; commit: 13bc5d5
+  > pushed — RPE, wearable cal, manual cal, and notes wrapped in collapsible details "More options"; auto-opens on edit when advanced fields populated; duration+intensity+activity stay visible; tests: 575 pass; commit: 13bc5d5; PR #130
 
 - [p] **#36 — Food search has no inline quantity input**
   Users must select from the dropdown and then click +Add. Add a quantity field inline with the search row so the action collapses to one step.
-  > pushed — food-inline-qty input between search and +Add; syncs with actual-quantity via bidirectional input listeners; tests: 575 pass; commit: c979880
+  > pushed — food-inline-qty input between search and +Add; syncs with actual-quantity via bidirectional input listeners + programmatic sync on saved-food select; tests: 575 pass; commit: c979880 3dc9b23; PR #130
 
 - [p] **#37 — No skeleton loaders during initial data fetch**
   Five Firestore reads run in parallel on load behind a full-screen spinner with no incremental feedback. Replace or supplement with per-section skeleton cards.
-  > pushed — spinner replaced with skeleton-loader: header, tabs, macro bar, and card placeholders with pulse animation; tests: 575 pass; commit: 13bc5d5
+  > pushed — spinner replaced with skeleton-loader: header, tabs, macro bar, and card placeholders with pulse animation; tests: 575 pass; commit: 13bc5d5; PR #130
 
 - [p] **#38 — Native number-input spinners are visually noisy**
   Hide with `::-webkit-outer-spin-button { -webkit-appearance: none; }` across all `input[type="number"]` fields in `styles.css`, or provide custom ± buttons on mobile.
-  > pushed — webkit inner/outer spin-button hidden + moz-appearance:textfield in styles.css; tests: 575 pass; commit: 635a289
+  > pushed — webkit inner/outer spin-button hidden + moz-appearance:textfield in styles.css; tests: 575 pass; commit: 635a289; PR #130
 
 - [p] **#39 — Activity level radio buttons are text-heavy**
   `index.html:341-376` — no visual differentiation between levels. Add a small icon (e.g., walking, jogging, lifting) at the left of each row.
-  > pushed — inline SVG icons per activity level (monitor, walking, jogging, running, flame); .activity-icon styled with theme color; tests: 575 pass; commit: 635a289
+  > pushed — inline SVG icons per activity level (monitor, walking, jogging, running, flame); .activity-icon styled with theme color; tests: 575 pass; commit: 635a289; PR #130
 
 - [p] **#40 — Null UL entries lack explanatory comments**
   `targets/nutritionReferences.js:199-206` — potassium, dietary magnesium, vitamin B12, and vitamin K have no UL because NASEM found no toxicity threshold, not because the values are missing or unknown. Add a short comment so future maintainers don't "fix" them.
-  > pushed — already resolved by #11; all null UL entries have NASEM-citing inline comments; no code change needed; commit: 635a289
+  > pushed — already resolved by #11; all null UL entries have NASEM-citing inline comments; no code change needed; commit: 635a289; PR #130
 
 ---
 
@@ -356,7 +356,7 @@ Use targeted testing judgment:
 
 - [p] **#41 — Fluid typography is half-applied**
   Only the app title uses `clamp()` (`styles.css:308`). Extend to body, label, and value text for smoother cross-device scaling.
-  > pushed — body font-size uses clamp(); all .text-xs through .text-3xl utilities use clamp() for fluid scaling; tests: 575 pass; commit: d2aeb0a
+  > pushed — body font-size uses clamp(); all .text-xs through .text-3xl utilities use clamp() for fluid scaling; tests: 575 pass; commit: d2aeb0a; PR #130
 
 - [ ] **#42 — No PWA / Add to Home Screen support**
   A daily-use nutrition app benefits enormously from a web app manifest + service worker. Install prompt and offline-first loading would meaningfully improve the mobile experience.
@@ -368,11 +368,11 @@ Use targeted testing judgment:
 
 - [p] **#44 — `<details>` expand arrow is a pseudo-content character**
   `styles.css:460` uses `content: '▶'` on `summary::before`. Replace with an SVG icon or Font Awesome caret for better scaling on hidpi displays.
-  > pushed — replaced unicode ▶ with CSS border chevron; scales cleanly on hidpi; rotates 45deg on open; tests: 575 pass; commit: d2aeb0a
+  > pushed — replaced unicode ▶ with CSS border chevron; scales cleanly on hidpi; rotates 45deg on open; literal ▸ removed from micronutrient summary; tests: 575 pass; commit: d2aeb0a; PR #130
 
 - [p] **#45 — Documentation update checklist not enforced**
   The project rules in `AGENTS.md` require docs updates in the same PR as fundamental changes, but there is no checklist item in `CONTRIBUTING.md` (or this README's smoke-test list) to verify it. Add a doc-update line to the PR checklist in `CONTRIBUTING.md`.
-  > pushed — added doc-update confirmation line to PR checklist in CONTRIBUTING.md; BACKLOG added to docs list; commit: d2aeb0a
+  > pushed — added doc-update confirmation line to PR checklist in CONTRIBUTING.md; BACKLOG added to docs list; commit: d2aeb0a; PR #130
 
 ---
 

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -320,35 +320,35 @@ Use targeted testing judgment:
 
 - [p] **#33 — Chart tooltip colors hardcoded, ignoring theme tokens**
   `ui/chart.js:27-38` — tooltip background and text colors are hardcoded dark values. Read `--surface-2` and `--text` CSS variables so tooltips adapt if the theme ever changes.
-  > pushed — getTooltipConfig() reads --surface-1/--text/--border at render time; applied to chart.js and both analysisUI.js charts; tests: 575 pass; commit: pending
+  > pushed — getTooltipConfig() reads --surface-1/--text/--border at render time; applied to chart.js and both analysisUI.js charts; tests: 575 pass; commit: 635a289
 
-- [ ] **#34 — Auto-target → Apply is a two-step flow with long scroll on mobile**
+- [p] **#34 — Auto-target → Apply is a two-step flow with long scroll on mobile**
   "Auto-Calculate" and "Apply to Baseline Targets" are far apart vertically on mobile. Combine into a single confirm-and-apply action with a collapsible diff view showing what changed.
-  > Resolved in: _pending_
+  > pushed — Apply button moved above explanation; explanation and manual overrides in collapsible details; scroll targets preview section; tests: 575 pass; commit: pending
 
-- [ ] **#35 — Exercise modal has too many visible fields for quick logging**
+- [p] **#35 — Exercise modal has too many visible fields for quick logging**
   `index.html:691-790` — RPE, distance, steps, wearable calories, and manual calories are all visible at once. Default to duration + intensity only; progressively disclose the rest.
-  > Resolved in: _pending_
+  > pushed — RPE, wearable cal, manual cal, and notes wrapped in collapsible details "More options"; duration+intensity+activity stay visible; tests: 575 pass; commit: pending
 
 - [ ] **#36 — Food search has no inline quantity input**
   Users must select from the dropdown and then click +Add. Add a quantity field inline with the search row so the action collapses to one step.
   > Resolved in: _pending_
 
-- [ ] **#37 — No skeleton loaders during initial data fetch**
+- [p] **#37 — No skeleton loaders during initial data fetch**
   Five Firestore reads run in parallel on load behind a full-screen spinner with no incremental feedback. Replace or supplement with per-section skeleton cards.
-  > Resolved in: _pending_
+  > pushed — spinner replaced with skeleton-loader: header, tabs, macro bar, and card placeholders with pulse animation; tests: 575 pass; commit: pending
 
 - [p] **#38 — Native number-input spinners are visually noisy**
   Hide with `::-webkit-outer-spin-button { -webkit-appearance: none; }` across all `input[type="number"]` fields in `styles.css`, or provide custom ± buttons on mobile.
-  > pushed — webkit inner/outer spin-button hidden + moz-appearance:textfield in styles.css; tests: 575 pass; commit: pending
+  > pushed — webkit inner/outer spin-button hidden + moz-appearance:textfield in styles.css; tests: 575 pass; commit: 635a289
 
 - [p] **#39 — Activity level radio buttons are text-heavy**
   `index.html:341-376` — no visual differentiation between levels. Add a small icon (e.g., walking, jogging, lifting) at the left of each row.
-  > pushed — inline SVG icons per activity level (monitor, walking, jogging, running, flame); .activity-icon styled with theme color; tests: 575 pass; commit: pending
+  > pushed — inline SVG icons per activity level (monitor, walking, jogging, running, flame); .activity-icon styled with theme color; tests: 575 pass; commit: 635a289
 
 - [p] **#40 — Null UL entries lack explanatory comments**
   `targets/nutritionReferences.js:199-206` — potassium, dietary magnesium, vitamin B12, and vitamin K have no UL because NASEM found no toxicity threshold, not because the values are missing or unknown. Add a short comment so future maintainers don't "fix" them.
-  > pushed — already resolved by #11; all null UL entries have NASEM-citing inline comments; no code change needed; commit: pending
+  > pushed — already resolved by #11; all null UL entries have NASEM-citing inline comments; no code change needed; commit: 635a289
 
 ---
 

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -324,19 +324,19 @@ Use targeted testing judgment:
 
 - [p] **#34 — Auto-target → Apply is a two-step flow with long scroll on mobile**
   "Auto-Calculate" and "Apply to Baseline Targets" are far apart vertically on mobile. Combine into a single confirm-and-apply action with a collapsible diff view showing what changed.
-  > pushed — Apply button moved above explanation; explanation and manual overrides in collapsible details; scroll targets preview section; tests: 575 pass; commit: pending
+  > pushed — Apply button moved above explanation; explanation and manual overrides in collapsible details; scroll targets preview section; tests: 575 pass; commit: 13bc5d5
 
 - [p] **#35 — Exercise modal has too many visible fields for quick logging**
   `index.html:691-790` — RPE, distance, steps, wearable calories, and manual calories are all visible at once. Default to duration + intensity only; progressively disclose the rest.
-  > pushed — RPE, wearable cal, manual cal, and notes wrapped in collapsible details "More options"; duration+intensity+activity stay visible; tests: 575 pass; commit: pending
+  > pushed — RPE, wearable cal, manual cal, and notes wrapped in collapsible details "More options"; duration+intensity+activity stay visible; tests: 575 pass; commit: 13bc5d5
 
-- [ ] **#36 — Food search has no inline quantity input**
+- [p] **#36 — Food search has no inline quantity input**
   Users must select from the dropdown and then click +Add. Add a quantity field inline with the search row so the action collapses to one step.
-  > Resolved in: _pending_
+  > pushed — food-inline-qty input between search and +Add; syncs with actual-quantity via bidirectional input listeners; tests: 575 pass; commit: pending
 
 - [p] **#37 — No skeleton loaders during initial data fetch**
   Five Firestore reads run in parallel on load behind a full-screen spinner with no incremental feedback. Replace or supplement with per-section skeleton cards.
-  > pushed — spinner replaced with skeleton-loader: header, tabs, macro bar, and card placeholders with pulse animation; tests: 575 pass; commit: pending
+  > pushed — spinner replaced with skeleton-loader: header, tabs, macro bar, and card placeholders with pulse animation; tests: 575 pass; commit: 13bc5d5
 
 - [p] **#38 — Native number-input spinners are visually noisy**
   Hide with `::-webkit-outer-spin-button { -webkit-appearance: none; }` across all `input[type="number"]` fields in `styles.css`, or provide custom ± buttons on mobile.

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -332,7 +332,7 @@ Use targeted testing judgment:
 
 - [p] **#36 — Food search has no inline quantity input**
   Users must select from the dropdown and then click +Add. Add a quantity field inline with the search row so the action collapses to one step.
-  > pushed — food-inline-qty input between search and +Add; syncs with actual-quantity via bidirectional input listeners; tests: 575 pass; commit: pending
+  > pushed — food-inline-qty input between search and +Add; syncs with actual-quantity via bidirectional input listeners; tests: 575 pass; commit: c979880
 
 - [p] **#37 — No skeleton loaders during initial data fetch**
   Five Firestore reads run in parallel on load behind a full-screen spinner with no incremental feedback. Replace or supplement with per-section skeleton cards.
@@ -354,9 +354,9 @@ Use targeted testing judgment:
 
 ## LOW / NICE-TO-HAVE
 
-- [ ] **#41 — Fluid typography is half-applied**
+- [p] **#41 — Fluid typography is half-applied**
   Only the app title uses `clamp()` (`styles.css:308`). Extend to body, label, and value text for smoother cross-device scaling.
-  > Resolved in: _pending_
+  > pushed — body font-size uses clamp(); all .text-xs through .text-3xl utilities use clamp() for fluid scaling; tests: 575 pass; commit: pending
 
 - [ ] **#42 — No PWA / Add to Home Screen support**
   A daily-use nutrition app benefits enormously from a web app manifest + service worker. Install prompt and offline-first loading would meaningfully improve the mobile experience.
@@ -366,13 +366,13 @@ Use targeted testing judgment:
   Export exists; import does not. Mirror the Date Night Roulette batch-upload pattern to allow users to seed or migrate their food database from a spreadsheet.
   > Resolved in: _pending_
 
-- [ ] **#44 — `<details>` expand arrow is a pseudo-content character**
+- [p] **#44 — `<details>` expand arrow is a pseudo-content character**
   `styles.css:460` uses `content: '▶'` on `summary::before`. Replace with an SVG icon or Font Awesome caret for better scaling on hidpi displays.
-  > Resolved in: _pending_
+  > pushed — replaced unicode ▶ with CSS border chevron; scales cleanly on hidpi; rotates 45deg on open; tests: 575 pass; commit: pending
 
-- [ ] **#45 — Documentation update checklist not enforced**
+- [p] **#45 — Documentation update checklist not enforced**
   The project rules in `AGENTS.md` require docs updates in the same PR as fundamental changes, but there is no checklist item in `CONTRIBUTING.md` (or this README's smoke-test list) to verify it. Add a doc-update line to the PR checklist in `CONTRIBUTING.md`.
-  > Resolved in: _pending_
+  > pushed — added doc-update confirmation line to PR checklist in CONTRIBUTING.md; BACKLOG added to docs list; commit: pending
 
 ---
 

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -356,7 +356,7 @@ Use targeted testing judgment:
 
 - [p] **#41 — Fluid typography is half-applied**
   Only the app title uses `clamp()` (`styles.css:308`). Extend to body, label, and value text for smoother cross-device scaling.
-  > pushed — body font-size uses clamp(); all .text-xs through .text-3xl utilities use clamp() for fluid scaling; tests: 575 pass; commit: pending
+  > pushed — body font-size uses clamp(); all .text-xs through .text-3xl utilities use clamp() for fluid scaling; tests: 575 pass; commit: d2aeb0a
 
 - [ ] **#42 — No PWA / Add to Home Screen support**
   A daily-use nutrition app benefits enormously from a web app manifest + service worker. Install prompt and offline-first loading would meaningfully improve the mobile experience.
@@ -368,11 +368,11 @@ Use targeted testing judgment:
 
 - [p] **#44 — `<details>` expand arrow is a pseudo-content character**
   `styles.css:460` uses `content: '▶'` on `summary::before`. Replace with an SVG icon or Font Awesome caret for better scaling on hidpi displays.
-  > pushed — replaced unicode ▶ with CSS border chevron; scales cleanly on hidpi; rotates 45deg on open; tests: 575 pass; commit: pending
+  > pushed — replaced unicode ▶ with CSS border chevron; scales cleanly on hidpi; rotates 45deg on open; tests: 575 pass; commit: d2aeb0a
 
 - [p] **#45 — Documentation update checklist not enforced**
   The project rules in `AGENTS.md` require docs updates in the same PR as fundamental changes, but there is no checklist item in `CONTRIBUTING.md` (or this README's smoke-test list) to verify it. Add a doc-update line to the PR checklist in `CONTRIBUTING.md`.
-  > pushed — added doc-update confirmation line to PR checklist in CONTRIBUTING.md; BACKLOG added to docs list; commit: pending
+  > pushed — added doc-update confirmation line to PR checklist in CONTRIBUTING.md; BACKLOG added to docs list; commit: d2aeb0a
 
 ---
 

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -286,29 +286,29 @@ Use targeted testing judgment:
 
 ## HIGH — mobile / visual
 
-- [p] **#26 — Today's calorie KPI is buried below the input column on mobile**
+- [x] **#26 — Today's calorie KPI is buried below the input column on mobile**
   The macro summary bar (`index.html:61`) has 0.75 rem values (`styles.css:385`), is easy to miss, and doesn't show "remaining" prominently. Bump value font to 0.875–0.95 rem and make the remaining-calories figure the largest item in the bar — it's the question users open the app to answer.
-  > pushed — macro values bumped to .875rem; calories cell shows prominent "X left" remaining figure with .macro-remaining class at 1rem; tests: 575 pass; commit: 5f8d8a0
+  > Resolved: macro values bumped to .875rem; calories cell shows prominent "X left" remaining figure with .macro-remaining class at 1rem; tests: 575 pass; merged 5f8d8a0
 
-- [p] **#27 — Fixed pixel chart height (400 px desktop / 280 px mobile)**
+- [x] **#27 — Fixed pixel chart height (400 px desktop / 280 px mobile)**
   `styles.css:535` — use `clamp(220px, 50vw, 420px)` and ensure Chart.js is initialized with `responsive: true, maintainAspectRatio: false` so the chart fills its container fluidly.
-  > pushed — chart-container uses clamp(220px, 50vw, 420px); mobile override removed; Chart.js already had responsive:true, maintainAspectRatio:false; tests: 575 pass; commit: 5f8d8a0
+  > Resolved: chart-container uses clamp(220px, 50vw, 420px); mobile override removed; Chart.js already had responsive:true, maintainAspectRatio:false; tests: 575 pass; merged 5f8d8a0
 
-- [p] **#28 — Modals not safe at 320 px**
+- [x] **#28 — Modals not safe at 320 px**
   Food Manager (`index.html:650`) and Exercise (`index.html:692`) modals use `max-w-4xl` and `p-4` outer padding. Add `min-width: 280px` and test at 320–360 px viewports.
-  > pushed — modal-content min-width:280px; ≤360px media query reduces padding to 1rem and drops min-width; tests: 575 pass; commit: 5f8d8a0
+  > Resolved: modal-content min-width:280px; ≤360px media query reduces padding to 1rem and drops min-width; tests: 575 pass; merged 5f8d8a0
 
-- [p] **#29 — Nutrient form `max-h-[45vh]` clips on small phones**
+- [x] **#29 — Nutrient form `max-h-[45vh]` clips on small phones**
   The collapsible nutrient input section uses a fixed viewport-height cap that leaves bottom inputs behind a tiny scroll area on 360 px phones. Remove or raise the cap conditionally on narrow viewports.
-  > pushed — max-h-[45vh] raised to 65vh at ≤480px viewport; tests: 575 pass; commit: 5f8d8a0
+  > Resolved: max-h-[45vh] raised to 65vh at ≤480px viewport; tests: 575 pass; merged 5f8d8a0
 
-- [p] **#30 — No empty states**
+- [x] **#30 — No empty states**
   Food items list, Nutrients tab, and Exercise session list all render as blank divs when empty. Add a one-line placeholder with an icon and a CTA (e.g., "No foods logged yet — add your first item above").
-  > pushed — exercise empty state enhanced with icon and CTA; food list and nutrients tab already had empty states; tests: 575 pass; commit: 5f8d8a0
+  > Resolved: exercise empty state enhanced with icon and CTA; food list and nutrients tab already had empty states; tests: 575 pass; merged 5f8d8a0
 
-- [p] **#31 — No save confirmation feedback**
+- [x] **#31 — No save confirmation feedback**
   Save buttons show no "Saved ✓" state. Users tap repeatedly because there is no signal that the write succeeded. Add a 1.5-second transient checkmark or toast per save action.
-  > pushed — flashSaveConfirmation() in utils/ui.js; applied to add-to-log, save-food, save-profile, apply-targets buttons; .btn-saved CSS class; tests: 575 pass; commit: 5f8d8a0
+  > Resolved: flashSaveConfirmation() in utils/ui.js; applied to add-to-log, save-food, save-profile, apply-targets buttons; .btn-saved CSS class; tests: 575 pass; merged 5f8d8a0
 
 ---
 
@@ -318,9 +318,9 @@ Use targeted testing judgment:
   `index.html:11` loads Chart.js 3.9.1 from CDN; current stable is v4.x with better mobile defaults and a smaller bundle. Pin a regression baseline with the existing smoke-test checklist before upgrading.
   > Resolved in: _pending_
 
-- [ ] **#33 — Chart tooltip colors hardcoded, ignoring theme tokens**
+- [p] **#33 — Chart tooltip colors hardcoded, ignoring theme tokens**
   `ui/chart.js:27-38` — tooltip background and text colors are hardcoded dark values. Read `--surface-2` and `--text` CSS variables so tooltips adapt if the theme ever changes.
-  > Resolved in: _pending_
+  > pushed — getTooltipConfig() reads --surface-1/--text/--border at render time; applied to chart.js and both analysisUI.js charts; tests: 575 pass; commit: pending
 
 - [ ] **#34 — Auto-target → Apply is a two-step flow with long scroll on mobile**
   "Auto-Calculate" and "Apply to Baseline Targets" are far apart vertically on mobile. Combine into a single confirm-and-apply action with a collapsible diff view showing what changed.
@@ -338,17 +338,17 @@ Use targeted testing judgment:
   Five Firestore reads run in parallel on load behind a full-screen spinner with no incremental feedback. Replace or supplement with per-section skeleton cards.
   > Resolved in: _pending_
 
-- [ ] **#38 — Native number-input spinners are visually noisy**
+- [p] **#38 — Native number-input spinners are visually noisy**
   Hide with `::-webkit-outer-spin-button { -webkit-appearance: none; }` across all `input[type="number"]` fields in `styles.css`, or provide custom ± buttons on mobile.
-  > Resolved in: _pending_
+  > pushed — webkit inner/outer spin-button hidden + moz-appearance:textfield in styles.css; tests: 575 pass; commit: pending
 
-- [ ] **#39 — Activity level radio buttons are text-heavy**
+- [p] **#39 — Activity level radio buttons are text-heavy**
   `index.html:341-376` — no visual differentiation between levels. Add a small icon (e.g., walking, jogging, lifting) at the left of each row.
-  > Resolved in: _pending_
+  > pushed — inline SVG icons per activity level (monitor, walking, jogging, running, flame); .activity-icon styled with theme color; tests: 575 pass; commit: pending
 
-- [ ] **#40 — Null UL entries lack explanatory comments**
+- [p] **#40 — Null UL entries lack explanatory comments**
   `targets/nutritionReferences.js:199-206` — potassium, dietary magnesium, vitamin B12, and vitamin K have no UL because NASEM found no toxicity threshold, not because the values are missing or unknown. Add a short comment so future maintainers don't "fix" them.
-  > Resolved in: _pending_
+  > pushed — already resolved by #11; all null UL entries have NASEM-citing inline comments; no code change needed; commit: pending
 
 ---
 

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -20,6 +20,7 @@ import { buildEatingPatternTargetSeries } from '../targets/targetEngine.js';
 import { handleWeightUpload } from './weightUpload.js';
 import { debugLog, showMessage, escapeHtml } from '../utils/ui.js';
 import { CONFIG } from '../config.js';
+import { getTooltipConfig } from '../ui/chart.js';
 import { getTodayInTimezone } from '../utils/time.js';
 import {
   saveEstimatedEntry,
@@ -954,9 +955,7 @@ function drawEatingPatternChart(rows) {
       plugins: {
         legend: { display: true, position: 'top', labels: { usePointStyle: true, padding: 12 } },
         tooltip: {
-          backgroundColor: 'rgba(0,0,0,0.9)',
-          titleColor: 'white',
-          bodyColor: 'white',
+          ...getTooltipConfig(),
           callbacks: {
             title(items) {
               if (!items.length) return '';
@@ -1726,12 +1725,7 @@ function drawWeightChart(rows) {
       },
       plugins: {
         tooltip: {
-          backgroundColor: 'rgba(0,0,0,0.9)',
-          titleColor: 'white',
-          bodyColor: 'white',
-          borderColor: 'rgba(255,255,255,0.3)',
-          borderWidth: 1,
-          cornerRadius: 8,
+          ...getTooltipConfig(),
           callbacks: {
             title(items) {
               if (!items.length) return '';

--- a/public/tools/CalorieTracker/events/wire.js
+++ b/public/tools/CalorieTracker/events/wire.js
@@ -258,6 +258,13 @@ function wireStagingEvents() {
     if (replaceDayBtn) replaceDayBtn.addEventListener('click', () => handleStagingAction('replace'));
     if (stageToTargetsBtn) stageToTargetsBtn.addEventListener('click', () => handleStagingAction('updateTargets'));
 
+    const inlineQty = document.getElementById('food-inline-qty');
+    const actualQty = document.getElementById('actual-quantity');
+    if (inlineQty && actualQty) {
+      inlineQty.addEventListener('input', () => { actualQty.value = inlineQty.value; });
+      actualQty.addEventListener('input', () => { inlineQty.value = actualQty.value; });
+    }
+
     debugLog('wire', 'Staging events wired');
   } catch (error) {
     handleError('wire-staging', error, 'Failed to wire staging events');

--- a/public/tools/CalorieTracker/events/wire.js
+++ b/public/tools/CalorieTracker/events/wire.js
@@ -400,6 +400,8 @@ function openExerciseModal(sessionId) {
   const title = document.getElementById('exercise-modal-title');
   if (title) title.textContent = sessionId ? 'Edit Exercise Session' : 'Add Exercise Session';
 
+  const advancedDetails = document.querySelector('.exercise-advanced-fields');
+
   if (sessionId) {
     // Populate fields with existing session data
     const dateStr  = state.dom.dateInput?.value || getTodayInTimezone();
@@ -417,6 +419,10 @@ function openExerciseModal(sessionId) {
       document.getElementById('es-wearable-cal').value    = s.wearableCalories || '';
       document.getElementById('es-manual-cal').value      = s.manualCalories   || '';
       document.getElementById('es-notes').value           = s.notes           || '';
+
+      if (advancedDetails) {
+        advancedDetails.open = Boolean(s.rpe || s.wearableCalories || s.manualCalories || s.notes);
+      }
     }
   } else {
     // Reset to defaults
@@ -430,6 +436,8 @@ function openExerciseModal(sessionId) {
     document.getElementById('es-wearable-cal').value    = '';
     document.getElementById('es-manual-cal').value      = '';
     document.getElementById('es-notes').value           = '';
+
+    if (advancedDetails) advancedDetails.open = false;
   }
 
   updateExerciseModalFields();

--- a/public/tools/CalorieTracker/food/manager.js
+++ b/public/tools/CalorieTracker/food/manager.js
@@ -31,8 +31,11 @@ export function populateStagingFromFood(foodData) {
     }
   });
 
+  const quantity = foodData.quantity ?? MANAGER_CONFIG.DEFAULT_QUANTITY;
   const qInput = document.getElementById('actual-quantity');
-  if (qInput) qInput.value = foodData.quantity ?? MANAGER_CONFIG.DEFAULT_QUANTITY;
+  if (qInput) qInput.value = quantity;
+  const inlineQty = document.getElementById('food-inline-qty');
+  if (inlineQty) inlineQty.value = quantity;
 }
 
 /**

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -345,6 +345,7 @@
           <div class="grid grid-cols-1 gap-2">
             <label class="flex items-start gap-3 p-3 rounded-lg border surface-2 cursor-pointer hover:border-accent/50 transition-colors">
               <input type="radio" name="profile-activity" value="sedentary" class="mt-0.5 shrink-0">
+              <svg class="activity-icon shrink-0" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="12" rx="2"/><line x1="8" y1="20" x2="16" y2="20"/><line x1="12" y1="16" x2="12" y2="20"/></svg>
               <span>
                 <span class="text-sm font-medium text-primary block">Sedentary</span>
                 <span class="text-xs text-muted">Desk job, minimal movement (PAL 1.20)</span>
@@ -352,6 +353,7 @@
             </label>
             <label class="flex items-start gap-3 p-3 rounded-lg border surface-2 cursor-pointer hover:border-accent/50 transition-colors">
               <input type="radio" name="profile-activity" value="light" class="mt-0.5 shrink-0">
+              <svg class="activity-icon shrink-0" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="4" r="2"/><path d="M14 10l-2 6-2-6"/><path d="M8 20l2-4"/><path d="M16 20l-2-4"/><path d="M7 10h10"/></svg>
               <span>
                 <span class="text-sm font-medium text-primary block">Lightly active</span>
                 <span class="text-xs text-muted">1–3 days/week exercise (PAL 1.375)</span>
@@ -359,6 +361,7 @@
             </label>
             <label class="flex items-start gap-3 p-3 rounded-lg border surface-2 cursor-pointer hover:border-accent/50 transition-colors">
               <input type="radio" name="profile-activity" value="moderate" class="mt-0.5 shrink-0">
+              <svg class="activity-icon shrink-0" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="14" cy="4" r="2"/><path d="M6 20l4-8 2 2 4-6"/><path d="M18 8l-2 4"/></svg>
               <span>
                 <span class="text-sm font-medium text-primary block">Moderately active</span>
                 <span class="text-xs text-muted">3–5 days/week exercise (PAL 1.55)</span>
@@ -366,6 +369,7 @@
             </label>
             <label class="flex items-start gap-3 p-3 rounded-lg border surface-2 cursor-pointer hover:border-accent/50 transition-colors">
               <input type="radio" name="profile-activity" value="active" class="mt-0.5 shrink-0">
+              <svg class="activity-icon shrink-0" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="16" cy="4" r="2"/><path d="M4 20l5-8 3 2 4-8"/><path d="M18 6l-2 6"/></svg>
               <span>
                 <span class="text-sm font-medium text-primary block">Active</span>
                 <span class="text-xs text-muted">6–7 days/week hard exercise (PAL 1.725)</span>
@@ -373,6 +377,7 @@
             </label>
             <label class="flex items-start gap-3 p-3 rounded-lg border surface-2 cursor-pointer hover:border-accent/50 transition-colors">
               <input type="radio" name="profile-activity" value="very_active" class="mt-0.5 shrink-0">
+              <svg class="activity-icon shrink-0" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2c1 3 3 5 3 8a5 5 0 0 1-10 0c0-3 2-5 3-8"/><path d="M12 12c0.5 1.5 1.5 2.5 1.5 4a2.5 2.5 0 0 1-5 0c0-1.5 1-2.5 1.5-4"/></svg>
               <span>
                 <span class="text-sm font-medium text-primary block">Very active</span>
                 <span class="text-xs text-muted">Physical job or twice-daily training (PAL 1.90)</span>

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -160,6 +160,7 @@
                 <input type="text" id="food-item-input" placeholder="Enter or select food name...">
                 <div id="food-dropdown" class="food-dropdown-list hidden"></div>
               </div>
+              <input type="number" id="food-inline-qty" class="input-xs shrink-0" style="width:3.5rem" min="0" step="0.5" value="1" title="Quantity" aria-label="Quantity">
               <button type="button" id="add-day-btn" class="btn btn-primary icon-btn shrink-0" title="Add to log" aria-label="Add to log">
                 <i class="fas fa-plus"></i>
               </button>

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -22,9 +22,34 @@
     </a>
   </nav>
 
-  <!-- Loading spinner -->
-  <div id="loader" class="flex justify-center items-center h-screen">
-    <i class="fas fa-spinner fa-spin fa-3x text-accent"></i>
+  <!-- Loading skeleton -->
+  <div id="loader" class="skeleton-loader">
+    <div class="skeleton-header">
+      <div class="skeleton-line" style="width:10rem;height:1.5rem"></div>
+      <div class="skeleton-line" style="width:5rem;height:2rem;border-radius:.375rem"></div>
+    </div>
+    <div class="skeleton-tabs">
+      <div class="skeleton-line" style="width:3rem;height:1.5rem"></div>
+      <div class="skeleton-line" style="width:4rem;height:1.5rem"></div>
+      <div class="skeleton-line" style="width:3.5rem;height:1.5rem"></div>
+      <div class="skeleton-line" style="width:5rem;height:1.5rem"></div>
+    </div>
+    <div class="skeleton-macros">
+      <div class="skeleton-line" style="flex:1;height:2.5rem;border-radius:.5rem"></div>
+      <div class="skeleton-line" style="flex:1;height:2.5rem;border-radius:.5rem"></div>
+      <div class="skeleton-line" style="flex:1;height:2.5rem;border-radius:.5rem"></div>
+      <div class="skeleton-line" style="flex:1;height:2.5rem;border-radius:.5rem"></div>
+    </div>
+    <div class="skeleton-card">
+      <div class="skeleton-line" style="width:8rem;height:1.25rem;margin-bottom:.75rem"></div>
+      <div class="skeleton-line" style="width:100%;height:2.5rem;border-radius:.5rem;margin-bottom:.5rem"></div>
+      <div class="skeleton-line" style="width:100%;height:2.5rem;border-radius:.5rem;margin-bottom:.5rem"></div>
+      <div class="skeleton-line" style="width:100%;height:2.5rem;border-radius:.5rem"></div>
+    </div>
+    <div class="skeleton-card">
+      <div class="skeleton-line" style="width:6rem;height:1.25rem;margin-bottom:.75rem"></div>
+      <div class="skeleton-line" style="width:100%;height:3rem;border-radius:.5rem"></div>
+    </div>
   </div>
 
   <!-- ====================================================
@@ -449,13 +474,7 @@
           </p>
         </div>
 
-        <!-- ── Explanation (shown after calculation) ─────────────────── -->
-        <div id="target-explanation" class="settings-section hidden">
-          <h3 class="text-lg font-semibold text-secondary mb-4">How Targets Were Calculated</h3>
-          <div id="target-explanation-content" class="space-y-0 text-sm"></div>
-        </div>
-
-        <!-- ── Target Preview + Overrides (shown after calculation) ───── -->
+        <!-- ── Target Preview (shown after calculation) ─────────────── -->
         <div id="target-preview" class="settings-section hidden">
           <h3 class="text-lg font-semibold text-secondary mb-4">Generated Targets</h3>
           <div id="target-preview-content"></div>
@@ -470,22 +489,30 @@
               style="color:hsl(var(--warning))"></ul>
           </div>
 
-          <!-- Manual Overrides -->
-          <div class="mt-6">
-            <h4 class="text-sm font-semibold text-secondary mb-1">Manual Overrides</h4>
-            <p class="text-xs text-muted mb-3">
-              Check a nutrient to pin it to a custom value. Unchecked nutrients use the auto-calculated value.
-              Overrides are saved with your goals and applied whenever you re-run the engine.
-            </p>
-            <div id="target-override-grid" class="grid grid-cols-1 gap-1"></div>
-          </div>
-
-          <!-- Apply + Save Profile buttons -->
-          <div class="mt-6 flex gap-3 flex-wrap">
+          <!-- Apply button — immediately visible after calculation -->
+          <div class="mt-4 flex gap-3 flex-wrap">
             <button type="button" id="apply-targets-btn" class="btn btn-primary flex-1">
               <i class="fas fa-check mr-2"></i>Apply to Baseline Targets
             </button>
           </div>
+
+          <!-- Explanation — collapsible -->
+          <details id="target-explanation" class="mt-4">
+            <summary class="text-sm text-accent cursor-pointer py-1">How targets were calculated</summary>
+            <div id="target-explanation-content" class="space-y-0 text-sm pt-2"></div>
+          </details>
+
+          <!-- Manual Overrides — collapsible -->
+          <details class="mt-4">
+            <summary class="text-sm text-accent cursor-pointer py-1">Manual overrides</summary>
+            <div class="pt-2">
+              <p class="text-xs text-muted mb-3">
+                Check a nutrient to pin it to a custom value. Unchecked nutrients use the auto-calculated value.
+                Overrides are saved with your goals and applied whenever you re-run the engine.
+              </p>
+              <div id="target-override-grid" class="grid grid-cols-1 gap-1"></div>
+            </div>
+          </details>
         </div>
 
         <!-- ── Target Mode ────────────────────────────────────────────────── -->
@@ -740,13 +767,6 @@
           </div>
         </div>
 
-        <div>
-          <label for="es-rpe" class="block text-sm font-medium text-primary mb-1">
-            RPE <span class="text-muted font-normal">(1–10, optional)</span>
-          </label>
-          <input type="number" id="es-rpe" min="1" max="10" step="0.5" placeholder="e.g. 7">
-        </div>
-
         <!-- Distance row — shown for relevant activities -->
         <div id="es-distance-row" class="hidden grid grid-cols-2 gap-3">
           <div>
@@ -770,24 +790,36 @@
           <input type="number" id="es-steps" min="0" step="100" placeholder="e.g. 8000">
         </div>
 
-        <div>
-          <label for="es-wearable-cal" class="block text-sm font-medium text-primary mb-1">
-            Wearable calories <span class="text-muted font-normal">(optional — overrides MET estimate)</span>
-          </label>
-          <input type="number" id="es-wearable-cal" min="0" placeholder="e.g. 320" oninput="updateExerciseLiveEstimate()">
-        </div>
+        <details class="exercise-advanced-fields">
+          <summary class="text-sm text-accent cursor-pointer py-1">More options</summary>
+          <div class="space-y-3 pt-2">
+            <div>
+              <label for="es-rpe" class="block text-sm font-medium text-primary mb-1">
+                RPE <span class="text-muted font-normal">(1–10, optional)</span>
+              </label>
+              <input type="number" id="es-rpe" min="1" max="10" step="0.5" placeholder="e.g. 7">
+            </div>
 
-        <div>
-          <label for="es-manual-cal" class="block text-sm font-medium text-primary mb-1">
-            Manual calorie override <span class="text-muted font-normal">(optional — highest priority)</span>
-          </label>
-          <input type="number" id="es-manual-cal" min="0" placeholder="e.g. 400" oninput="updateExerciseLiveEstimate()">
-        </div>
+            <div>
+              <label for="es-wearable-cal" class="block text-sm font-medium text-primary mb-1">
+                Wearable calories <span class="text-muted font-normal">(optional — overrides MET estimate)</span>
+              </label>
+              <input type="number" id="es-wearable-cal" min="0" placeholder="e.g. 320" oninput="updateExerciseLiveEstimate()">
+            </div>
 
-        <div>
-          <label for="es-notes" class="block text-sm font-medium text-primary mb-1">Notes <span class="text-muted font-normal">(optional)</span></label>
-          <textarea id="es-notes" rows="2" placeholder="e.g. felt strong, outdoor trail"></textarea>
-        </div>
+            <div>
+              <label for="es-manual-cal" class="block text-sm font-medium text-primary mb-1">
+                Manual calorie override <span class="text-muted font-normal">(optional — highest priority)</span>
+              </label>
+              <input type="number" id="es-manual-cal" min="0" placeholder="e.g. 400" oninput="updateExerciseLiveEstimate()">
+            </div>
+
+            <div>
+              <label for="es-notes" class="block text-sm font-medium text-primary mb-1">Notes <span class="text-muted font-normal">(optional)</span></label>
+              <textarea id="es-notes" rows="2" placeholder="e.g. felt strong, outdoor trail"></textarea>
+            </div>
+          </div>
+        </details>
 
         <!-- Live calorie estimate -->
         <div id="es-estimate-display" class="p-3 rounded-lg surface-2 border text-center text-sm font-medium text-accent">

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -1050,3 +1050,42 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
   flex-shrink: 0;
 }
 .sync-notice-dismiss:hover { color: hsl(var(--text)); }
+
+/* ── Skeleton loader ───────────────────────────────────────── */
+.skeleton-loader {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 1rem 1rem 2rem;
+}
+.skeleton-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: .75rem 0 1rem;
+}
+.skeleton-tabs {
+  display: flex;
+  gap: .75rem;
+  padding-bottom: .75rem;
+  border-bottom: 1px solid hsl(var(--border));
+}
+.skeleton-macros {
+  display: flex;
+  gap: .5rem;
+  padding: .75rem 0;
+}
+.skeleton-card {
+  background: hsl(var(--surface-1));
+  border-radius: .75rem;
+  padding: 1rem;
+  margin-top: .75rem;
+}
+.skeleton-line {
+  background: hsl(var(--surface-2));
+  border-radius: .25rem;
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: .4; }
+  50%      { opacity: .8; }
+}

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -234,6 +234,10 @@ select,
   font-size: .875rem;
 }
 
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+input[type="number"] { -moz-appearance: textfield; }
+
 input::placeholder, textarea::placeholder { color: hsl(var(--text-3)); }
 
 input:focus, textarea:focus, select:focus {
@@ -241,6 +245,9 @@ input:focus, textarea:focus, select:focus {
   border-color: hsl(var(--accent));
   box-shadow: 0 0 0 3px hsl(var(--accent) / .1);
 }
+
+/* ── Activity level icons ───────────────────────────────────── */
+.activity-icon { color: hsl(var(--text-3)); margin-top: 2px; }
 
 /* ============================================================
    BUTTON EXTRAS

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -18,6 +18,7 @@ html, body { min-height: 100dvh; margin: 0; }
 
 body {
   font-family: 'Poppins', sans-serif;
+  font-size: clamp(.875rem, 1.6vw, 1rem);
   background: hsl(var(--bg));
   color: hsl(var(--text));
 }
@@ -70,14 +71,14 @@ body {
 .ml-2 { margin-left: .5rem; }
 .ml-auto { margin-left: auto; }
 
-/* ── Typography ─────────────────────────────────────────────── */
-.text-xs   { font-size: .75rem;   line-height: 1rem; }
-.text-sm   { font-size: .875rem;  line-height: 1.25rem; }
-.text-md   { font-size: 1rem; }
-.text-lg   { font-size: 1.125rem; }
-.text-xl   { font-size: 1.25rem; }
-.text-2xl  { font-size: 1.5rem; }
-.text-3xl  { font-size: 1.875rem; }
+/* ── Typography (fluid) ─────────────────────────────────────── */
+.text-xs   { font-size: clamp(.6875rem, 1.2vw, .75rem);   line-height: 1rem; }
+.text-sm   { font-size: clamp(.8125rem, 1.4vw, .875rem);  line-height: 1.25rem; }
+.text-md   { font-size: clamp(.9375rem, 1.6vw, 1rem); }
+.text-lg   { font-size: clamp(1rem, 1.8vw, 1.125rem); }
+.text-xl   { font-size: clamp(1.125rem, 2vw, 1.25rem); }
+.text-2xl  { font-size: clamp(1.25rem, 2.4vw, 1.5rem); }
+.text-3xl  { font-size: clamp(1.5rem, 3vw, 1.875rem); }
 .font-medium   { font-weight: 500; }
 .font-semibold { font-weight: 600; }
 .font-bold     { font-weight: 700; }
@@ -499,14 +500,17 @@ details.collapsible > summary {
 }
 details.collapsible > summary::-webkit-details-marker { display: none; }
 details.collapsible > summary::before {
-  content: '▶';
+  content: '';
   display: inline-block;
-  font-size: .5625rem;
+  width: .5625rem;
+  height: .5625rem;
+  border-right: 2px solid hsl(var(--text-3));
+  border-bottom: 2px solid hsl(var(--text-3));
+  transform: rotate(-45deg);
   transition: transform .18s;
-  color: hsl(var(--text-3));
   flex-shrink: 0;
 }
-details.collapsible[open] > summary::before { transform: rotate(90deg); }
+details.collapsible[open] > summary::before { transform: rotate(45deg); }
 details.collapsible > summary:hover { color: hsl(var(--text)); }
 
 /* ── Staging sticky headings ────────────────────────────────── */

--- a/public/tools/CalorieTracker/targets/targetUI.js
+++ b/public/tools/CalorieTracker/targets/targetUI.js
@@ -447,7 +447,7 @@ function renderTargetPreview(result, currentOverrides) {
         </div>`).join('')}
     </div>
     <details class="text-sm">
-      <summary class="cursor-pointer text-secondary font-medium mb-2">All micronutrient targets ▸</summary>
+      <summary class="cursor-pointer text-secondary font-medium mb-2">All micronutrient targets</summary>
       <div class="grid grid-cols-2 gap-x-4 gap-1 mt-2">
         ${MICRO_KEYS.map(({ key, label }) => `
           <div class="flex justify-between text-xs py-0.5 border-b border-border/20">

--- a/public/tools/CalorieTracker/targets/targetUI.js
+++ b/public/tools/CalorieTracker/targets/targetUI.js
@@ -326,7 +326,7 @@ async function calculateAndRenderTargets({ scroll = false } = {}) {
 
     // Only scroll when triggered by the explicit button click
     if (scroll) {
-      document.getElementById('target-explanation')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      document.getElementById('target-preview')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   } catch (err) {
     handleError('auto-calculate', err, 'Failed to calculate targets.');
@@ -389,7 +389,7 @@ async function _doAutosave() {
 function renderExplanation(result) {
   const section = document.getElementById('target-explanation');
   const content = document.getElementById('target-explanation-content');
-  if (!section || !content || !result.explanation) { section?.classList.add('hidden'); return; }
+  if (!section || !content || !result.explanation) { if (section) section.style.display = 'none'; return; }
 
   const exp = result.explanation;
   const rows = [
@@ -411,7 +411,7 @@ function renderExplanation(result) {
       <span class="text-primary">${value ?? '—'}</span>
     </div>`).join('');
 
-  section.classList.remove('hidden');
+  section.style.display = '';
 }
 
 // ---------------------------------------------------------------------------

--- a/public/tools/CalorieTracker/ui/chart.js
+++ b/public/tools/CalorieTracker/ui/chart.js
@@ -24,12 +24,8 @@ const CHART_CONFIG = {
     offsetY: 1
   },
   
-  // Tooltip styling
-  TOOLTIP_CONFIG: {
-    backgroundColor: 'rgba(0,0,0,0.9)',
-    titleColor: 'white',
-    bodyColor: 'white',
-    borderColor: 'rgba(255,255,255,0.3)',
+  // Tooltip styling (structural defaults; colors resolved at render time via getTooltipConfig)
+  TOOLTIP_STRUCTURAL: {
     borderWidth: 1,
     cornerRadius: 8,
     displayColors: true,
@@ -46,6 +42,17 @@ const CHART_CONFIG = {
 // Pull border color token for target line
 const css = getComputedStyle(document.documentElement);
 const borderColor = `hsl(${css.getPropertyValue('--border').trim()})`;
+
+export function getTooltipConfig() {
+  const cs = getComputedStyle(document.documentElement);
+  return {
+    ...CHART_CONFIG.TOOLTIP_STRUCTURAL,
+    backgroundColor: `hsl(${cs.getPropertyValue('--surface-1').trim()})`,
+    titleColor: `hsl(${cs.getPropertyValue('--text').trim()})`,
+    bodyColor: `hsl(${cs.getPropertyValue('--text').trim()})`,
+    borderColor: `hsl(${cs.getPropertyValue('--border').trim()})`,
+  };
+}
 
 // Chart colors are provided by CONFIG.CHART_COLORS
 
@@ -514,7 +521,7 @@ export function updateChart() {
         },
         plugins: {
           tooltip: {
-            ...CHART_CONFIG.TOOLTIP_CONFIG,
+            ...getTooltipConfig(),
             filter: function(tooltipItem) {
               return !tooltipItem.dataset._isTargetLine && !tooltipItem.dataset._isAverage;
             },


### PR DESCRIPTION
## Summary

Completes Session H (polish & hygiene) and most of Session I (nice-to-have) from the CalorieTracker backlog. Also reconciles Session G items (#26-31) to `[x]` after merge.

### Items addressed

- **#33** — Chart tooltip colors now read `--surface-1`, `--text`, `--border` CSS vars at render time via `getTooltipConfig()`, applied to all three charts (nutrients, energy, weight)
- **#34** — Auto-target Apply button moved above explanation; explanation and manual overrides wrapped in collapsible `<details>` so Calculate→Apply fits on one mobile screen
- **#35** — Exercise modal: RPE, wearable calories, manual calorie override, and notes wrapped in collapsible "More options"; auto-opens on edit when any advanced field has a saved value; closed by default for new sessions
- **#36** — Inline quantity input added between food search box and +Add button; bidirectional sync with staging area quantity; programmatic sync on saved-food selection
- **#37** — Full-screen spinner replaced with skeleton loader showing header, tabs, macro bar, and card placeholders with pulse animation
- **#38** — Native number-input spinners hidden via webkit/moz appearance rules
- **#39** — Inline SVG icons (monitor, walking, jogging, running, flame) added to activity level radio buttons
- **#40** — Already resolved by #11; all null UL entries have NASEM-citing comments
- **#41** — Fluid typography extended: body and all `.text-xs` through `.text-3xl` utilities use `clamp()` for smooth cross-device scaling
- **#44** — Unicode ▶ in `<details>` summary replaced with CSS border chevron; literal ▸ removed from micronutrient target summary
- **#45** — Doc-update confirmation line added to PR checklist in CONTRIBUTING.md

### Follow-up fixes (post-initial push)

- **#36 regression**: `populateStagingFromFood()` now sets both `#actual-quantity` and `#food-inline-qty` so saved-food selection updates the visible inline quantity
- **#35 regression**: `openExerciseModal()` auto-opens `.exercise-advanced-fields` when editing a session with rpe, wearableCalories, manualCalories, or notes; keeps it closed for new sessions
- **Backlog refs**: All `[p]` entries reference both commit SHA and PR #130; repo uses merge commits so branch SHAs are reachable from main after merge

### Not included

- **#32** (Chart.js 3→4 upgrade) — skipped; requires visual regression verification
- **#42** (PWA support), **#43** (CSV food import) — remaining Session I items for a future batch

## Checks
- `cd public/tools/CalorieTracker && npm test` — passed (575 tests, 9 files)

## Docs changed
- `backlogs/calorie-tracker.md` — reconciled #26-31 to `[x]`; marked #33-#45 as `[p]` with commit SHAs and PR ref
- `CONTRIBUTING.md` — added doc-update checklist line (#45)

Backlog: `backlogs/calorie-tracker.md`