### PR TITLE
CalorieTracker: Today macro summary redesign, expandable target breakdown (#47, #48)

### DIFF
--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -154,13 +154,14 @@ _(empty)_
 
 ### HIGH
 
-- [ ] **#47 Today macro summary bar redesign** — *[quick win]* Clean, prominent bar at the
+- [p] **#47 Today macro summary bar redesign** — *[quick win]* Clean, prominent bar at the
   top of the Today view: Calories with **remaining clearly highlighted**, Protein/Fat/Carbs,
   and the current daily target number. Refine `renderTodayMacroHeader` / `renderTodayCompact`
   (`ui/dashboard.js`); strip the inline `Base + Exercise + Bank = Target` text formula (it
   moves into #48). Keep the main view focused on food entry. Files: `ui/dashboard.js`,
   `styles.css`, `index.html`.
-- [ ] **#48 Clickable target → expandable financial-statement breakdown** — *[quick win]*
+  > pushed — redesigned sticky macro header and dashboard hero card; tests: 575 pass; commit: 2de2407
+- [p] **#48 Clickable target → expandable financial-statement breakdown** — *[quick win]*
   Make the target number a clickable `<summary>` that expands to clean vertical rows: Base
   target → Exercise impact → **bridge to best-guess TDEE (bold final TDEE line)** → Banking
   adjustment → Goal-based reduction → **Final Target** (the number that drives Remaining).
@@ -170,6 +171,7 @@ _(empty)_
   `computeTDEE` metadata (`targets/dailyTargetResolver.js`, `targets/targetEngine.js:232`).
   No calc change — `todayKcalTarget` already drives `remaining`. Files: `ui/dashboard.js`,
   `targets/dailyTargetResolver.js` (expose bridge fields if needed), `styles.css`.
+  > pushed — clickable <details> target with financial-statement breakdown panel; tests: 575 pass; commit: bcb139b
 - [ ] **#49 Zero-log vacation / low-log quick button** — *[quick win]* Render only when the
   current day has no food items **and** no existing daily document data that would be overwritten
   (exercise sessions, day-activity selection, legacy top-level calories, notes, or other

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -401,18 +401,48 @@ input:focus, textarea:focus, select:focus {
    MACRO SUMMARY BAR  (inside app-bar, Today tab only)
    ============================================================ */
 .macro-summary-bar {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: .5rem;
+  display: flex;
+  flex-direction: column;
+  gap: .375rem;
   padding: .5rem 1rem;
   background: hsl(var(--surface-2) / .5);
   border-top: 1px solid hsl(var(--border));
 }
 
+/* Calorie hero section in sticky bar */
+.macro-cal-hero {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: .25rem .5rem;
+}
+.macro-cal-remaining {
+  font-size: 1.25rem;
+  font-weight: 800;
+  line-height: 1;
+}
+.macro-cal-meta {
+  font-size: .6875rem;
+  color: hsl(var(--text-3));
+  white-space: nowrap;
+}
+.macro-cal-bar {
+  width: 100%;
+  height: 4px;
+  flex-shrink: 0;
+}
+
+/* P / F / C grid */
+.macro-pfc-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: .375rem;
+}
+
 .macro-cell { display: flex; flex-direction: column; min-width: 0; }
 
 .macro-cell-label {
-  font-size: .625rem;
+  font-size: .5625rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: .06em;
@@ -421,26 +451,99 @@ input:focus, textarea:focus, select:focus {
 }
 
 .macro-cell-value {
-  font-size: .875rem;
+  font-size: .8125rem;
   font-weight: 700;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.macro-cell-value.macro-remaining {
-  font-size: 1rem;
-  font-weight: 800;
+
+.macro-cell-remain {
+  font-size: .625rem;
+  font-weight: 500;
 }
 
 .macro-cell .hbar {
-  height: 4px;
-  margin-top: .15rem;
+  height: 3px;
+  margin-top: .125rem;
   border-radius: 999px;
   background: hsl(var(--surface-3));
   overflow: hidden;
 }
 
 .macro-cell .hbar-fill { height: 100%; border-radius: 999px; }
+
+/* ============================================================
+   TODAY HERO (dashboard output, calorie summary card)
+   ============================================================ */
+.today-hero {
+  margin-bottom: 1rem;
+  padding: 1rem 1.25rem;
+  background: hsl(var(--surface-2));
+  border: 1px solid hsl(var(--border));
+  border-radius: .75rem;
+}
+
+.today-hero-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.today-hero-remaining { text-align: left; }
+.today-hero-label {
+  font-size: .6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: hsl(var(--text-3));
+}
+.today-hero-number {
+  font-size: 2.5rem;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.today-hero-stats {
+  display: flex;
+  gap: 1rem;
+  text-align: right;
+}
+.today-hero-stat {
+  display: flex;
+  flex-direction: column;
+}
+.today-hero-stat-val {
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+.today-hero-stat-label {
+  font-size: .625rem;
+  color: hsl(var(--text-3));
+}
+.today-mode-badge {
+  font-size: .5625rem;
+  font-weight: 600;
+}
+
+.today-warnings {
+  margin-top: .5rem;
+  padding-top: .375rem;
+  border-top: 1px solid hsl(var(--border));
+}
+.today-warning-line {
+  font-size: .6875rem;
+  color: hsl(var(--warning));
+  line-height: 1.4;
+}
+
+.today-macros {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
 
 /* ============================================================
    TAB PANELS
@@ -963,13 +1066,15 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
   .section-card      { padding: 1rem .75rem; border-radius: .75rem; }
   .tab-btn           { padding: .625rem .625rem; font-size: .8rem; }
 
-  /* Macro summary bar: 2×2 grid on narrow phones */
-  .macro-summary-bar {
-    padding: .4rem .75rem;
-    grid-template-columns: repeat(2, 1fr);
-  }
-  .macro-cell-value  { font-size: .8rem; }
-  .macro-cell-value.macro-remaining { font-size: .9rem; }
+  /* Macro summary bar: tighter on narrow phones */
+  .macro-summary-bar { padding: .375rem .75rem; }
+  .macro-cal-remaining { font-size: 1.125rem; }
+  .macro-cell-value { font-size: .75rem; }
+
+  /* Today hero: stack vertically */
+  .today-hero-top { flex-direction: column; align-items: flex-start; gap: .5rem; }
+  .today-hero-stats { align-self: stretch; justify-content: space-between; text-align: left; }
+  .today-hero-number { font-size: 2rem; }
 
   .settings-panel    { padding: 1rem .75rem; }
   .settings-section  { padding: 1rem .75rem; border-radius: .75rem; }

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -546,6 +546,73 @@ input:focus, textarea:focus, select:focus {
 }
 
 /* ============================================================
+   TARGET BREAKDOWN (expandable financial-statement, #48)
+   ============================================================ */
+.target-breakdown-details {
+  position: relative;
+}
+.target-breakdown-details > summary {
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.target-breakdown-details > summary::-webkit-details-marker { display: none; }
+.target-breakdown-details[open] > summary .today-hero-stat-label {
+  opacity: .7;
+}
+
+.target-breakdown-panel {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: 20;
+  min-width: 16rem;
+  padding: .75rem;
+  background: hsl(var(--surface-1));
+  border: 1px solid hsl(var(--border));
+  border-radius: .5rem;
+  box-shadow: var(--shadow-2);
+  text-align: left;
+}
+
+.target-breakdown-section {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+  padding-bottom: .5rem;
+  margin-bottom: .5rem;
+  border-bottom: 1px solid hsl(var(--border));
+}
+.target-breakdown-section:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.target-breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: .75rem;
+  font-size: .75rem;
+  line-height: 1.5;
+}
+.target-breakdown-final {
+  padding-top: .375rem;
+  margin-top: .125rem;
+  border-top: 2px solid hsl(var(--text-3));
+  font-weight: 700;
+  font-size: .8125rem;
+}
+
+.target-breakdown-note {
+  font-size: .6875rem;
+  color: hsl(var(--text-3));
+  margin-top: .375rem;
+  font-style: italic;
+}
+
+/* ============================================================
    TAB PANELS
    ============================================================ */
 .tab-panel { outline: none; }

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -375,6 +375,7 @@ export function calculateBankingData(targetDateStr) {
       tdeeSource:      todayResolvedFull.planningTdeeSource      ?? null,
       tdeeSourceLabel: todayResolvedFull.planningTdeeSourceLabel ?? null,
       planningTdee:    todayResolvedFull.planningTdee            ?? null,
+      goalDeficit:     todayResolvedFull.goalDeficit             ?? null,
 
       // Aliases for structured consumers (Today/Energy/Nutrients)
       finalCalories:    todayKcalTarget,
@@ -1044,7 +1045,7 @@ function renderTodayCompact(bankingData) {
     bankMode, targetFloorApplied, effectiveFloor, floorSource, scheduleCapped,
     scheduleAdjustment, macroFloorExceedsCalories,
     bankAdjustmentApplied, manualBankCapped, bankBalance, rawBankBalance,
-    exerciseAddMode, planningTdee, tdeeSourceLabel,
+    exerciseAddMode, planningTdee, tdeeSourceLabel, goalDeficit,
     displayProteinG, displayFatG, displayCarbsG,
   } = bankingData;
 
@@ -1109,6 +1110,11 @@ function renderTodayCompact(bankingData) {
   if (planningTdee) {
     breakdownRows.push({ label: `Planning TDEE (${tdeeSourceLabel ?? 'estimate'})`, value: `${planningTdee} kcal`, cls: 'text-muted', bold: false });
   }
+  if (planningTdee && goalDeficit != null && goalDeficit !== 0) {
+    const sign = goalDeficit > 0 ? '+' : '';
+    const defLabel = goalDeficit < 0 ? 'Goal deficit' : 'Goal surplus';
+    breakdownRows.push({ label: defLabel, value: `${sign}${goalDeficit} kcal/day`, cls: goalDeficit < 0 ? 'text-negative' : 'text-positive', bold: false });
+  }
   breakdownRows.push({
     label: `Base target (${targetMode === 'autoGoal' ? 'Auto Goal' : 'Manual'})`,
     value: `${todayBaseCalories} kcal`, cls: '', bold: false,
@@ -1127,10 +1133,11 @@ function renderTodayCompact(bankingData) {
       });
     }
   } else if (bankMode === 'manualRolling' && bankAdjustmentApplied !== 0) {
-    let bankLabel = `Rolling bank: ${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied} kcal`;
-    if (manualBankCapped) bankLabel += ` (raw: ${bankBalance > 0 ? '+' : ''}${bankBalance})`;
+    const bankValue = manualBankCapped
+      ? `${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied} kcal (raw: ${bankBalance > 0 ? '+' : ''}${bankBalance}, capped)`
+      : `${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied} kcal`;
     breakdownRows.push({
-      label: 'Rolling bank', value: `${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied} kcal`,
+      label: 'Rolling bank', value: bankValue,
       cls: bankAdjustmentApplied > 0 ? 'text-positive' : 'text-negative', bold: false,
     });
   }

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -710,7 +710,8 @@ export function activateTab(name) {
 // =========================
 
 /**
- * Render the compact 4-cell macro progress bar into #today-macro-header.
+ * Render the compact macro progress bar into #today-macro-header.
+ * Prominent remaining-calorie readout + compact P/F/C cells.
  */
 function renderTodayMacroHeader(bankingData) {
   const el = document.getElementById('today-macro-header');
@@ -727,27 +728,33 @@ function renderTodayMacroHeader(bankingData) {
     return acc;
   }, { cal: 0, pro: 0, fat: 0, carb: 0 });
 
-  const cell = (label, actual, target, isCalorie) => {
-    const pct = Math.max(0, Math.min(150, target > 0 ? (actual / target) * 100 : 0));
-    const cls = pct >= 100 ? 'good' : pct >= 66 ? 'warn' : 'bad';
-    const remaining = Math.round(target - actual);
-    const remainingText = isCalorie
-      ? `<span class="macro-cell-value macro-remaining ${remaining < 0 ? 'text-negative' : ''}">${remaining} left</span>`
-      : '';
+  const calRemaining = Math.round(todayKcalTarget - totals.cal);
+  const calPct = clampPct150(totals.cal, todayKcalTarget);
+  const calLabel = calRemaining >= 0 ? 'left' : 'over';
+
+  const macroCell = (label, actual, target) => {
+    const pct = clampPct150(actual, target);
+    const rem = Math.round(target - actual);
     return `
       <div class="macro-cell">
         <span class="macro-cell-label">${label}</span>
-        ${remainingText}
-        <span class="macro-cell-value ${pct > 110 ? 'text-negative' : ''}">${Math.round(actual)}/${Math.round(target)}</span>
-        <div class="hbar"><div class="hbar-fill ${cls}" style="width:${pct.toFixed(1)}%"></div></div>
+        <span class="macro-cell-value ${pct > 110 ? 'text-negative' : ''}">${Math.round(actual)}/${Math.round(target)}g</span>
+        <span class="macro-cell-remain ${remainClass(rem)}">${rem > 0 ? `${rem}g left` : rem < 0 ? `${Math.abs(rem)}g over` : 'on target'}</span>
+        <div class="hbar"><div class="hbar-fill ${pctClass(actual, target)}" style="width:${pct.toFixed(1)}%"></div></div>
       </div>`;
   };
 
-  el.innerHTML =
-    cell('Cal',     totals.cal,  todayKcalTarget, true)  +
-    cell('Protein', totals.pro,  finalProteinG,   false) +
-    cell('Fat',     totals.fat,  finalFatG,        false) +
-    cell('Carbs',   totals.carb, finalCarbsG,      false);
+  el.innerHTML = `
+    <div class="macro-cal-hero">
+      <span class="macro-cal-remaining ${calRemaining < 0 ? 'text-negative' : ''}">${Math.abs(calRemaining)}</span>
+      <span class="macro-cal-meta">kcal ${calLabel} · ${Math.round(totals.cal)} / ${todayKcalTarget}</span>
+      <div class="hbar macro-cal-bar"><div class="hbar-fill ${pctClass(totals.cal, todayKcalTarget)}" style="width:${calPct.toFixed(1)}%"></div></div>
+    </div>
+    <div class="macro-pfc-grid">
+      ${macroCell('Protein', totals.pro, finalProteinG)}
+      ${macroCell('Fat', totals.fat, finalFatG)}
+      ${macroCell('Carbs', totals.carb, finalCarbsG)}
+    </div>`;
 }
 
 /**
@@ -1032,9 +1039,9 @@ function renderCalcDetailsPanel(bankingData) {
 function renderTodayCompact(bankingData) {
   const {
     todayKcalTarget, finalProteinG, finalFatG, finalCarbsG,
-    todayBaseCalories, todaysTrainingBump, bankBalance, bankIncomplete, unknownDays, targetMode,
-    bankMode, scheduleAdjustment, rawBankBalance, targetFloorApplied, effectiveFloor, floorSource, scheduleCapped,
-    macroFloorExceedsCalories, bankAdjustmentApplied, manualBankCapped,
+    bankIncomplete, unknownDays, targetMode,
+    bankMode, targetFloorApplied, effectiveFloor, floorSource, scheduleCapped,
+    scheduleAdjustment, macroFloorExceedsCalories,
   } = bankingData;
 
   const totals = state.dailyFoodItems.reduce((acc, item) => {
@@ -1048,7 +1055,6 @@ function renderTodayCompact(bankingData) {
 
   const remaining   = todayKcalTarget - totals.calories;
   const remainColor = remaining >= 0 ? 'text-positive' : 'text-negative';
-  // Label changes when over target so the large number isn't mistaken for a negative calorie target
   const remainLabel = remaining >= 0 ? 'Calories Remaining' : 'Calories Over Target';
   const remainDisplay = Math.abs(Math.round(remaining));
 
@@ -1072,75 +1078,47 @@ function renderTodayCompact(bankingData) {
   };
 
   const modeBadge = targetMode === 'autoGoal'
-    ? `<span class="text-xs font-medium text-accent ml-1">Auto Goal</span>`
-    : `<span class="text-xs text-muted ml-1">Manual Baseline</span>`;
+    ? `<span class="today-mode-badge text-accent">Auto Goal</span>`
+    : `<span class="today-mode-badge text-muted">Manual</span>`;
 
-  // Build the adjustment segment of the formula line.
-  let adjSegment = '';
-  if (bankMode === 'autoGoalSchedule') {
-    if (scheduleAdjustment !== 0) {
-      adjSegment = ` + Schedule: ${scheduleAdjustment > 0 ? '+' : ''}${scheduleAdjustment}`;
-    }
-  } else {
-    // Manual mode — rolling bank (use applied/capped value in formula)
-    if (bankAdjustmentApplied !== 0) {
-      adjSegment = ` + Bank: ${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied}`;
-      if (manualBankCapped) {
-        adjSegment += ` (raw: ${bankBalance > 0 ? '+' : ''}${bankBalance}, capped)`;
-      }
-    }
+  // Warning notes — only actionable warnings, no formula text
+  const warnings = [];
+  if (targetFloorApplied) {
+    warnings.push(`Target floored at ${effectiveFloor} kcal${floorSource === 'bmr_floor' ? ' (BMR min)' : ''}.`);
   }
-  const exerciseSegment = todaysTrainingBump > 0 ? ` + Exercise: +${todaysTrainingBump}` : '';
+  if (macroFloorExceedsCalories) {
+    warnings.push('Protein + fat floors exceed calorie target — carbs set to 0.');
+  }
+  if (scheduleCapped) {
+    warnings.push(`Schedule correction capped at ${scheduleAdjustment} kcal/day.`);
+  }
+  if (bankIncomplete) {
+    warnings.push(`${bankMode === 'autoGoalSchedule' ? 'Schedule' : 'Bank'} incomplete — missing: ${unknownDays.join(', ')}.`);
+  }
 
-  // Informational raw-bank line for Auto Goal mode
-  const rawBankNote = bankMode === 'autoGoalSchedule' && rawBankBalance !== 0
-    ? `<div class="text-xs text-muted mt-0.5">
-        7-day raw ${rawBankBalance < 0 ? 'overage' : 'credit'}: ${Math.abs(rawBankBalance)} kcal
-        ${rawBankBalance < 0 && scheduleAdjustment !== 0 ? '— spread over goal window' : ''}
-        ${rawBankBalance > 0 && scheduleAdjustment > 0 ? '— spread forward as a small schedule increase' : ''}
-       </div>`
-    : '';
-
-  const bankNote = bankIncomplete
-    ? `<div class="text-xs text-warning mt-1">⚠ ${bankMode === 'autoGoalSchedule' ? 'Schedule context' : 'Rolling bank'} incomplete — missing data for: ${unknownDays.join(', ')}. Unknown days treated as on-target.</div>`
-    : '';
-
-  const floorNote = targetFloorApplied
-    ? `<div class="text-xs text-warning mt-1">⚠ Target was floored at ${effectiveFloor} kcal${floorSource === 'bmr_floor' ? ' (BMR-based minimum)' : ''}. Goal date may need adjustment or recent overage is being carried forward.</div>`
-    : '';
-
-  const capNote = scheduleCapped
-    ? `<div class="text-xs text-warning mt-0.5">Schedule correction capped at ${scheduleAdjustment} kcal/day (daily limit). Goal date may benefit from extension.</div>`
-    : '';
-
-  const profileNote = targetMode !== 'autoGoal'
-    ? `<div class="text-xs text-muted mt-0.5 italic" style="font-size:0.7rem">Profile &amp; Goals only changes Today after "Apply to Baseline Targets" or switching to Auto Goal mode.</div>`
-    : '';
-
-  const macroFeasibilityNote = macroFloorExceedsCalories
-    ? `<div class="text-xs text-warning mt-1">⚠ Protein + fat floors exceed today's calorie target — carbs set to 0. Consider relaxing the target or adjusting macro floors.</div>`
+  const warningHtml = warnings.length > 0
+    ? `<div class="today-warnings">${warnings.map(w => `<div class="today-warning-line">⚠ ${w}</div>`).join('')}</div>`
     : '';
 
   return `
-    <div class="mb-4 p-4 surface-2 rounded-lg border text-center">
-      <div class="text-xs text-muted uppercase tracking-wide mb-1">${remainLabel}</div>
-      <div class="text-4xl font-bold ${remainColor}">${remainDisplay}</div>
-      <div class="text-xs text-muted mt-1">${Math.round(totals.calories)} eaten · ${todayKcalTarget} target</div>
-      <div class="text-xs text-muted mt-1">
-        Target: ${modeBadge} · Base: ${todayBaseCalories}${exerciseSegment}${adjSegment} = ${todayKcalTarget} kcal
+    <div class="today-hero">
+      <div class="today-hero-top">
+        <div class="today-hero-remaining">
+          <div class="today-hero-label">${remainLabel}</div>
+          <div class="today-hero-number ${remainColor}">${remainDisplay}</div>
+        </div>
+        <div class="today-hero-stats">
+          <div class="today-hero-stat"><span class="today-hero-stat-val">${Math.round(totals.calories)}</span><span class="today-hero-stat-label">eaten</span></div>
+          <div class="today-hero-stat"><span class="today-hero-stat-val">${todayKcalTarget}</span><span class="today-hero-stat-label">target ${modeBadge}</span></div>
+        </div>
       </div>
-      ${rawBankNote}
-      ${floorNote}
-      ${macroFeasibilityNote}
-      ${capNote}
-      ${bankNote}
-      ${profileNote}
       <div class="hbar mt-2">
         <div class="hbar-fill ${pctClass(totals.calories, todayKcalTarget)}" style="width:${pctWidth(totals.calories, todayKcalTarget)}"></div>
         <div class="hbar-marker" style="left:${markerLeft}"></div>
       </div>
+      ${warningHtml}
     </div>
-    <div class="divide-y">
+    <div class="today-macros">
       ${macroRow('Protein', totals.protein, finalProteinG)}
       ${macroRow('Fat (min)', totals.fat, finalFatG)}
       ${macroRow('Carbs', totals.carbs, finalCarbsG)}

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -1039,9 +1039,13 @@ function renderCalcDetailsPanel(bankingData) {
 function renderTodayCompact(bankingData) {
   const {
     todayKcalTarget, finalProteinG, finalFatG, finalCarbsG,
+    todayBaseCalories, todaysTrainingBump, todaysTrainingBumpRaw,
     bankIncomplete, unknownDays, targetMode,
     bankMode, targetFloorApplied, effectiveFloor, floorSource, scheduleCapped,
     scheduleAdjustment, macroFloorExceedsCalories,
+    bankAdjustmentApplied, manualBankCapped, bankBalance, rawBankBalance,
+    exerciseAddMode, planningTdee, tdeeSourceLabel,
+    displayProteinG, displayFatG, displayCarbsG,
   } = bankingData;
 
   const totals = state.dailyFoodItems.reduce((acc, item) => {
@@ -1100,6 +1104,59 @@ function renderTodayCompact(bankingData) {
     ? `<div class="today-warnings">${warnings.map(w => `<div class="today-warning-line">⚠ ${w}</div>`).join('')}</div>`
     : '';
 
+  // #48 — expandable target breakdown (financial-statement style)
+  const breakdownRows = [];
+  if (planningTdee) {
+    breakdownRows.push({ label: `Planning TDEE (${tdeeSourceLabel ?? 'estimate'})`, value: `${planningTdee} kcal`, cls: 'text-muted', bold: false });
+  }
+  breakdownRows.push({
+    label: `Base target (${targetMode === 'autoGoal' ? 'Auto Goal' : 'Manual'})`,
+    value: `${todayBaseCalories} kcal`, cls: '', bold: false,
+  });
+  if (exerciseAddMode === 'skip' && todaysTrainingBumpRaw > 0) {
+    breakdownRows.push({ label: 'Exercise (in TDEE)', value: `+${todaysTrainingBumpRaw} kcal — not added`, cls: 'text-muted', bold: false });
+  } else if (todaysTrainingBump > 0) {
+    breakdownRows.push({ label: 'Exercise', value: `+${todaysTrainingBump} kcal`, cls: 'text-accent', bold: false });
+  }
+  if (bankMode === 'autoGoalSchedule') {
+    if (scheduleAdjustment !== 0) {
+      breakdownRows.push({
+        label: scheduleAdjustment > 0 ? 'Schedule credit' : 'Schedule correction',
+        value: `${scheduleAdjustment > 0 ? '+' : ''}${scheduleAdjustment} kcal`,
+        cls: scheduleAdjustment > 0 ? 'text-positive' : 'text-negative', bold: false,
+      });
+    }
+  } else if (bankMode === 'manualRolling' && bankAdjustmentApplied !== 0) {
+    let bankLabel = `Rolling bank: ${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied} kcal`;
+    if (manualBankCapped) bankLabel += ` (raw: ${bankBalance > 0 ? '+' : ''}${bankBalance})`;
+    breakdownRows.push({
+      label: 'Rolling bank', value: `${bankAdjustmentApplied > 0 ? '+' : ''}${bankAdjustmentApplied} kcal`,
+      cls: bankAdjustmentApplied > 0 ? 'text-positive' : 'text-negative', bold: false,
+    });
+  }
+  if (targetFloorApplied) {
+    breakdownRows.push({ label: `Floor applied (${floorSource === 'bmr_floor' ? 'BMR' : 'minimum'})`, value: `${effectiveFloor} kcal`, cls: 'text-warning', bold: false });
+  }
+  breakdownRows.push({ label: 'Final Target', value: `${todayKcalTarget} kcal`, cls: '', bold: true });
+
+  const breakdownHtml = breakdownRows.map(r =>
+    `<div class="target-breakdown-row${r.bold ? ' target-breakdown-final' : ''}">
+      <span>${r.label}</span>
+      <span class="${r.cls} ${r.bold ? 'font-bold' : ''}">${r.value}</span>
+    </div>`
+  ).join('');
+
+  const macroBreakdownHtml = `
+    <div class="target-breakdown-section">
+      <div class="target-breakdown-row"><span>Protein</span><span>${displayProteinG}g</span></div>
+      <div class="target-breakdown-row"><span>Fat (min)</span><span>${displayFatG}g</span></div>
+      <div class="target-breakdown-row"><span>Carbs</span><span>${displayCarbsG}g (${finalCarbsG}g after adjustments)</span></div>
+    </div>`;
+
+  const rawBankInfo = bankMode === 'autoGoalSchedule' && rawBankBalance !== 0
+    ? `<div class="target-breakdown-note">7-day raw ${rawBankBalance < 0 ? 'overage' : 'credit'}: ${Math.abs(rawBankBalance)} kcal</div>`
+    : '';
+
   return `
     <div class="today-hero">
       <div class="today-hero-top">
@@ -1109,7 +1166,17 @@ function renderTodayCompact(bankingData) {
         </div>
         <div class="today-hero-stats">
           <div class="today-hero-stat"><span class="today-hero-stat-val">${Math.round(totals.calories)}</span><span class="today-hero-stat-label">eaten</span></div>
-          <div class="today-hero-stat"><span class="today-hero-stat-val">${todayKcalTarget}</span><span class="today-hero-stat-label">target ${modeBadge}</span></div>
+          <details class="target-breakdown-details">
+            <summary class="today-hero-stat">
+              <span class="today-hero-stat-val">${todayKcalTarget}</span>
+              <span class="today-hero-stat-label">target ${modeBadge} ▾</span>
+            </summary>
+            <div class="target-breakdown-panel">
+              <div class="target-breakdown-section">${breakdownHtml}</div>
+              ${macroBreakdownHtml}
+              ${rawBankInfo}
+            </div>
+          </details>
         </div>
       </div>
       <div class="hbar mt-2">


### PR DESCRIPTION
## Summary

- **#47 Today macro summary bar redesign** — Redesigned the sticky macro header and dashboard hero card. Prominent remaining-calorie readout with eaten/target stats, compact P/F/C grid with per-macro remaining and progress bars. Stripped the inline formula text from the Today view (moved into #48). Condensed warning notes into scannable one-line format. Added responsive styles for narrow viewports.

- **#48 Clickable target → expandable financial-statement breakdown** — Made the target number on the Today view a clickable `<details>` element that expands to a financial-statement-style breakdown: Planning TDEE → Base target → Exercise → Banking/Schedule adjustment → Floor → Final Target, plus protein/fat/carb target rows. Reuses metadata already computed by `calculateBankingData` and `resolveDailyPlanningTargets`.

## Checks

- `cd public/tools/CalorieTracker && npm test` — 575 tests, 9 files, all passing

## Files changed

- `public/tools/CalorieTracker/ui/dashboard.js` — `renderTodayMacroHeader`, `renderTodayCompact`
- `public/tools/CalorieTracker/styles.css` — macro summary bar, today hero, target breakdown panel
- `backlogs/calorie-tracker.md` — marked #47 and #48 as `[p]`

## Backlog reference

See `backlogs/calorie-tracker.md` for protocol and active items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kq6sYKzik9LFxLfy1FZCnx)_