### PR TITLE
CalorieTracker: vacation quick-estimate button, shared chart date-range control (#49, #50)

### DIFF
--- a/backlogs/calorie-tracker-completed.md
+++ b/backlogs/calorie-tracker-completed.md
@@ -128,6 +128,16 @@ For the active backlog (new items, protocol, invariants), see `backlogs/calorie-
 
 ---
 
+## HIGH — UI/UX & information architecture
+
+- [x] **#47 — Today macro summary bar redesign**
+  > Resolved: redesigned sticky macro header and dashboard hero card with prominent remaining-calorie readout, compact P/F/C grid, stripped inline formula text; merged 2de2407
+
+- [x] **#48 — Clickable target → expandable financial-statement breakdown**
+  > Resolved: clickable details target with financial-statement breakdown panel (TDEE → Base → Exercise → Banking → Goal deficit → Final Target plus macro targets); merged bcb139b, fix dbd2509
+
+---
+
 ## MEDIUM — polish & hygiene
 
 - [x] **#32 — Chart.js 3.9.1 is two majors behind**

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -169,6 +169,7 @@ _(#47 and #48 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   (`constants.js:9`), saved through `saveEstimatedEntry` without clobbering preserved fields.
   Later weight-based correction is handled by #56. Files: `index.html`, `events/wire.js`,
   `ui/dashboard.js`, `analysis/engine.js` (reuse).
+  > pushed — vacation quick-estimate panel with 4 presets + custom; rest key added to VACATION_TYPE_CONFIG; tests: 575 pass; commit: 200a37b
 - [p] **#50 Shared chart date-range control** — *[quick win]* One reusable control applied to
   every chart: presets **Last 7 / 30 / 90 days / YTD / 1 Year**, **Since goal start**, and
   **custom From/To** date pickers. Because normalized `goalSettings` currently has `targetDate`
@@ -179,6 +180,7 @@ _(#47 and #48 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   the nutrient chart, weight-trend chart, eating-pattern chart, and the new corrections chart
   (#52). Files: new `ui/dateRange.js` (small helper), `ui/chart.js`,
   `analysis/analysisUI.js`, `index.html`, `styles.css`.
+  > pushed — new ui/dateRange.js with chip presets + custom From/To; applied to all 3 charts; tests: 575 pass; commit: df2b0af
 
 ### MEDIUM
 

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -169,7 +169,7 @@ _(#47 and #48 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   (`constants.js:9`), saved through `saveEstimatedEntry` without clobbering preserved fields.
   Later weight-based correction is handled by #56. Files: `index.html`, `events/wire.js`,
   `ui/dashboard.js`, `analysis/engine.js` (reuse).
-- [ ] **#50 Shared chart date-range control** — *[quick win]* One reusable control applied to
+- [p] **#50 Shared chart date-range control** — *[quick win]* One reusable control applied to
   every chart: presets **Last 7 / 30 / 90 days / YTD / 1 Year**, **Since goal start**, and
   **custom From/To** date pickers. Because normalized `goalSettings` currently has `targetDate`
   but no persisted start-date field, either add a goal-start field with schema/UI migration and

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -154,25 +154,8 @@ _(empty)_
 
 ### HIGH
 
-- [p] **#47 Today macro summary bar redesign** — *[quick win]* Clean, prominent bar at the
-  top of the Today view: Calories with **remaining clearly highlighted**, Protein/Fat/Carbs,
-  and the current daily target number. Refine `renderTodayMacroHeader` / `renderTodayCompact`
-  (`ui/dashboard.js`); strip the inline `Base + Exercise + Bank = Target` text formula (it
-  moves into #48). Keep the main view focused on food entry. Files: `ui/dashboard.js`,
-  `styles.css`, `index.html`.
-  > pushed — redesigned sticky macro header and dashboard hero card; tests: 575 pass; commit: 2de2407
-- [p] **#48 Clickable target → expandable financial-statement breakdown** — *[quick win]*
-  Make the target number a clickable `<summary>` that expands to clean vertical rows: Base
-  target → Exercise impact → **bridge to best-guess TDEE (bold final TDEE line)** → Banking
-  adjustment → Goal-based reduction → **Final Target** (the number that drives Remaining).
-  Surface protein/fat/carb targets in the same row format. Reuse/adapt the existing
-  `renderCalcDetailsPanel` (`ui/dashboard.js:894`, currently on the Energy tab) into a
-  collapsible on Today; add the TDEE-bridge rows from `resolveDailyPlanningTargets` /
-  `computeTDEE` metadata (`targets/dailyTargetResolver.js`, `targets/targetEngine.js:232`).
-  No calc change — `todayKcalTarget` already drives `remaining`. Files: `ui/dashboard.js`,
-  `targets/dailyTargetResolver.js` (expose bridge fields if needed), `styles.css`.
-  > pushed — clickable <details> target with financial-statement breakdown panel; tests: 575 pass; commit: bcb139b
-- [ ] **#49 Zero-log vacation / low-log quick button** — *[quick win]* Render only when the
+_(#47 and #48 completed — moved to `backlogs/calorie-tracker-completed.md`)_
+- [p] **#49 Zero-log vacation / low-log quick button** — *[quick win]* Render only when the
   current day has no food items **and** no existing daily document data that would be overwritten
   (exercise sessions, day-activity selection, legacy top-level calories, notes, or other
   non-food fields), unless the implementation explicitly merges and preserves those fields.

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -22,6 +22,7 @@ import { debugLog, showMessage, escapeHtml } from '../utils/ui.js';
 import { CONFIG } from '../config.js';
 import { getTooltipConfig } from '../ui/chart.js';
 import { getTodayInTimezone } from '../utils/time.js';
+import { renderDateRangeControl, initDateRangeEvents, resolveRange, daysBetween } from '../ui/dateRange.js';
 import {
   saveEstimatedEntry,
   removeEstimateItem,
@@ -156,21 +157,23 @@ export function initAnalysisEvents() {
     drawEatingPatternChart(state.analysisResults.rows);
   }
 
-  // Redraw eating pattern chart when the "include estimates" toggle changes
   document.getElementById('eating-chart-include-estimates')?.addEventListener('change', () => {
     if (state.analysisResults && !state.analysisResults.error) {
       drawEatingPatternChart(state.analysisResults.rows);
     }
   });
 
-  const timeframeSelect = document.getElementById('weight-chart-timeframe');
-  if (timeframeSelect) {
-    timeframeSelect.addEventListener('change', () => {
-      if (state.analysisResults && !state.analysisResults.error) {
-        drawWeightChart(state.analysisResults.rows);
-      }
-    });
-  }
+  initDateRangeEvents('eating-chart', () => {
+    if (state.analysisResults && !state.analysisResults.error) {
+      drawEatingPatternChart(state.analysisResults.rows);
+    }
+  });
+
+  initDateRangeEvents('weight-chart', () => {
+    if (state.analysisResults && !state.analysisResults.error) {
+      drawWeightChart(state.analysisResults.rows);
+    }
+  });
 
   // ── Missing Calories section (unified candidates only) ────────────────────
   const allCandidates = state._trueUpCandidates || [];
@@ -752,6 +755,7 @@ function renderEatingPatternChart(results) {
   return `
     <div class="mb-6 card p-6 shadow-lg">
       <h3 class="text-responsive-xl font-bold text-secondary mb-1">📊 Eating Pattern vs Weight Change</h3>
+      ${renderDateRangeControl('eating-chart', { defaultPreset: '90' })}
       <div class="mb-3 flex flex-wrap gap-4 items-center text-sm">
         <label class="flex items-center gap-2 cursor-pointer">
           <input type="checkbox" id="eating-chart-include-estimates" class="h-4 w-4">
@@ -815,6 +819,10 @@ function drawEatingPatternChart(rows) {
   const canvas = document.getElementById('eating-pattern-chart');
   if (!canvas || !rows || rows.length === 0) return;
 
+  const range = resolveRange('eating-chart');
+  const visibleRows = rows.filter(r => r.date >= range.startDate && r.date <= range.endDate);
+  if (visibleRows.length === 0) return;
+
   const WINDOW = 7;
   const chartColors = CONFIG.CHART_COLORS || [];
   const calsColor   = chartColors[2] || '#3b82f6';
@@ -824,30 +832,25 @@ function drawEatingPatternChart(rows) {
 
   const tdeeVal  = state.analysisResults?.bmrModel?.tdee_current || null;
 
-  // Respect the "include estimates" toggle if it exists in the DOM
   const includeEstimates = document.getElementById('eating-chart-include-estimates')?.checked ?? false;
 
-  // Only draw reported calorie series from the first day the user manually logged food.
-  // This prevents weight data before tracking started from appearing as calorie points.
   const firstNutritionDate = findFirstManualNutritionDate();
 
-  // Build 7d rolling average from REAL logged calories only.
-  // Engine-imputed values (r.calories_imputed) are never included as reported intake.
   const labels        = [];
   const rollingCals   = [];
   const smoothWeights = [];
 
-  for (let i = 0; i < rows.length; i++) {
-    labels.push(rows[i].date);
-    smoothWeights.push(rows[i].wt_smooth_lb);
+  for (let i = 0; i < visibleRows.length; i++) {
+    labels.push(visibleRows[i].date);
+    smoothWeights.push(visibleRows[i].wt_smooth_lb);
 
     // Before tracking started: no calorie data point
-    if (!firstNutritionDate || rows[i].date < firstNutritionDate) {
+    if (!firstNutritionDate || visibleRows[i].date < firstNutritionDate) {
       rollingCals.push(null);
       continue;
     }
 
-    const slice = rows.slice(Math.max(0, i - WINDOW + 1), i + 1);
+    const slice = visibleRows.slice(Math.max(0, i - WINDOW + 1), i + 1);
     const calVals = slice
       .filter(r => firstNutritionDate && r.date >= firstNutritionDate)
       .map(r => _realCaloriesForDate(r.date, includeEstimates))
@@ -983,13 +986,8 @@ function renderWeightChart() {
     <div class="mb-6 card p-6 shadow-lg">
       <div class="flex justify-between items-center mb-4">
         <h3 class="text-responsive-xl font-bold text-secondary">Weight Trend</h3>
-        <select id="weight-chart-timeframe" class="p-2 border rounded-md" style="width:auto;">
-          <option value="90">Last 90 Days</option>
-          <option value="180">Last 180 Days</option>
-          <option value="365">Last Year</option>
-          <option value="all">All Time</option>
-        </select>
       </div>
+      ${renderDateRangeControl('weight-chart', { defaultPreset: '90' })}
       <div style="position:relative; height:350px;">
         <canvas id="weight-trend-chart"></canvas>
       </div>
@@ -1650,10 +1648,8 @@ function drawWeightChart(rows) {
   const canvas = document.getElementById('weight-trend-chart');
   if (!canvas) return;
 
-  const timeframeSelect = document.getElementById('weight-chart-timeframe');
-  const daysBack = timeframeSelect?.value === 'all' ? rows.length : parseInt(timeframeSelect?.value || '90');
-  const cutoffIdx = Math.max(0, rows.length - daysBack);
-  const visible = rows.slice(cutoffIdx);
+  const range = resolveRange('weight-chart');
+  const visible = rows.filter(r => r.date >= range.startDate && r.date <= range.endDate);
 
   const labels = [], rawData = [], smoothData = [];
   for (const r of visible) {

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -821,7 +821,10 @@ function drawEatingPatternChart(rows) {
 
   const range = resolveRange('eating-chart');
   const visibleRows = rows.filter(r => r.date >= range.startDate && r.date <= range.endDate);
-  if (visibleRows.length === 0) return;
+  if (visibleRows.length === 0) {
+    if (window._eatingPatternChart) { window._eatingPatternChart.destroy(); window._eatingPatternChart = null; }
+    return;
+  }
 
   const WINDOW = 7;
   const chartColors = CONFIG.CHART_COLORS || [];
@@ -836,6 +839,20 @@ function drawEatingPatternChart(rows) {
 
   const firstNutritionDate = findFirstManualNutritionDate();
 
+  // Build rolling averages from full history so the window isn't truncated at range boundaries
+  const fullRolling = new Map();
+  for (let i = 0; i < rows.length; i++) {
+    if (!firstNutritionDate || rows[i].date < firstNutritionDate) continue;
+    const slice = rows.slice(Math.max(0, i - WINDOW + 1), i + 1);
+    const calVals = slice
+      .filter(r => firstNutritionDate && r.date >= firstNutritionDate)
+      .map(r => _realCaloriesForDate(r.date, includeEstimates))
+      .filter(v => v != null);
+    fullRolling.set(rows[i].date, calVals.length >= 3
+      ? Math.round(calVals.reduce((a, b) => a + b, 0) / calVals.length)
+      : null);
+  }
+
   const labels        = [];
   const rollingCals   = [];
   const smoothWeights = [];
@@ -843,22 +860,7 @@ function drawEatingPatternChart(rows) {
   for (let i = 0; i < visibleRows.length; i++) {
     labels.push(visibleRows[i].date);
     smoothWeights.push(visibleRows[i].wt_smooth_lb);
-
-    // Before tracking started: no calorie data point
-    if (!firstNutritionDate || visibleRows[i].date < firstNutritionDate) {
-      rollingCals.push(null);
-      continue;
-    }
-
-    const slice = visibleRows.slice(Math.max(0, i - WINDOW + 1), i + 1);
-    const calVals = slice
-      .filter(r => firstNutritionDate && r.date >= firstNutritionDate)
-      .map(r => _realCaloriesForDate(r.date, includeEstimates))
-      .filter(v => v != null);
-
-    rollingCals.push(calVals.length >= 3
-      ? Math.round(calVals.reduce((a, b) => a + b, 0) / calVals.length)
-      : null);
+    rollingCals.push(fullRolling.get(visibleRows[i].date) ?? null);
   }
 
   if (window._eatingPatternChart) { window._eatingPatternChart.destroy(); window._eatingPatternChart = null; }

--- a/public/tools/CalorieTracker/analysis/engine.js
+++ b/public/tools/CalorieTracker/analysis/engine.js
@@ -1294,6 +1294,12 @@ export function classifyAllDays(rows, dailyEntries, perDayResiduals = null) {
 
 /** Calorie-adjustment parameters keyed by vacation day type. */
 export const VACATION_TYPE_CONFIG = {
+  rest: {
+    label: 'Rest',
+    description: 'Resting day — minimal activity, 0–2k steps',
+    tdeeMultiplier: 0.80,
+    calorieOffset: -100,
+  },
   light: {
     label: 'Light',
     description: 'Relaxed day — lower activity, leisurely meals',

--- a/public/tools/CalorieTracker/events/wire.js
+++ b/public/tools/CalorieTracker/events/wire.js
@@ -15,9 +15,9 @@ import { openFoodManager, closeFoodManager, selectFoodItem, editFoodItem, delete
 import { closeBlankFoodNameModal, closeDuplicateDialog } from '../ui/modals.js';
 import { saveFoodItemToDatabase } from '../food/save.js';
 import { handleLogin, handleSignUp, handleGuestLogin, handleLogout } from '../main.js';
-import { saveTargets, saveDailyEntry } from '../services/firebase.js';
+import { saveTargets, saveDailyEntry, saveEstimatedEntry } from '../services/firebase.js';
 import { allNutrients } from '../constants.js';
-import { updateDashboard, activateTab } from '../ui/dashboard.js';
+import { updateDashboard, activateTab, renderVacationQuickPanel } from '../ui/dashboard.js';
 import { updateChart } from '../ui/chart.js';
 import { debugLog, handleError, clampNutrient, flushPendingUndo } from '../utils/ui.js';
 import {
@@ -26,6 +26,7 @@ import {
 } from '../exercise/met.js';
 import { getTodayInTimezone } from '../utils/time.js';
 import { resolveWeightKg } from '../ui/nutrientHelpers.js';
+import { buildVacationDayEntry } from '../analysis/engine.js';
 
 /**
  * Main event wiring function - called from main.js after DOM is ready
@@ -54,6 +55,7 @@ export function wire() {
     wireExportEvents();
     wireTabs();
     wireExerciseSessionModal();
+    wireVacationQuickButtons();
 
     // Expose global functions for inline HTML onclick handlers
     exposeGlobalFunctions();
@@ -395,6 +397,56 @@ function wireExerciseSessionModal() {
     debugLog('wire', 'Exercise session modal wired');
   } catch (error) {
     handleError('wire-exercise-modal', error, 'Failed to wire exercise session modal');
+  }
+}
+
+/**
+ * Wire vacation / low-log quick estimate buttons using event delegation.
+ */
+function wireVacationQuickButtons() {
+  try {
+    const container = document.getElementById('vacation-quick-container');
+    if (!container) return;
+
+    container.addEventListener('click', async (e) => {
+      const presetBtn = e.target.closest('.vacation-quick-btn');
+      const customBtn = e.target.closest('#vacation-custom-btn');
+      if (!presetBtn && !customBtn) return;
+
+      const dateStr = state.dom.dateInput?.value;
+      if (!dateStr) return;
+
+      let vacationType, customCalories = null;
+      if (presetBtn) {
+        vacationType = presetBtn.dataset.vacationType;
+      } else {
+        vacationType = 'custom';
+        const input = document.getElementById('vacation-custom-cal');
+        customCalories = parseFloat(input?.value);
+        if (!customCalories || customCalories <= 0) {
+          input?.focus();
+          return;
+        }
+      }
+
+      try {
+        const entry = buildVacationDayEntry(
+          dateStr, vacationType,
+          state.analysisResults, state.dailyEntries,
+          state.baselineTargets, customCalories
+        );
+        await saveEstimatedEntry(dateStr, entry);
+        await loadDailyFoodItems();
+        updateDashboard();
+        debugLog('wire-vacation', `Quick estimate saved for ${dateStr} (${vacationType})`);
+      } catch (err) {
+        handleError('wire-vacation-quick', err, 'Failed to save quick estimate');
+      }
+    });
+
+    debugLog('wire', 'Vacation quick buttons wired');
+  } catch (error) {
+    handleError('wire-vacation', error, 'Failed to wire vacation quick buttons');
   }
 }
 

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -133,6 +133,9 @@
             <div id="exercise-sessions-list" class="space-y-1 text-sm"></div>
           </div>
 
+          <!-- Vacation / Low-Log Quick Estimate -->
+          <div id="vacation-quick-container"></div>
+
           <!-- Collapsible: Paste & Parse -->
           <details class="collapsible" id="paste-parse-details" open>
             <summary>Paste &amp; Parse</summary>

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -546,6 +546,49 @@ input:focus, textarea:focus, select:focus {
 }
 
 /* ============================================================
+   VACATION / LOW-LOG QUICK ESTIMATE (#49)
+   ============================================================ */
+.vacation-quick-panel {
+  padding: .75rem;
+  margin-bottom: .75rem;
+  border-radius: .5rem;
+  background: hsl(var(--surface-2));
+  border: 1px dashed hsl(var(--border));
+}
+.vacation-quick-header {
+  margin-bottom: .5rem;
+}
+.vacation-quick-presets {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: .375rem;
+}
+.vacation-quick-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: .5rem .25rem;
+  font-size: .75rem;
+  line-height: 1.3;
+}
+.vacation-quick-label {
+  font-weight: 600;
+}
+.vacation-quick-hint {
+  font-size: .625rem;
+  color: hsl(var(--text-3));
+}
+.vacation-quick-custom {
+  display: flex;
+  gap: .375rem;
+  margin-top: .375rem;
+}
+.vacation-quick-custom input {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ============================================================
    TARGET BREAKDOWN (expandable financial-statement, #48)
    ============================================================ */
 .target-breakdown-details {

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -929,6 +929,55 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
 }
 
 /* ============================================================
+   SHARED DATE-RANGE CONTROL (#50)
+   ============================================================ */
+.date-range-control {
+  margin-bottom: .5rem;
+}
+.date-range-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .25rem;
+}
+.date-range-chip {
+  padding: .2rem .5rem;
+  font-size: .6875rem;
+  line-height: 1.2;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--surface-2));
+  color: hsl(var(--text-3));
+  cursor: pointer;
+  white-space: nowrap;
+  font-family: inherit;
+  transition: border-color .15s, background .15s, color .15s;
+}
+.date-range-chip:hover {
+  border-color: hsl(var(--accent) / .5);
+  color: hsl(var(--text));
+}
+.date-range-chip.active {
+  background: hsl(var(--accent) / .15);
+  border-color: hsl(var(--accent));
+  color: hsl(var(--accent));
+  font-weight: 600;
+}
+.date-range-custom {
+  display: flex;
+  align-items: center;
+  gap: .375rem;
+  margin-top: .375rem;
+}
+.date-range-custom input[type="date"] {
+  font-size: .75rem;
+  padding: .2rem .375rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: .25rem;
+  background: hsl(var(--surface-1));
+  color: hsl(var(--text));
+}
+
+/* ============================================================
    NUTRIENT FILTER BAR
    ============================================================ */
 .nutrient-filter-bar {

--- a/public/tools/CalorieTracker/ui/chart.js
+++ b/public/tools/CalorieTracker/ui/chart.js
@@ -8,6 +8,7 @@ import { CONFIG } from '../config.js';
 import { allNutrients, averagedNutrients } from '../constants.js';
 import { formatNutrientName } from '../utils/ui.js';
 import { getPastDate, formatDate } from '../utils/time.js';
+import { resolveRange, initDateRangeEvents, daysBetween } from './dateRange.js';
 import { getEntryExerciseKcal } from '../exercise/met.js';
 import { resolveWeightKg } from './nutrientHelpers.js';
 import { resolveDailyBaseTargets } from '../targets/dailyTargetResolver.js';
@@ -130,7 +131,6 @@ export function initializeChartControls() {
     debugLog('init-controls', 'Starting chart controls initialization');
 
     const chipContainer = document.getElementById('chart-nutrient-chips');
-    const chartTimeframe = document.getElementById('chart-timeframe');
     const show3DayAvg = document.getElementById('show-3day-avg');
     const show7DayAvg = document.getElementById('show-7day-avg');
 
@@ -139,7 +139,6 @@ export function initializeChartControls() {
       return;
     }
 
-    // Populate chip buttons (one per nutrient), restoring prior selection from _chartState
     chipContainer.innerHTML = '';
     allNutrients.forEach(nutrient => {
       const btn = document.createElement('button');
@@ -160,17 +159,16 @@ export function initializeChartControls() {
       chipContainer.appendChild(btn);
     });
 
-    // Restore timeframe and avg toggles from _chartState
-    if (chartTimeframe) chartTimeframe.value = _chartState.timeframe;
     if (show3DayAvg)   show3DayAvg.checked   = _chartState.show3Day;
     if (show7DayAvg)   show7DayAvg.checked   = _chartState.show7Day;
 
     const safe = (el, ev, fn) => {
       if (el) el.addEventListener(ev, e => { try { fn(e); } catch (err) { handleChartError('event-handler', err); } });
     };
-    safe(chartTimeframe, 'change', (e) => { _chartState.timeframe = e.target.value; updateChart(); });
     safe(show3DayAvg,   'change', (e) => { _chartState.show3Day  = e.target.checked; updateChart(); });
     safe(show7DayAvg,   'change', (e) => { _chartState.show7Day  = e.target.checked; updateChart(); });
+
+    initDateRangeEvents('nutrient-chart', () => { try { updateChart(); } catch (err) { handleChartError('date-range', err); } });
 
     debugLog('init-controls', 'Chart controls initialized successfully');
     updateChart();
@@ -195,12 +193,16 @@ export function initializeChartControls() {
 function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = false) {
   try {
     debugLog('get-data', { nutrientKeys, timeframe, show3Day, show7Day });
-    
-    const endDate = new Date(`${state.dom.dateInput.value}T00:00:00`);
-    
-    let days = 7;
-    if (timeframe === '3days') days = 3;
-    else if (timeframe === 'month') days = 30;
+
+    const range = resolveRange('nutrient-chart');
+    const endDate = new Date(`${range.endDate}T00:00:00`);
+
+    let days;
+    if (typeof timeframe === 'number') {
+      days = timeframe;
+    } else {
+      days = daysBetween(range.startDate, range.endDate);
+    }
 
     // Get extra days for moving averages
     const maxAvgDays = Math.max(show3Day ? 3 : 0, show7Day ? 7 : 0);
@@ -416,7 +418,6 @@ export function updateChart() {
       return;
     }
 
-    const chartTimeframe = document.getElementById('chart-timeframe');
     const show3DayAvg = document.getElementById('show-3day-avg');
     const show7DayAvg = document.getElementById('show-7day-avg');
 
@@ -428,7 +429,6 @@ export function updateChart() {
 
     const activeChips = chipContainer.querySelectorAll('.chart-chip.active');
     if (!activeChips.length) {
-      // Empty selection: clear stale chart and show a hint in the table area
       if (state.chartInstance) {
         state.chartInstance.destroy();
         state.chartInstance = null;
@@ -441,11 +441,12 @@ export function updateChart() {
     }
 
     const selectedNutrients = Array.from(activeChips).map(c => c.dataset.nutrient);
-    const timeframe = chartTimeframe?.value || CHART_CONFIG.DEFAULT_TIMEFRAME;
+    const range = resolveRange('nutrient-chart');
+    const days = daysBetween(range.startDate, range.endDate);
     const show3Day = show3DayAvg?.checked || false;
     const show7Day = show7DayAvg?.checked || false;
 
-    const { labels, datasets, tableData } = getChartData(selectedNutrients, timeframe, show3Day, show7Day);
+    const { labels, datasets, tableData } = getChartData(selectedNutrients, days, show3Day, show7Day);
     const isAutoGoalMode = (state.goalSettings?.targetMode === 'autoGoal');
     const canvas = document.getElementById('nutrition-chart');
     

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -30,7 +30,7 @@ import { CONFIG } from '../config.js';
 import { renderAnalysisSection, initAnalysisEvents } from '../analysis/analysisUI.js';
 import { UL_TABLE } from '../targets/nutritionReferences.js';
 import { resolveDailyBaseTargets, resolveDailyPlanningTargets } from '../targets/dailyTargetResolver.js';
-import { runAnalysis } from '../analysis/engine.js';
+import { runAnalysis, buildVacationDayEntry, VACATION_TYPE_CONFIG } from '../analysis/engine.js';
 import { computeBMR, resolveCurrentWeightLb, latestWeightLbFromEntries, computeMicronutrientTargets } from '../targets/targetEngine.js';
 import { calcBankingCore, hasTrustedCalories, prepareBankingInputs } from './bankingEngine.js';
 import { getTodayInTimezone } from '../utils/time.js';
@@ -1201,6 +1201,61 @@ function renderTodayCompact(bankingData) {
 }
 
 // =========================
+// VACATION / LOW-LOG QUICK ESTIMATE (#49)
+// =========================
+
+const VACATION_QUICK_PRESETS = [
+  { key: 'rest',   label: 'Rest',     hint: '~0–2k steps', vacationType: 'rest' },
+  { key: 'light',  label: 'Light',    hint: '~5k steps',   vacationType: 'light' },
+  { key: 'moderate', label: 'Moderate', hint: '~8–10k steps', vacationType: 'medium' },
+  { key: 'active', label: 'Active',   hint: '~12k+ steps', vacationType: 'heavy' },
+];
+
+function isDayEmpty(entry) {
+  if (!entry) return true;
+  const hasFoodItems = Array.isArray(entry.foodItems) && entry.foodItems.length > 0;
+  const hasExercise = Array.isArray(entry.exerciseSessions) && entry.exerciseSessions.length > 0;
+  const hasLegacyCals = (entry.entryType !== 'estimate') && (parseFloat(entry.calories) || 0) > 0 && (!Array.isArray(entry.foodItems) || entry.foodItems.length === 0);
+  const hasActivity = entry.dayActivityLevel && entry.dayActivityLevel !== 'rest';
+  const hasNotes = entry.notes?.trim();
+  const isEstimate = entry.entryType === 'estimate';
+  return !hasFoodItems && !hasExercise && !hasLegacyCals && !hasActivity && !hasNotes && !isEstimate;
+}
+
+export function renderVacationQuickPanel() {
+  const container = document.getElementById('vacation-quick-container');
+  if (!container) return;
+
+  const dateStr = state.dom.dateInput?.value;
+  if (!dateStr) { container.innerHTML = ''; return; }
+
+  const entry = state.dailyEntries.get(dateStr);
+  if (!isDayEmpty(entry) || !state.userId || Object.keys(state.baselineTargets).length === 0) {
+    container.innerHTML = '';
+    return;
+  }
+
+  const presetBtns = VACATION_QUICK_PRESETS.map(p =>
+    `<button type="button" class="btn btn-secondary vacation-quick-btn" data-vacation-type="${p.vacationType}" data-preset="${p.key}">
+      <span class="vacation-quick-label">${p.label}</span>
+      <span class="vacation-quick-hint">${p.hint}</span>
+    </button>`
+  ).join('');
+
+  container.innerHTML = `
+    <div class="vacation-quick-panel">
+      <div class="vacation-quick-header">
+        <span class="text-sm font-semibold text-secondary">No food logged — estimate this day?</span>
+      </div>
+      <div class="vacation-quick-presets">${presetBtns}</div>
+      <div class="vacation-quick-custom">
+        <input type="number" id="vacation-custom-cal" class="input-xs" min="0" step="50" placeholder="kcal" aria-label="Custom calorie estimate">
+        <button type="button" class="btn btn-secondary btn-sm" id="vacation-custom-btn">Custom</button>
+      </div>
+    </div>`;
+}
+
+// =========================
 // EXERCISE IMPACT PANEL (Today tab output + Energy tab)
 // =========================
 
@@ -1374,6 +1429,7 @@ export function updateDashboard() {
     `;
 
     renderTodayMacroHeader(bankingData);
+    renderVacationQuickPanel();
 
     // Re-render the active secondary tab so it stays fresh
     const activeTab = state.activeTab || 'today';

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -1217,7 +1217,7 @@ function isDayEmpty(entry) {
   const hasFoodItems = Array.isArray(entry.foodItems) && entry.foodItems.length > 0;
   const hasExercise = Array.isArray(entry.exerciseSessions) && entry.exerciseSessions.length > 0;
   const hasLegacyCals = (entry.entryType !== 'estimate') && (parseFloat(entry.calories) || 0) > 0 && (!Array.isArray(entry.foodItems) || entry.foodItems.length === 0);
-  const hasActivity = entry.dayActivityLevel && entry.dayActivityLevel !== 'rest';
+  const hasActivity = !!entry.dayActivityLevel;
   const hasNotes = entry.notes?.trim();
   const isEstimate = entry.entryType === 'estimate';
   return !hasFoodItems && !hasExercise && !hasLegacyCals && !hasActivity && !hasNotes && !isEstimate;

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -26,6 +26,7 @@ import { computeTrendDirection, classifyTargetSource, resolveWeightKg } from './
 import { formatNutrientName } from '../utils/ui.js';
 import { getPastDate, formatDate } from '../utils/time.js';
 import { initializeChartControls } from './chart.js';
+import { renderDateRangeControl, initDateRangeEvents, resolveRange } from './dateRange.js';
 import { CONFIG } from '../config.js';
 import { renderAnalysisSection, initAnalysisEvents } from '../analysis/analysisUI.js';
 import { UL_TABLE } from '../targets/nutritionReferences.js';
@@ -1730,16 +1731,9 @@ function renderChartSection() {
         <div id="chart-nutrient-chips" class="chart-chip-picker" role="group" aria-label="Select nutrients for chart"></div>
       </div>
 
-      <div class="mb-4 flex flex-wrap gap-4 items-end">
-        <div class="flex-1">
-          <label for="chart-timeframe" class="block text-sm font-medium text-primary mb-1">Time Frame</label>
-          <select id="chart-timeframe">
-            <option value="3days">Last 3 Days</option>
-            <option value="week">Last Week</option>
-            <option value="month">Last Month</option>
-          </select>
-        </div>
-        <div class="flex gap-4 items-center flex-wrap">
+      <div class="mb-4">
+        ${renderDateRangeControl('nutrient-chart', { defaultPreset: '7' })}
+        <div class="flex gap-4 items-center flex-wrap mt-2">
           <label class="flex items-center gap-2 cursor-pointer text-sm text-primary">
             <input type="checkbox" id="show-3day-avg" class="h-4 w-4">
             <span>3-day avg</span>

--- a/public/tools/CalorieTracker/ui/dateRange.js
+++ b/public/tools/CalorieTracker/ui/dateRange.js
@@ -1,0 +1,134 @@
+/**
+ * @file ui/dateRange.js
+ * @description Shared chart date-range control — presets + custom From/To.
+ * Per-chart state (not synchronized between charts).
+ */
+
+import { state } from '../state/store.js';
+import { getTodayInTimezone } from '../utils/time.js';
+
+const _rangeStates = new Map();
+
+const PRESETS = [
+  { value: '7',     label: '7 d' },
+  { value: '30',    label: '30 d' },
+  { value: '90',    label: '90 d' },
+  { value: 'ytd',   label: 'YTD' },
+  { value: '365',   label: '1 yr' },
+  { value: 'first', label: 'All' },
+  { value: 'custom', label: 'Custom' },
+];
+
+function getFirstLoggedDate() {
+  let earliest = null;
+  for (const dateStr of state.dailyEntries.keys()) {
+    if (!earliest || dateStr < earliest) earliest = dateStr;
+  }
+  if (!earliest) {
+    for (const dateStr of state.weightEntries.keys()) {
+      if (!earliest || dateStr < earliest) earliest = dateStr;
+    }
+  }
+  return earliest;
+}
+
+function addDays(dateStr, n) {
+  const d = new Date(dateStr + 'T00:00:00');
+  d.setDate(d.getDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+export function resolveRange(chartId) {
+  const s = _rangeStates.get(chartId) || { preset: '30' };
+  const endDate = state.dom.dateInput?.value || getTodayInTimezone();
+
+  if (s.preset === 'custom') {
+    return {
+      startDate: s.customFrom || addDays(endDate, -29),
+      endDate: s.customTo || endDate,
+    };
+  }
+
+  let startDate;
+  if (s.preset === 'ytd') {
+    startDate = endDate.slice(0, 4) + '-01-01';
+  } else if (s.preset === 'first') {
+    startDate = getFirstLoggedDate() || addDays(endDate, -29);
+  } else {
+    const days = parseInt(s.preset) || 30;
+    startDate = addDays(endDate, -(days - 1));
+  }
+
+  return { startDate, endDate };
+}
+
+export function renderDateRangeControl(chartId, { defaultPreset = '30' } = {}) {
+  if (!_rangeStates.has(chartId)) {
+    _rangeStates.set(chartId, { preset: defaultPreset });
+  }
+  const s = _rangeStates.get(chartId);
+  const { startDate, endDate } = resolveRange(chartId);
+
+  const chips = PRESETS.map(p =>
+    `<button type="button" class="date-range-chip${s.preset === p.value ? ' active' : ''}" data-chart="${chartId}" data-preset="${p.value}">${p.label}</button>`
+  ).join('');
+
+  const customHidden = s.preset === 'custom' ? '' : ' hidden';
+  return `
+    <div class="date-range-control" data-chart-id="${chartId}">
+      <div class="date-range-chips">${chips}</div>
+      <div class="date-range-custom${customHidden}" id="date-range-custom-${chartId}">
+        <input type="date" class="date-range-from" id="date-range-from-${chartId}" value="${startDate}">
+        <span class="text-muted text-xs">to</span>
+        <input type="date" class="date-range-to" id="date-range-to-${chartId}" value="${endDate}">
+      </div>
+    </div>`;
+}
+
+export function initDateRangeEvents(chartId, onChange) {
+  const container = document.querySelector(`.date-range-control[data-chart-id="${chartId}"]`);
+  if (!container) return;
+
+  container.addEventListener('click', (e) => {
+    const chip = e.target.closest('.date-range-chip');
+    if (!chip || chip.dataset.chart !== chartId) return;
+
+    const s = _rangeStates.get(chartId) || { preset: '30' };
+    s.preset = chip.dataset.preset;
+    _rangeStates.set(chartId, s);
+
+    container.querySelectorAll('.date-range-chip').forEach(c => c.classList.remove('active'));
+    chip.classList.add('active');
+
+    const customRow = document.getElementById(`date-range-custom-${chartId}`);
+    if (customRow) customRow.classList.toggle('hidden', s.preset !== 'custom');
+
+    if (s.preset === 'custom') {
+      const fromEl = document.getElementById(`date-range-from-${chartId}`);
+      const toEl = document.getElementById(`date-range-to-${chartId}`);
+      const range = resolveRange(chartId);
+      if (fromEl && !fromEl.value) fromEl.value = range.startDate;
+      if (toEl && !toEl.value) toEl.value = range.endDate;
+    }
+
+    onChange(resolveRange(chartId));
+  });
+
+  const fromEl = document.getElementById(`date-range-from-${chartId}`);
+  const toEl = document.getElementById(`date-range-to-${chartId}`);
+  const onCustomChange = () => {
+    const s = _rangeStates.get(chartId);
+    if (!s || s.preset !== 'custom') return;
+    s.customFrom = fromEl?.value || null;
+    s.customTo = toEl?.value || null;
+    onChange(resolveRange(chartId));
+  };
+  fromEl?.addEventListener('change', onCustomChange);
+  toEl?.addEventListener('change', onCustomChange);
+}
+
+export function daysBetween(startDate, endDate) {
+  const s = new Date(startDate + 'T00:00:00');
+  const e = new Date(endDate + 'T00:00:00');
+  return Math.round((e - s) / 86400000) + 1;
+}

--- a/public/tools/CalorieTracker/ui/dateRange.js
+++ b/public/tools/CalorieTracker/ui/dateRange.js
@@ -24,10 +24,9 @@ function getFirstLoggedDate() {
   for (const dateStr of state.dailyEntries.keys()) {
     if (!earliest || dateStr < earliest) earliest = dateStr;
   }
-  if (!earliest) {
-    for (const dateStr of state.weightEntries.keys()) {
-      if (!earliest || dateStr < earliest) earliest = dateStr;
-    }
+  for (const [, entry] of state.weightEntries) {
+    const d = entry?.date;
+    if (d && (!earliest || d < earliest)) earliest = d;
   }
   return earliest;
 }
@@ -38,9 +37,13 @@ function addDays(dateStr, n) {
   return d.toISOString().slice(0, 10);
 }
 
+const _analysisCharts = new Set(['weight-chart', 'eating-chart']);
+
 export function resolveRange(chartId) {
   const s = _rangeStates.get(chartId) || { preset: '30' };
-  const endDate = state.dom.dateInput?.value || getTodayInTimezone();
+  const endDate = _analysisCharts.has(chartId)
+    ? getTodayInTimezone()
+    : (state.dom.dateInput?.value || getTodayInTimezone());
 
   if (s.preset === 'custom') {
     return {
@@ -104,11 +107,13 @@ export function initDateRangeEvents(chartId, onChange) {
     if (customRow) customRow.classList.toggle('hidden', s.preset !== 'custom');
 
     if (s.preset === 'custom') {
+      const prevRange = resolveRange(chartId);
+      s.customFrom = prevRange.startDate;
+      s.customTo = prevRange.endDate;
       const fromEl = document.getElementById(`date-range-from-${chartId}`);
       const toEl = document.getElementById(`date-range-to-${chartId}`);
-      const range = resolveRange(chartId);
-      if (fromEl && !fromEl.value) fromEl.value = range.startDate;
-      if (toEl && !toEl.value) toEl.value = range.endDate;
+      if (fromEl) fromEl.value = s.customFrom;
+      if (toEl) toEl.value = s.customTo;
     }
 
     onChange(resolveRange(chartId));


### PR DESCRIPTION
## Summary

- **#49 Zero-log vacation / low-log quick button** — Added a quick-estimate panel above the food-entry area for days with no logged data. Four preset activity levels (Rest ~0–2k steps / Light ~5k / Moderate ~8–10k / Active ~12k+) plus a custom calorie input. Extended `VACATION_TYPE_CONFIG` with a `rest` key (TDEE × 0.80 − 100) for truly resting days. Panel only renders when the day has no food items, exercise sessions, activity level, notes, or existing estimate — avoids clobbering data. Each preset creates an estimate via the existing `buildVacationDayEntry` engine and saves through `saveEstimatedEntry`.

- **#50 Shared chart date-range control** — New `ui/dateRange.js` module with a reusable chip-based date-range picker: presets for 7d / 30d / 90d / YTD / 1 yr / All, plus custom From/To date pickers. Per-chart state (not synchronized). "All" preset uses first logged date as fallback since no goal-start field exists yet. Applied to all three charts: nutrient chart (replaces old 3-day/week/month dropdown), weight trend chart (replaces old 90/180/365/all dropdown), and eating pattern chart (was showing all data, now has date-range control).

Also reconciles #47 and #48 to completed (merged to main via PR #135). Resolved all 7 codex review threads on PR #134 (backlog clarifications already incorporated).

## Checks

- `cd public/tools/CalorieTracker && npm test` — 575 tests, 9 files, all passing

## Files changed

- `public/tools/CalorieTracker/analysis/engine.js` — added `rest` to `VACATION_TYPE_CONFIG`
- `public/tools/CalorieTracker/ui/dashboard.js` — `renderVacationQuickPanel()`, date-range control in nutrient chart
- `public/tools/CalorieTracker/ui/dateRange.js` — new shared date-range control module
- `public/tools/CalorieTracker/ui/chart.js` — uses `resolveRange()` instead of old timeframe select
- `public/tools/CalorieTracker/analysis/analysisUI.js` — date-range control on weight + eating charts
- `public/tools/CalorieTracker/events/wire.js` — vacation quick-button event delegation
- `public/tools/CalorieTracker/index.html` — vacation quick-button container
- `public/tools/CalorieTracker/styles.css` — vacation panel + date-range chip styles
- `backlogs/calorie-tracker.md` — marked #49 #50 as `[p]` with commit SHAs
- `backlogs/calorie-tracker-completed.md` — archived #47 #48 as completed

## Backlog reference

See `backlogs/calorie-tracker.md` for protocol and active items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bnv7rsRaSTZJitN4wHYSdD)_