### PR TITLE
CalorieTracker: Corrections tab, collapsible explanations (#51, #54)

### DIFF
--- a/backlogs/calorie-tracker-completed.md
+++ b/backlogs/calorie-tracker-completed.md
@@ -186,6 +186,20 @@ For the active backlog (new items, protocol, invariants), see `backlogs/calorie-
 - [x] **#45 — Documentation update checklist not enforced**
   > Resolved: added doc-update confirmation line to PR checklist in CONTRIBUTING.md; BACKLOG added to docs list; merged d2aeb0a
 
+## UI/UX & information-architecture review (#47+)
+
+- [x] **#47 — Today macro summary bar redesign**
+  > Resolved: redesigned sticky macro header and dashboard hero card with prominent remaining-calorie readout, compact P/F/C grid, condensed warnings; merged via PR #135 (2de2407)
+
+- [x] **#48 — Clickable target → expandable financial-statement breakdown**
+  > Resolved: target number expands to financial-statement breakdown (TDEE → Base → Exercise → Banking → Floor → Final); includes goal deficit row and capped bank context; merged via PR #135 (bcb139b)
+
+- [x] **#49 — Zero-log vacation / low-log quick button**
+  > Resolved: vacation quick-estimate panel with 4 presets (Rest/Light/Moderate/Active) + custom; rest key added to VACATION_TYPE_CONFIG; isDayEmpty guards non-null dayActivityLevel; merged via PR #136 (200a37b)
+
+- [x] **#50 — Shared chart date-range control**
+  > Resolved: new ui/dateRange.js with chip presets (7d/30d/90d/YTD/1yr/All) + custom From/To; applied to nutrient, weight, and eating charts; analysis charts anchor to today; rolling avg computed from full history; merged via PR #136 (df2b0af)
+
 ---
 
 ## What was already verified as correct (do not regress)

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -154,37 +154,11 @@ _(empty)_
 
 ### HIGH
 
-_(#47 and #48 completed — moved to `backlogs/calorie-tracker-completed.md`)_
-- [p] **#49 Zero-log vacation / low-log quick button** — *[quick win]* Render only when the
-  current day has no food items **and** no existing daily document data that would be overwritten
-  (exercise sessions, day-activity selection, legacy top-level calories, notes, or other
-  non-food fields), unless the implementation explicitly merges and preserves those fields.
-  Place directly above the food-entry area. Quick-choice of 4 presets with parenthetical step
-  guidance (Rest ~0–2k steps / Light ~5k / Moderate ~8–10k / Active ~12k+) plus a Custom/manual
-  option. Map the quick choices to existing engine keys before calling the estimator: Rest →
-  `light` with resting/low-step day-activity metadata (or extend `VACATION_TYPE_CONFIG` with a
-  real `rest` key), Light → `light`, Moderate → `medium`, Active → `heavy`, Custom → `custom`.
-  Each selection creates an estimate day via the existing `buildVacationDayEntry` /
-  `estimateVacationCalories` engine (`analysis/engine.js:1445/1373`) and `DAY_ACTIVITY_LEVELS`
-  (`constants.js:9`), saved through `saveEstimatedEntry` without clobbering preserved fields.
-  Later weight-based correction is handled by #56. Files: `index.html`, `events/wire.js`,
-  `ui/dashboard.js`, `analysis/engine.js` (reuse).
-  > pushed — vacation quick-estimate panel with 4 presets + custom; rest key added to VACATION_TYPE_CONFIG; tests: 575 pass; commit: 200a37b
-- [p] **#50 Shared chart date-range control** — *[quick win]* One reusable control applied to
-  every chart: presets **Last 7 / 30 / 90 days / YTD / 1 Year**, **Since goal start**, and
-  **custom From/To** date pickers. Because normalized `goalSettings` currently has `targetDate`
-  but no persisted start-date field, either add a goal-start field with schema/UI migration and
-  fallback handling, or define the preset as "since first logged day" until such a field exists.
-  Per-chart state (not synchronized).
-  Generalize the existing `_chartState.timeframe` pattern (`ui/chart.js:128/195`). Apply to
-  the nutrient chart, weight-trend chart, eating-pattern chart, and the new corrections chart
-  (#52). Files: new `ui/dateRange.js` (small helper), `ui/chart.js`,
-  `analysis/analysisUI.js`, `index.html`, `styles.css`.
-  > pushed — new ui/dateRange.js with chip presets + custom From/To; applied to all 3 charts; tests: 575 pass; commit: df2b0af
+_(#47–#50 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 
 ### MEDIUM
 
-- [ ] **#51 New "Corrections & Gaps" tab (split from Energy)** — *[larger refactor]* Add
+- [p] **#51 New "Corrections & Gaps" tab (split from Energy)** — *[larger refactor]* Add
   `'corrections'` to `VALID_TABS` (`ui/dashboard.js:616`) plus a nav button/panel in
   `index.html`. Move the missing-day fill (`renderMissingCaloriesSection`), vacation editor
   (`renderVacationEditorSection`), estimate management (`renderEstimateManagementSection`),
@@ -213,7 +187,7 @@ _(#47 and #48 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   magnitudes are fixed scientific constants — "dynamic" means profile-driven selection and
   scaling, not invented values. Files: `ui/dashboard.js`, `targets/nutritionReferences.js`,
   `targets/targetEngine.js`, `styles.css`.
-- [ ] **#54 Collapse long-form explanations** — *[quick win]* Wrap methodology and
+- [p] **#54 Collapse long-form explanations** — *[quick win]* Wrap methodology and
   statistical notes across the Energy, Nutrients, and Corrections tabs in
   `<details class="collapsible">` "How this is calculated" / "More detail" sections to reduce
   cognitive load. Files: `analysis/analysisUI.js`, `ui/dashboard.js`, `styles.css`.

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -166,6 +166,7 @@ _(#47–#50 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   render path. Energy retains KPIs, weight chart, confidence card, and the TDEE/BMR/PAL
   detail (`renderEnergyDetail`). No engine logic moves — render wiring only. Files:
   `index.html`, `ui/dashboard.js`, `events/wire.js`, `analysis/analysisUI.js`.
+  > pushed — new Corrections tab with all 4 correction sections moved from Energy; tests: 575 pass; commit: ffe15a9
 - [ ] **#52 Recorded vs. corrected/imputed chart + trend** — *[quick win; depends on #50,
   #51]* Single Chart.js line chart on the Corrections tab showing, for the selected range:
   recorded/logged calories, model-corrected/imputed calories, and a trend line — so the user
@@ -191,6 +192,7 @@ _(#47–#50 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   statistical notes across the Energy, Nutrients, and Corrections tabs in
   `<details class="collapsible">` "How this is calculated" / "More detail" sections to reduce
   cognitive load. Files: `analysis/analysisUI.js`, `ui/dashboard.js`, `styles.css`.
+  > pushed — eating pattern notes, energy detail, TDEE horizons, PAL table, vacation/imputation explanations, info boxes all collapsible; tests: 575 pass; commit: ffe15a9
 - [ ] **#55 Larger-gap imputation with min-data-on-each-side rigor** — *[larger refactor]*
   `getTrueUpCandidates` (`analysis/engine.js:1644`) already uses centered windows
   `[-7,+6]/[-14,+13]/[-21,+20]` with ≥50% coverage + minimum future weights. Parameterize and

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -67,6 +67,36 @@ export function renderAnalysisSection() {
           </details>
           ${renderPlateauStatus(results.plateau)}
           ${renderEnergyDetail(results)}
+        `
+      }
+    </div>
+  `;
+}
+
+export function renderCorrectionsSection() {
+  const results = state.analysisResults || runAnalysis(
+    state.weightEntries,
+    state.dailyEntries,
+    state.userProfile || null,
+    state.weightEntriesMulti || null,
+    getTodayInTimezone(),
+  );
+  if (!state.analysisResults) state.analysisResults = results;
+
+  if (!state._trueUpCandidates) {
+    state._trueUpCandidates = results.error
+      ? []
+      : getTrueUpCandidates(results.rows, state.dailyEntries, results.bmrModel, state.baselineTargets);
+  }
+
+  return `
+    <div class="mb-8">
+      <h2 class="text-responsive-2xl font-bold text-secondary mb-4">🔧 Corrections & Gaps</h2>
+      <p class="text-sm text-muted mb-6">Fill missing days, manage vacation estimates, and review imputed entries. Corrections here improve the accuracy of your energy model.</p>
+
+      ${results.error
+        ? `<p class="text-muted text-center py-8">Upload weight data on the Energy tab to enable corrections.</p>`
+        : `
           ${renderImputationTable(results.rows)}
           ${renderMissingCaloriesSection(state._trueUpCandidates)}
           ${renderVacationEditorSection()}
@@ -174,7 +204,9 @@ export function initAnalysisEvents() {
       drawWeightChart(state.analysisResults.rows);
     }
   });
+}
 
+export function initCorrectionsEvents() {
   // ── Missing Calories section (unified candidates only) ────────────────────
   const allCandidates = state._trueUpCandidates || [];
   const candidateMap  = new Map(allCandidates.map(d => [d.date, d]));
@@ -765,16 +797,18 @@ function renderEatingPatternChart(results) {
       <div style="position:relative; height:300px;" class="mb-4">
         <canvas id="eating-pattern-chart"></canvas>
       </div>
-      <div class="p-3 surface-2 rounded-lg border text-sm text-muted space-y-2">
-        <p class="font-semibold text-primary">How the model thinks about this:</p>
-        ${tdee ? `<p>Estimated total daily energy expenditure: <strong>${tdee} kcal/day</strong> (${tdeeSource}). ${restDayTdee !== tdee ? `Rest-day TDEE: <strong>${restDayTdee} kcal/day</strong> (fitted BMR × rest-day PAL).` : ''}</p>` : ''}
-        ${targetNote}
-        ${uncertaintyNote ? `<p>${uncertaintyNote} This is a physical lower bound on single-day precision — scale fluctuations can mask real trends.</p>` : ''}
-        ${residualNote ? `<p>${residualNote} ${Math.abs(residual?.medianKcalPerDay ?? 0) > 100 ? 'This gap likely reflects underlogged meals, not metabolic differences.' : 'Small gap — logging appears consistent.'}</p>` : ''}
-        ${firstDateNote ? `<p>${firstDateNote} Weight data before this date affects the trend chart only.</p>` : ''}
-        <p>${targetModeNote}</p>
-        <p class="text-xs">The chart shows your 7-day rolling calorie average (blue, real logged days only) vs your ${targetLineDesc} and the TDEE estimate (orange). The smoothed weight trend is overlaid on the right axis. Unsaved imputed values are never included in the reported calorie series.</p>
-      </div>
+      <details class="collapsible">
+        <summary>How this is calculated</summary>
+        <div class="p-3 surface-2 rounded-lg border text-sm text-muted space-y-2 mt-2">
+          ${tdee ? `<p>Estimated total daily energy expenditure: <strong>${tdee} kcal/day</strong> (${tdeeSource}). ${restDayTdee !== tdee ? `Rest-day TDEE: <strong>${restDayTdee} kcal/day</strong> (fitted BMR × rest-day PAL).` : ''}</p>` : ''}
+          ${targetNote}
+          ${uncertaintyNote ? `<p>${uncertaintyNote} This is a physical lower bound on single-day precision — scale fluctuations can mask real trends.</p>` : ''}
+          ${residualNote ? `<p>${residualNote} ${Math.abs(residual?.medianKcalPerDay ?? 0) > 100 ? 'This gap likely reflects underlogged meals, not metabolic differences.' : 'Small gap — logging appears consistent.'}</p>` : ''}
+          ${firstDateNote ? `<p>${firstDateNote} Weight data before this date affects the trend chart only.</p>` : ''}
+          <p>${targetModeNote}</p>
+          <p class="text-xs">The chart shows your 7-day rolling calorie average (blue, real logged days only) vs your ${targetLineDesc} and the TDEE estimate (orange). The smoothed weight trend is overlaid on the right axis. Unsaved imputed values are never included in the reported calorie series.</p>
+        </div>
+      </details>
     </div>
   `;
 }
@@ -1048,7 +1082,6 @@ function renderEnergyDetail(results) {
   const horizonSection = Object.keys(tdeeByHorizon || {}).length > 0 ? `
     <div class="mb-6">
       <h4 class="font-semibold text-secondary mb-2 text-sm uppercase tracking-wide">Observed TDEE at Different Horizons</h4>
-      <p class="text-xs text-muted mb-2">Each number is a trimmed average of 14-day rolling block estimates in that window. Longer windows are more stable; short windows react faster to recent changes. Do not act on differences smaller than ~100 kcal — that is within normal noise.</p>
       <div class="overflow-x-auto">
         <table class="w-full border rounded-lg">
           <thead class="surface-2">
@@ -1061,6 +1094,10 @@ function renderEnergyDetail(results) {
           <tbody class="divide-y">${horizonRows}</tbody>
         </table>
       </div>
+      <details class="collapsible mb-2">
+        <summary>More detail</summary>
+        <p class="text-xs text-muted mt-2 p-3 surface-2 rounded-lg border">Each number is a trimmed average of 14-day rolling block estimates in that window. Longer windows are more stable; short windows react faster to recent changes. Do not act on differences smaller than ~100 kcal — that is within normal noise.</p>
+      </details>
     </div>` : '';
 
   // ── Section: BMR / RMR cards ─────────────────────────────────────────────
@@ -1176,12 +1213,6 @@ function renderEnergyDetail(results) {
 
     palSection = `
       <h4 class="font-semibold text-secondary mb-2 text-sm uppercase tracking-wide">Retrospective TDEE by Activity Level</h4>
-      <div class="mb-3 p-3 surface-2 rounded-lg border text-xs text-muted space-y-1">
-        <p><strong>What this table is:</strong> A retrospective data-fitted model. The PAL multiplier for each activity bucket was chosen by minimising BMR volatility across your history. It reflects what your total expenditure appears to have been on days of each type.</p>
-        <p><strong>Activity categories are a temporary compatibility layer.</strong> The four buckets (Rest / Light +100 / Hard +280 / HIIT +400 kcal) map to the legacy training-bump field. Once structured exercise sessions are fully implemented, these will be replaced by continuous per-session calorie estimates.</p>
-        <p><strong>Prospective budgets are separate:</strong> Your daily calorie target uses fixed flat bumps, not these PAL multipliers. That is intentional — the PALs are retrospective; the bumps are forward-looking planning values.</p>
-        ${palInverted ? `<p class="text-warning"><strong>Why does Light show higher than Hard?</strong> Hard-training days often have higher sodium and carbs, which causes temporary water retention. That inflates the apparent scale weight on hard days, making the implied TDEE look smaller — so the grid search assigns a lower PAL. This is a water/glycogen signal, not a model bug. Use the flat bumps in your daily plan.</p>` : ''}
-      </div>
       <div class="overflow-x-auto mb-4">
         <table class="w-full border rounded-lg">
           <thead class="surface-2">
@@ -1193,18 +1224,29 @@ function renderEnergyDetail(results) {
           </thead>
           <tbody class="divide-y">${palRows}</tbody>
         </table>
-      </div>`;
+      </div>
+      <details class="collapsible mb-2">
+        <summary>More detail</summary>
+        <div class="p-3 surface-2 rounded-lg border text-xs text-muted space-y-1 mt-2">
+          <p><strong>What this table is:</strong> A retrospective data-fitted model. The PAL multiplier for each activity bucket was chosen by minimising BMR volatility across your history. It reflects what your total expenditure appears to have been on days of each type.</p>
+          <p><strong>Activity categories are a temporary compatibility layer.</strong> The four buckets (Rest / Light +100 / Hard +280 / HIIT +400 kcal) map to the legacy training-bump field. Once structured exercise sessions are fully implemented, these will be replaced by continuous per-session calorie estimates.</p>
+          <p><strong>Prospective budgets are separate:</strong> Your daily calorie target uses fixed flat bumps, not these PAL multipliers. That is intentional — the PALs are retrospective; the bumps are forward-looking planning values.</p>
+          ${palInverted ? `<p class="text-warning"><strong>Why does Light show higher than Hard?</strong> Hard-training days often have higher sodium and carbs, which causes temporary water retention. That inflates the apparent scale weight on hard days, making the implied TDEE look smaller — so the grid search assigns a lower PAL. This is a water/glycogen signal, not a model bug. Use the flat bumps in your daily plan.</p>` : ''}
+        </div>
+      </details>`;
   }
 
   return `
-    <div class="mb-6 card p-6 shadow-lg">
-      <h3 class="text-responsive-xl font-bold text-secondary mb-4">Energy Model Detail</h3>
-      ${horizonSection}
-      ${expenditureRow}
-      ${bmrSection}
-      ${residualSection}
-      ${palSection}
-    </div>
+    <details class="mb-6 card p-6 shadow-lg collapsible">
+      <summary class="text-responsive-xl font-bold text-secondary">Energy Model Detail</summary>
+      <div class="mt-4">
+        ${horizonSection}
+        ${expenditureRow}
+        ${bmrSection}
+        ${residualSection}
+        ${palSection}
+      </div>
+    </details>
   `;
 }
 
@@ -1236,8 +1278,11 @@ function renderImputationTable(rows) {
 
   return `
     <div class="mb-6 card p-6 shadow-lg">
-      <h3 class="text-responsive-xl font-bold text-secondary mb-4">Missing Day Estimates</h3>
-      <p class="text-sm text-muted mb-4">Days without logged calories are estimated using your TDEE model and weight change. Estimates only appear after 14+ days have passed and enough weight data exists.</p>
+      <h3 class="text-responsive-xl font-bold text-secondary mb-2">Missing Day Estimates</h3>
+      <details class="collapsible mb-4">
+        <summary>How this works</summary>
+        <p class="text-sm text-muted mt-2 p-3 surface-2 rounded-lg border">Days without logged calories are estimated using your TDEE model and weight change. Estimates only appear after 14+ days have passed and enough weight data exists.</p>
+      </details>
       <div class="overflow-x-auto">
         <table class="w-full border rounded-lg">
           <thead class="surface-2">
@@ -1494,11 +1539,14 @@ function renderVacationEditorSection() {
     <div class="mb-6 card p-6 shadow-lg">
       <h3 class="text-responsive-xl font-bold text-secondary mb-2">🏖️ Vacation / Missed Days</h3>
 
-      <div class="mb-4 p-3 surface-2 rounded-lg border text-xs text-muted space-y-1">
-        <p>Select a date range and assign an intake type. The model estimates calories from your TDEE history, weekday patterns, and the activity level implied by the day type, then fills in a complete synthetic day log.</p>
-        <p><strong>Light</strong> — ~85% of your usual intake. <strong>Medium</strong> — ~100%. <strong>Heavy</strong> — ~110% + 200 kcal. <strong>Custom</strong> — you specify the number directly.</p>
-        <p>You can override the type per day before filling. After filling, use the Estimate Management panel below to lock or remove individual estimates.</p>
-      </div>
+      <details class="collapsible mb-4">
+        <summary>How this works</summary>
+        <div class="p-3 surface-2 rounded-lg border text-xs text-muted space-y-1 mt-2">
+          <p>Select a date range and assign an intake type. The model estimates calories from your TDEE history, weekday patterns, and the activity level implied by the day type, then fills in a complete synthetic day log.</p>
+          <p><strong>Light</strong> — ~85% of your usual intake. <strong>Medium</strong> — ~100%. <strong>Heavy</strong> — ~110% + 200 kcal. <strong>Custom</strong> — you specify the number directly.</p>
+          <p>You can override the type per day before filling. After filling, use the Estimate Management panel below to lock or remove individual estimates.</p>
+        </div>
+      </details>
 
       <!-- Step 1: range + default type -->
       <div class="flex flex-wrap gap-2 mb-4 items-end">

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -83,11 +83,9 @@ export function renderCorrectionsSection() {
   );
   if (!state.analysisResults) state.analysisResults = results;
 
-  if (!state._trueUpCandidates) {
-    state._trueUpCandidates = results.error
-      ? []
-      : getTrueUpCandidates(results.rows, state.dailyEntries, results.bmrModel, state.baselineTargets);
-  }
+  state._trueUpCandidates = results.error
+    ? []
+    : getTrueUpCandidates(results.rows, state.dailyEntries, results.bmrModel, state.baselineTargets);
 
   return `
     <div class="mb-8">

--- a/public/tools/CalorieTracker/index.html
+++ b/public/tools/CalorieTracker/index.html
@@ -84,6 +84,7 @@
           <button id="tab-btn-today"     class="tab-btn active" data-tab="today"     role="tab" aria-selected="true"  aria-controls="tab-today"     tabindex="0">Today</button>
           <button id="tab-btn-nutrients" class="tab-btn"        data-tab="nutrients" role="tab" aria-selected="false" aria-controls="tab-nutrients" tabindex="-1">Nutrients</button>
           <button id="tab-btn-energy"    class="tab-btn"        data-tab="energy"    role="tab" aria-selected="false" aria-controls="tab-energy"    tabindex="-1">Energy</button>
+          <button id="tab-btn-corrections" class="tab-btn"      data-tab="corrections" role="tab" aria-selected="false" aria-controls="tab-corrections" tabindex="-1">Corrections</button>
           <button id="tab-btn-profile"   class="tab-btn"        data-tab="profile"   role="tab" aria-selected="false" aria-controls="tab-profile"   tabindex="-1">Profile &amp; Goals</button>
           <button id="tab-btn-settings"  class="tab-btn"        data-tab="settings"  role="tab" aria-selected="false" aria-controls="tab-settings"  tabindex="-1">Settings</button>
         </nav>
@@ -265,6 +266,16 @@
     <div id="tab-energy" class="tab-panel hidden" role="tabpanel" aria-labelledby="tab-btn-energy">
       <div class="tab-content-inner">
         <div id="energy-content" class="text-primary"></div>
+      </div>
+    </div>
+
+
+    <!-- ══════════════════════════════════════════════════
+         CORRECTIONS & GAPS TAB
+         ══════════════════════════════════════════════════ -->
+    <div id="tab-corrections" class="tab-panel hidden" role="tabpanel" aria-labelledby="tab-btn-corrections">
+      <div class="tab-content-inner">
+        <div id="corrections-content" class="text-primary"></div>
       </div>
     </div>
 

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -1450,6 +1450,7 @@ export function updateDashboard() {
     const activeTab = state.activeTab || 'today';
     if (activeTab === 'nutrients') renderNutrientsOutput();
     else if (activeTab === 'energy') renderEnergyOutput();
+    else if (activeTab === 'corrections') renderCorrectionsOutput();
 
     debugLog('update-complete', 'Dashboard update completed successfully');
 

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -28,7 +28,7 @@ import { getPastDate, formatDate } from '../utils/time.js';
 import { initializeChartControls } from './chart.js';
 import { renderDateRangeControl, initDateRangeEvents, resolveRange } from './dateRange.js';
 import { CONFIG } from '../config.js';
-import { renderAnalysisSection, initAnalysisEvents } from '../analysis/analysisUI.js';
+import { renderAnalysisSection, initAnalysisEvents, renderCorrectionsSection, initCorrectionsEvents } from '../analysis/analysisUI.js';
 import { UL_TABLE } from '../targets/nutritionReferences.js';
 import { resolveDailyBaseTargets, resolveDailyPlanningTargets } from '../targets/dailyTargetResolver.js';
 import { runAnalysis, buildVacationDayEntry, VACATION_TYPE_CONFIG } from '../analysis/engine.js';
@@ -615,7 +615,7 @@ export function calculateMicronutrientMetrics(dateStr) {
 // TAB MANAGEMENT
 // =========================
 
-const VALID_TABS = ['today', 'nutrients', 'energy', 'profile', 'settings'];
+const VALID_TABS = ['today', 'nutrients', 'energy', 'corrections', 'profile', 'settings'];
 
 function applyTabButtonState(activeTab) {
   document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -698,6 +698,7 @@ export function activateTab(name) {
 
     if (name === 'nutrients') renderNutrientsOutput();
     else if (name === 'energy') renderEnergyOutput();
+    else if (name === 'corrections') renderCorrectionsOutput();
     else if (name === 'settings') populateSettingsForm();
     else if (name === 'today') updateDashboard();
 
@@ -895,6 +896,19 @@ function renderEnergyOutput() {
   container.innerHTML = bankingHtml + renderAnalysisSection();
   setupCollapsibleHandlers();
   initAnalysisEvents();
+}
+
+function renderCorrectionsOutput() {
+  const container = document.getElementById('corrections-content');
+  if (!container) return;
+
+  if (!state.userId || Object.keys(state.baselineTargets).length === 0) {
+    container.innerHTML = '<p class="text-muted text-center py-8">Log in and set targets to see corrections and gap-filling tools.</p>';
+    return;
+  }
+
+  container.innerHTML = renderCorrectionsSection();
+  initCorrectionsEvents();
 }
 
 /**
@@ -1506,40 +1520,40 @@ function renderInfoBox() {
     const softCap = BANKING_CONFIG.MAX_SCHEDULE_ADJ_SOFT ?? 150;
     const hardCap = BANKING_CONFIG.MAX_SCHEDULE_ADJ_HARD ?? 250;
     return `
-      <div class="mb-6 p-4 surface-2 rounded-lg border">
-        <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How Auto Goal Works</h3>
-        <div class="text-sm text-muted space-y-1">
+      <details class="collapsible mb-6 p-4 surface-2 rounded-lg border">
+        <summary class="font-semibold text-secondary"><i class="fas fa-info-circle mr-2"></i>How Auto Goal Works</summary>
+        <div class="text-sm text-muted space-y-1 mt-2">
           <p><strong>Daily Target:</strong> Recalculated from your current weight, goal, and target date — adapts as your weight changes. The base calorie target never comes from a fixed 7-day window.</p>
           <p><strong>Schedule Correction:</strong> Weekly overages and credits are spread symmetrically across remaining goal days. Overage correction: up to ${softCap} kcal/day normally, up to ${hardCap} kcal/day in extreme cases. Credit bonus: up to ${softCap} kcal/day — never concentrated into a single day.</p>
           <p><strong>Training Days:</strong> Exercise calories are added when the planning TDEE is a rest-day estimate. If your TDEE was derived from observed data (which already includes your activity), exercise bumps are skipped to avoid double-counting.</p>
           <p><strong>7-Day Raw Balance:</strong> Shown as informational context only. In Auto Goal mode it feeds the schedule correction but does not directly set today's target.</p>
         </div>
-      </div>
+      </details>
     `;
   }
 
   if (state.goalSettings?.useRollingBanking === false) {
     return `
-      <div class="mb-6 p-4 surface-2 rounded-lg border">
-        <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How This Works</h3>
-        <div class="text-sm text-muted space-y-1">
+      <details class="collapsible mb-6 p-4 surface-2 rounded-lg border">
+        <summary class="font-semibold text-secondary"><i class="fas fa-info-circle mr-2"></i>How This Works</summary>
+        <div class="text-sm text-muted space-y-1 mt-2">
           <p><strong>Fixed Daily Target:</strong> Banking is off. Your target each day is your manual baseline plus any exercise calories — past intake has no effect on today's number.</p>
           <p><strong>Past 6 Days:</strong> Shown as context only and do not roll into the current target.</p>
           <p><strong>Training Days:</strong> Select your workout type above — this adds calories and scales electrolytes appropriately.</p>
         </div>
-      </div>
+      </details>
     `;
   }
 
   return `
-    <div class="mb-6 p-4 surface-2 rounded-lg border">
-      <h3 class="font-semibold text-secondary mb-2"><i class="fas fa-info-circle mr-2"></i>How This Works</h3>
-      <div class="text-sm text-muted space-y-1">
+    <details class="collapsible mb-6 p-4 surface-2 rounded-lg border">
+      <summary class="font-semibold text-secondary"><i class="fas fa-info-circle mr-2"></i>How This Works</summary>
+      <div class="text-sm text-muted space-y-1 mt-2">
         <p><strong>Rolling 7-Day Balance:</strong> Your calorie budget is tracked over a 7-day window. Under-eat one day? You get extra the next. Over-eat? Tomorrow's target drops.</p>
         <p><strong>Auto-Correct:</strong> Today's target is set so that hitting it exactly makes tomorrow's target your base goal. The system trues up naturally.</p>
         <p><strong>Training Days:</strong> Select your workout type above — this adds calories and scales electrolytes appropriately.</p>
       </div>
-    </div>
+    </details>
   `;
 }
 


### PR DESCRIPTION
## Summary

- **#51 New "Corrections & Gaps" tab** — Split correction/gap-filling sections out of the Energy tab into a dedicated Corrections tab. Moved `renderImputationTable`, `renderMissingCaloriesSection`, `renderVacationEditorSection`, and `renderEstimateManagementSection` into a new `renderCorrectionsSection()` with its own `initCorrectionsEvents()`. Energy tab retains KPIs, charts, confidence card, plateau status, and energy model detail. Added tab button, panel, and `VALID_TABS` entry.

- **#54 Collapse long-form explanations** — Wrapped methodology and statistical explanation blocks in `<details class="collapsible">` across Energy and Corrections tabs: eating pattern chart notes, energy model detail card, TDEE horizon explanation, PAL table notes, vacation editor instructions, imputation table description, and all three `renderInfoBox` variants (auto goal, banking off, rolling bank). Reduces cognitive load while keeping information accessible.

Also reconciled #49 and #50 to completed (merged to main via PR #136).

## Checks

- `cd public/tools/CalorieTracker && npm test` — 575 tests, 9 files, all passing
- `npm run build` — passed

## Files changed

- `public/tools/CalorieTracker/analysis/analysisUI.js` — split render/event functions for corrections tab; wrapped explanations in collapsible details
- `public/tools/CalorieTracker/ui/dashboard.js` — added `renderCorrectionsOutput`, updated `VALID_TABS` and `activateTab`; wrapped info boxes in collapsible details
- `public/tools/CalorieTracker/index.html` — added Corrections tab button and panel
- `backlogs/calorie-tracker.md` — reconciled #49/#50, marked #51/#54 as `[p]`
- `backlogs/calorie-tracker-completed.md` — archived #47–#50 as completed

## Backlog reference

See `backlogs/calorie-tracker.md` for protocol and active items.

---
_Generated by [Claude Code](https://claude.ai/code/session_015r9tBVwS8QmEz3nRQRepgr)_