### PR TITLE
CalorieTracker: corrections chart, dynamic micronutrient bounds (#52, #53)

### DIFF
--- a/backlogs/calorie-tracker-completed.md
+++ b/backlogs/calorie-tracker-completed.md
@@ -200,6 +200,12 @@ For the active backlog (new items, protocol, invariants), see `backlogs/calorie-
 - [x] **#50 — Shared chart date-range control**
   > Resolved: new ui/dateRange.js with chip presets (7d/30d/90d/YTD/1yr/All) + custom From/To; applied to nutrient, weight, and eating charts; analysis charts anchor to today; rolling avg computed from full history; merged via PR #136 (df2b0af)
 
+- [x] **#51 — New "Corrections & Gaps" tab (split from Energy)**
+  > Resolved: added corrections tab with all 4 correction sections moved from Energy; updateDashboard renders on data load; candidate cache invalidated on save; merged via PR #137 (ffe15a9)
+
+- [x] **#54 — Collapse long-form explanations**
+  > Resolved: eating pattern notes, energy detail, TDEE horizons, PAL table, vacation/imputation explanations, info boxes all wrapped in collapsible details elements; merged via PR #137 (ffe15a9)
+
 ---
 
 ## What was already verified as correct (do not regress)

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -168,7 +168,7 @@ _(#51 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   original-log source) so previously corrected days do not collapse recorded and corrected lines.
   Uses the #50 date-range control. Files:
   new `ui/correctionsChart.js` (or `analysis/analysisUI.js`).
-  > pushed — corrections chart with recorded/corrected/trend lines using date-range control; tests: 575 pass; commit: pending
+  > pushed — corrections chart with recorded/corrected/trend lines using date-range control; tests: 575 pass; commit: 04f625f
 - [ ] **#53 Dynamic micronutrient upper+lower bounds** — *[larger refactor]* Show both the
   lower bound (DRI/RDA) and the upper bound (`UL_TABLE`) where evidence exists, with a
   position indicator (**Low / Within range / Near upper / Over**). Extend `renderNutrientRow`

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -158,16 +158,8 @@ _(#47–#50 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 
 ### MEDIUM
 
-- [p] **#51 New "Corrections & Gaps" tab (split from Energy)** — *[larger refactor]* Add
-  `'corrections'` to `VALID_TABS` (`ui/dashboard.js:616`) plus a nav button/panel in
-  `index.html`. Move the missing-day fill (`renderMissingCaloriesSection`), vacation editor
-  (`renderVacationEditorSection`), estimate management (`renderEstimateManagementSection`),
-  and imputation table (`renderImputationTable`) out of the Energy tab into the new tab's
-  render path. Energy retains KPIs, weight chart, confidence card, and the TDEE/BMR/PAL
-  detail (`renderEnergyDetail`). No engine logic moves — render wiring only. Files:
-  `index.html`, `ui/dashboard.js`, `events/wire.js`, `analysis/analysisUI.js`.
-  > pushed — new Corrections tab with all 4 correction sections moved from Energy; tests: 575 pass; commit: ffe15a9
-- [ ] **#52 Recorded vs. corrected/imputed chart + trend** — *[quick win; depends on #50,
+_(#51 completed — moved to `backlogs/calorie-tracker-completed.md`)_
+- [p] **#52 Recorded vs. corrected/imputed chart + trend** — *[quick win; depends on #50,
   #51]* Single Chart.js line chart on the Corrections tab showing, for the selected range:
   recorded/logged calories, model-corrected/imputed calories, and a trend line — so the user
   can visually evaluate whether the model's recommendation makes sense. Use `runAnalysis` rows
@@ -176,6 +168,7 @@ _(#47–#50 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   original-log source) so previously corrected days do not collapse recorded and corrected lines.
   Uses the #50 date-range control. Files:
   new `ui/correctionsChart.js` (or `analysis/analysisUI.js`).
+  > pushed — corrections chart with recorded/corrected/trend lines using date-range control; tests: 575 pass; commit: pending
 - [ ] **#53 Dynamic micronutrient upper+lower bounds** — *[larger refactor]* Show both the
   lower bound (DRI/RDA) and the upper bound (`UL_TABLE`) where evidence exists, with a
   position indicator (**Low / Within range / Near upper / Over**). Extend `renderNutrientRow`
@@ -188,11 +181,7 @@ _(#47–#50 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   magnitudes are fixed scientific constants — "dynamic" means profile-driven selection and
   scaling, not invented values. Files: `ui/dashboard.js`, `targets/nutritionReferences.js`,
   `targets/targetEngine.js`, `styles.css`.
-- [p] **#54 Collapse long-form explanations** — *[quick win]* Wrap methodology and
-  statistical notes across the Energy, Nutrients, and Corrections tabs in
-  `<details class="collapsible">` "How this is calculated" / "More detail" sections to reduce
-  cognitive load. Files: `analysis/analysisUI.js`, `ui/dashboard.js`, `styles.css`.
-  > pushed — eating pattern notes, energy detail, TDEE horizons, PAL table, vacation/imputation explanations, info boxes all collapsible; tests: 575 pass; commit: ffe15a9
+_(#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 - [ ] **#55 Larger-gap imputation with min-data-on-each-side rigor** — *[larger refactor]*
   `getTrueUpCandidates` (`analysis/engine.js:1644`) already uses centered windows
   `[-7,+6]/[-14,+13]/[-21,+20]` with ≥50% coverage + minimum future weights. Parameterize and

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -169,7 +169,7 @@ _(#51 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   Uses the #50 date-range control. Files:
   new `ui/correctionsChart.js` (or `analysis/analysisUI.js`).
   > pushed — corrections chart with recorded/corrected/trend lines using date-range control; tests: 575 pass; commit: 04f625f
-- [ ] **#53 Dynamic micronutrient upper+lower bounds** — *[larger refactor]* Show both the
+- [p] **#53 Dynamic micronutrient upper+lower bounds** — *[larger refactor]* Show both the
   lower bound (DRI/RDA) and the upper bound (`UL_TABLE`) where evidence exists, with a
   position indicator (**Low / Within range / Near upper / Over**). Extend `renderNutrientRow`
   (`ui/dashboard.js:1668`) and `calculateMicronutrientMetrics` (`ui/dashboard.js:485`).
@@ -181,6 +181,7 @@ _(#51 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   magnitudes are fixed scientific constants — "dynamic" means profile-driven selection and
   scaling, not invented values. Files: `ui/dashboard.js`, `targets/nutritionReferences.js`,
   `targets/targetEngine.js`, `styles.css`.
+  > pushed — position indicator (Low/OK/Near UL/Over UL), UL shown in target span and as bar marker, ULs static per NASEM; tests: 575 pass; commit: pending
 _(#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 - [ ] **#55 Larger-gap imputation with min-data-on-each-side rigor** — *[larger refactor]*
   `getTrueUpCandidates` (`analysis/engine.js:1644`) already uses centered windows

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -181,7 +181,7 @@ _(#51 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   magnitudes are fixed scientific constants — "dynamic" means profile-driven selection and
   scaling, not invented values. Files: `ui/dashboard.js`, `targets/nutritionReferences.js`,
   `targets/targetEngine.js`, `styles.css`.
-  > pushed — position indicator (Low/OK/Near UL/Over UL), UL shown in target span and as bar marker, ULs static per NASEM; tests: 575 pass; commit: pending
+  > pushed — position indicator (Low/OK/Near UL/Over UL), UL shown in target span and as bar marker, ULs static per NASEM; tests: 575 pass; commit: 86e7335
 _(#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 - [ ] **#55 Larger-gap imputation with min-data-on-each-side rigor** — *[larger refactor]*
   `getTrueUpCandidates` (`analysis/engine.js:1644`) already uses centered windows

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -14,6 +14,7 @@ import {
   classifyDay,
   estimateVacationCalories,
   computeWeekdayAverages,
+  isSyntheticItem,
   VACATION_TYPE_CONFIG,
 } from './engine.js';
 import { buildEatingPatternTargetSeries } from '../targets/targetEngine.js';
@@ -95,6 +96,7 @@ export function renderCorrectionsSection() {
       ${results.error
         ? `<p class="text-muted text-center py-8">Upload weight data on the Energy tab to enable corrections.</p>`
         : `
+          ${renderCorrectionsChart()}
           ${renderImputationTable(results.rows)}
           ${renderMissingCaloriesSection(state._trueUpCandidates)}
           ${renderVacationEditorSection()}
@@ -205,6 +207,13 @@ export function initAnalysisEvents() {
 }
 
 export function initCorrectionsEvents() {
+  // ── Corrections chart ────────────────────────────────────────────────────────
+  const analysisRows = state.analysisResults?.rows;
+  if (analysisRows) {
+    drawCorrectionsChart(analysisRows);
+    initDateRangeEvents('corrections-chart', () => drawCorrectionsChart(analysisRows));
+  }
+
   // ── Missing Calories section (unified candidates only) ────────────────────
   const allCandidates = state._trueUpCandidates || [];
   const candidateMap  = new Map(allCandidates.map(d => [d.date, d]));
@@ -738,6 +747,182 @@ function renderConfidenceCard(confidence, results) {
       ${uncertaintyNote}
     </div>
   `;
+}
+
+// ==========================================
+// CORRECTIONS CHART — Recorded vs Corrected/Imputed
+// ==========================================
+
+function renderCorrectionsChart() {
+  return `
+    <div class="mb-6 card p-6 shadow-lg">
+      <h3 class="text-responsive-xl font-bold text-secondary mb-1">📈 Recorded vs Corrected Calories</h3>
+      ${renderDateRangeControl('corrections-chart', { defaultPreset: '90' })}
+      <div style="position:relative; height:300px;" class="mb-4">
+        <canvas id="corrections-chart-canvas"></canvas>
+      </div>
+      <details class="collapsible">
+        <summary>How this is calculated</summary>
+        <div class="p-3 surface-2 rounded-lg border text-sm text-muted space-y-2 mt-2">
+          <p><strong>Recorded</strong> (blue): calories from real food items you logged — synthetic estimates and adjustments are excluded so corrected days still show your original log.</p>
+          <p><strong>Corrected</strong> (amber markers): the model's recommended total for days it flagged as blank or under-logged, based on centered-window weight-change analysis.</p>
+          <p><strong>Trend</strong> (green): 7-day rolling average of recorded calories to show your baseline intake pattern.</p>
+          <p class="text-xs">Days with no recorded food show as gaps in the blue line. Corrected points appear only for days the model identified as candidates for adjustment.</p>
+        </div>
+      </details>
+    </div>
+  `;
+}
+
+function _getRecordedCalories(dateStr) {
+  const entry = state.dailyEntries.get(dateStr);
+  if (!entry) return null;
+  const items = Array.isArray(entry.foodItems) ? entry.foodItems : [];
+  if (items.length === 0) {
+    if (entry.entryType === 'estimate') return null;
+    const cals = parseFloat(entry.calories);
+    return cals > 0 ? cals : null;
+  }
+  const realItems = items.filter(fi => !isSyntheticItem(fi));
+  if (realItems.length === 0) return null;
+  return Math.round(realItems.reduce((sum, fi) => {
+    const qty = parseFloat(fi.quantity ?? 1) || 0;
+    const cals = parseFloat(fi.calories) || 0;
+    return sum + qty * cals;
+  }, 0));
+}
+
+function drawCorrectionsChart(rows) {
+  const canvas = document.getElementById('corrections-chart-canvas');
+  if (!canvas || !rows || rows.length === 0) return;
+
+  const range = resolveRange('corrections-chart');
+  const visibleRows = rows.filter(r => r.date >= range.startDate && r.date <= range.endDate);
+  if (visibleRows.length === 0) {
+    if (window._correctionsChart) { window._correctionsChart.destroy(); window._correctionsChart = null; }
+    return;
+  }
+
+  const chartColors = CONFIG.CHART_COLORS || [];
+  const recordedColor  = chartColors[2] || '#3b82f6';
+  const correctedColor = chartColors[1] || '#f59e0b';
+  const trendColor     = chartColors[3] || '#22c55e';
+
+  const candidates = state._trueUpCandidates || [];
+  const candidateMap = new Map(candidates.map(c => [c.date, c]));
+
+  const WINDOW = 7;
+  const fullRolling = new Map();
+  for (let i = 0; i < rows.length; i++) {
+    const slice = rows.slice(Math.max(0, i - WINDOW + 1), i + 1);
+    const calVals = slice
+      .map(r => _getRecordedCalories(r.date))
+      .filter(v => v != null);
+    fullRolling.set(rows[i].date, calVals.length >= 3
+      ? Math.round(calVals.reduce((a, b) => a + b, 0) / calVals.length)
+      : null);
+  }
+
+  const labels    = [];
+  const recorded  = [];
+  const corrected = [];
+  const trend     = [];
+
+  for (const row of visibleRows) {
+    labels.push(row.date);
+    recorded.push(_getRecordedCalories(row.date));
+    const cand = candidateMap.get(row.date);
+    corrected.push(cand ? cand.expectedCalories : null);
+    trend.push(fullRolling.get(row.date) ?? null);
+  }
+
+  if (window._correctionsChart) { window._correctionsChart.destroy(); window._correctionsChart = null; }
+
+  window._correctionsChart = new Chart(canvas.getContext('2d'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Recorded calories',
+          data: recorded,
+          borderColor: recordedColor,
+          backgroundColor: recordedColor + '30',
+          borderWidth: 2,
+          pointRadius: 0,
+          fill: false,
+          spanGaps: false,
+          tension: 0.3,
+          order: 2,
+        },
+        {
+          label: 'Model-corrected',
+          data: corrected,
+          borderColor: correctedColor,
+          backgroundColor: correctedColor,
+          borderWidth: 0,
+          pointRadius: 5,
+          pointStyle: 'triangle',
+          showLine: false,
+          order: 1,
+        },
+        {
+          label: 'Trend (7d avg)',
+          data: trend,
+          borderColor: trendColor,
+          backgroundColor: trendColor + '20',
+          borderWidth: 1.5,
+          borderDash: [4, 2],
+          pointRadius: 0,
+          fill: false,
+          spanGaps: true,
+          tension: 0.3,
+          order: 3,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false,
+      interaction: { intersect: false, mode: 'index' },
+      scales: {
+        y: {
+          position: 'left',
+          title: { display: true, text: 'Calories (kcal)' },
+          grid: { color: 'rgba(255,255,255,0.05)' },
+        },
+        x: {
+          grid: { display: false },
+          ticks: {
+            maxTicksLimit: 12,
+            callback(value) {
+              const d = new Date(this.getLabelForValue(value) + 'T00:00:00');
+              return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+            },
+          },
+        },
+      },
+      plugins: {
+        legend: { display: true, position: 'top', labels: { usePointStyle: true, padding: 12 } },
+        tooltip: {
+          ...getTooltipConfig(),
+          callbacks: {
+            title(items) {
+              if (!items.length) return '';
+              const d = new Date(items[0].label + 'T00:00:00');
+              return d.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' });
+            },
+            label(ctx) {
+              if (ctx.raw == null) return null;
+              const suffix = ctx.dataset.label === 'Model-corrected' ? ' kcal (model estimate)' : ' kcal';
+              return `${ctx.dataset.label}: ${ctx.raw}${suffix}`;
+            },
+          },
+        },
+      },
+    },
+  });
 }
 
 // ==========================================

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -832,7 +832,17 @@ function drawCorrectionsChart(rows) {
     labels.push(row.date);
     recorded.push(_getRecordedCalories(row.date));
     const cand = candidateMap.get(row.date);
-    corrected.push(cand ? cand.expectedCalories : null);
+    if (cand) {
+      corrected.push(cand.expectedCalories);
+    } else {
+      // Show saved corrections: if the entry has synthetic items, its total
+      // calories represent a previously applied correction.
+      const entry = state.dailyEntries.get(row.date);
+      const items = Array.isArray(entry?.foodItems) ? entry.foodItems : [];
+      const hasSynthetic = items.some(fi => isSyntheticItem(fi));
+      const totalCals = parseFloat(entry?.calories);
+      corrected.push(hasSynthetic && totalCals > 0 ? Math.round(totalCals) : null);
+    }
     trend.push(fullRolling.get(row.date) ?? null);
   }
 

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -1061,6 +1061,16 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
 .nt-status-good { background: hsl(var(--success) / .15); color: hsl(var(--success)); text-transform: uppercase; letter-spacing: .03em; }
 .nt-status-warn { background: hsl(var(--warning) / .15); color: hsl(var(--warning)); text-transform: uppercase; letter-spacing: .03em; }
 .nt-status-bad  { background: hsl(var(--error)   / .15); color: hsl(var(--error));   text-transform: uppercase; letter-spacing: .03em; }
+.nt-status-over { background: hsl(var(--error)   / .20); color: hsl(var(--error));   text-transform: uppercase; letter-spacing: .03em; font-weight: 600; }
+
+.hbar-ul-marker {
+  position: absolute;
+  top: -2px; bottom: -2px;
+  width: 2px;
+  background: hsl(var(--error));
+  opacity: .7;
+  border-radius: 1px;
+}
 
 .nt-trend {
   font-size: .8em;

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -583,6 +583,17 @@ export function calculateMicronutrientMetrics(dateStr) {
       const checkValue = averagedNutrients.includes(nutrient) ? avgIntake : todaysIntake;
       const isUlExceeded = ul !== null && checkValue >= ul * 0.8;
 
+      // Position indicator relative to lower bound (target) and upper bound (UL)
+      let position;
+      if (ul !== null) {
+        if (checkValue >= ul) position = 'over';
+        else if (checkValue >= ul * 0.8) position = 'near_upper';
+        else if (checkValue >= scaledTarget * 0.9) position = 'within';
+        else position = 'low';
+      } else {
+        position = checkValue >= scaledTarget * 0.9 ? 'within' : 'low';
+      }
+
       metrics[nutrient] = {
         name: nutrient,
         baseTarget,
@@ -600,6 +611,7 @@ export function calculateMicronutrientMetrics(dateStr) {
         trendDirection,
         ul,
         isUlExceeded,
+        position,
       };
     });
 
@@ -1788,7 +1800,7 @@ function renderMicronutrientSections(metrics, filter = 'all') {
     const {
       baseTarget, scaledTarget, todaysIntake, avgIntake, threeDayAvg,
       isDailyFloor, isAveraged, scaleSuggested, scaleReason,
-      targetSource, trendDirection, ul, isUlExceeded,
+      targetSource, trendDirection, ul, isUlExceeded, position,
     } = data;
 
     const displayValue = isAveraged ? avgIntake : todaysIntake;
@@ -1816,42 +1828,50 @@ function renderMicronutrientSections(metrics, filter = 'all') {
     const [trendIcon, trendCls] = trendMap[trendDirection] || trendMap.stable;
     const trendBadge = `<span class="${trendCls} nt-trend" title="Recent trend">${trendIcon}</span>`;
 
-    // UL warning
-    const ulLabel = nutrient === 'sodium'
-      ? `Near/above CDRR target (${ul})`
-      : `Near/above upper limit (UL: ${ul})`;
-    const ulBadge = isUlExceeded
-      ? `<span class="nt-badge nt-badge-ul" title="${ulLabel}">⚠️</span>`
-      : '';
-
-    // Status text label (accessible alternative to color-only bar)
-    const statusTextMap = { red: ['low', 'nt-status-bad'], amber: ['near', 'nt-status-warn'], green: ['ok', 'nt-status-good'] };
-    const [statusText, statusCls] = statusTextMap[data.status] || statusTextMap.green;
-    const statusBadge = `<span class="nt-badge ${statusCls}">${statusText}</span>`;
+    // Position indicator (replaces separate status + UL badges)
+    const posMap = {
+      low:        ['Low', 'nt-status-bad',  'Below recommended intake'],
+      within:     ['OK', 'nt-status-good', ul ? `Between lower bound and upper limit (${ul})` : 'Meeting recommended intake'],
+      near_upper: ['Near UL', 'nt-status-warn', nutrient === 'sodium' ? `Near CDRR (${ul})` : `Approaching upper limit (${ul})`],
+      over:       ['Over UL', 'nt-status-over', nutrient === 'sodium' ? `Above CDRR (${ul})` : `Above upper limit (${ul})`],
+    };
+    const [posText, posCls, posTitle] = posMap[position] || posMap.low;
+    const positionBadge = `<span class="nt-badge ${posCls}" title="${posTitle}">${posText}</span>`;
 
     // Source label in target span
     const srcLabel = targetSource === 'manual_override'    ? ' (pinned)'
                    : targetSource === 'auto_goal'           ? ' (auto goal)'
                    : targetSource === 'manual_baseline'     ? ' (custom)'
                    : targetSource === 'dri_profile_default' ? ' (profile DRI)'
-                   : ' (DRI)'; // 'dri' = matches generic DRI reference value
+                   : ' (DRI)';
+
+    // Target display: show both lower and upper bounds when UL exists
+    const ulSuffix = ul !== null
+      ? ` · UL ${ul}`
+      : '';
 
     // For averaged nutrients show today's value as sub-detail below the bar
     const subDetail = isAveraged
       ? `<div class="nt-sub-detail">Today: ${todaysIntake.toFixed(1)} · 3d avg: ${threeDayAvg.toFixed(1)}</div>`
       : '';
 
+    // UL marker position on the bar (relative to target scale)
+    const ulMarkerHtml = ul !== null && targetValue > 0
+      ? `<div class="hbar-ul-marker" style="left:${clampPct150(ul, targetValue * 1.5)}%" title="Upper limit: ${ul}"></div>`
+      : '';
+
     return `
       <div class="kpi-row">
         <div class="meta">
-          <span class="label">${formatNutrientName(nutrient)}${statusBadge}${sourceBadge}${scaleBadge}${trendBadge}${ulBadge}</span>
+          <span class="label">${formatNutrientName(nutrient)}${positionBadge}${sourceBadge}${scaleBadge}${trendBadge}</span>
           <span class="current">${displayValue.toFixed(1)}${isAveraged ? '<span class="nt-avg-label">avg</span>' : ''}</span>
-          <span class="target">target ${targetValue.toFixed(1)}${srcLabel}</span>
+          <span class="target">target ${targetValue.toFixed(1)}${ulSuffix}${srcLabel}</span>
           <span class="remain ${remainClass(remaining)}">${remaining > 0 ? `${remaining.toFixed(1)} left` : remaining < 0 ? `${Math.abs(remaining).toFixed(1)} over` : '0 left'}</span>
         </div>
         <div class="hbar">
           <div class="hbar-fill ${pctClass(displayValue, targetValue)}" style="width:${pctWidth(displayValue, targetValue)}"></div>
           <div class="hbar-marker" style="left:${markerLeft}"></div>
+          ${ulMarkerHtml}
         </div>
         ${subDetail}
       </div>`;

--- a/public/tools/CalorieTracker/ui/dashboard.js
+++ b/public/tools/CalorieTracker/ui/dashboard.js
@@ -583,15 +583,18 @@ export function calculateMicronutrientMetrics(dateStr) {
       const checkValue = averagedNutrients.includes(nutrient) ? avgIntake : todaysIntake;
       const isUlExceeded = ul !== null && checkValue >= ul * 0.8;
 
-      // Position indicator relative to lower bound (target) and upper bound (UL)
+      // Position indicator relative to lower bound (target) and upper bound (UL).
+      // Sodium is special: its CDRR (2300) often equals the DRI target, so UL-based
+      // thresholds would make "within" unreachable. Skip UL checks when ul <= scaledTarget.
       let position;
-      if (ul !== null) {
+      const ulApplies = ul !== null && ul > scaledTarget;
+      if (ulApplies) {
         if (checkValue >= ul) position = 'over';
         else if (checkValue >= ul * 0.8) position = 'near_upper';
-        else if (checkValue >= scaledTarget * 0.9) position = 'within';
+        else if (checkValue >= scaledTarget) position = 'within';
         else position = 'low';
       } else {
-        position = checkValue >= scaledTarget * 0.9 ? 'within' : 'low';
+        position = checkValue >= scaledTarget ? 'within' : 'low';
       }
 
       metrics[nutrient] = {
@@ -854,8 +857,8 @@ function renderNutrientFilterBar(activeFilter) {
   const filters = [
     { id: 'all',      label: 'All' },
     { id: 'low',      label: '🔴 Low' },
-    { id: 'near',     label: '🟡 Near Target' },
-    { id: 'above',    label: '🟢 On Target' },
+    { id: 'above',    label: '🟢 OK' },
+    { id: 'near',     label: '🟡 Near/Over UL' },
     { id: 'override', label: '📌 Overridden' },
   ];
   return `
@@ -1786,9 +1789,9 @@ function renderChartSection() {
 function renderMicronutrientSections(metrics, filter = 'all') {
   const filterFn = (data) => {
     switch (filter) {
-      case 'low':      return data.status === 'red';
-      case 'near':     return data.status === 'amber';
-      case 'above':    return data.status === 'green';
+      case 'low':      return data.position === 'low';
+      case 'near':     return data.position === 'near_upper' || data.position === 'over';
+      case 'above':    return data.position === 'within';
       case 'override': return data.targetSource === 'manual_override';
       default:         return true;
     }
@@ -1855,9 +1858,13 @@ function renderMicronutrientSections(metrics, filter = 'all') {
       ? `<div class="nt-sub-detail">Today: ${todaysIntake.toFixed(1)} · 3d avg: ${threeDayAvg.toFixed(1)}</div>`
       : '';
 
-    // UL marker position on the bar (relative to target scale)
-    const ulMarkerHtml = ul !== null && targetValue > 0
-      ? `<div class="hbar-ul-marker" style="left:${clampPct150(ul, targetValue * 1.5)}%" title="Upper limit: ${ul}"></div>`
+    // UL marker on the bar. The bar maps 0–150% of target onto 0–100% width,
+    // so the UL position is (ul / target) * markerPct, clamped to 100%.
+    const ulMarkerPos = ul !== null && targetValue > 0
+      ? Math.min(100, (ul / targetValue) * markerPct)
+      : null;
+    const ulMarkerHtml = ulMarkerPos !== null
+      ? `<div class="hbar-ul-marker" style="left:${ulMarkerPos.toFixed(2)}%" title="Upper limit: ${ul}"></div>`
       : '';
 
     return `

--- a/public/tools/CalorieTracker/ui/dateRange.js
+++ b/public/tools/CalorieTracker/ui/dateRange.js
@@ -37,7 +37,7 @@ function addDays(dateStr, n) {
   return d.toISOString().slice(0, 10);
 }
 
-const _analysisCharts = new Set(['weight-chart', 'eating-chart']);
+const _analysisCharts = new Set(['weight-chart', 'eating-chart', 'corrections-chart']);
 
 export function resolveRange(chartId) {
   const s = _rangeStates.get(chartId) || { preset: '30' };


### PR DESCRIPTION
## Summary

- **#52 Recorded vs. corrected/imputed chart + trend** — New Chart.js line chart on the Corrections tab showing three series: recorded calories (from real food items, excluding synthetic `est-`/`vac-`/`adj-` items), model-corrected values (triangle markers from `getTrueUpCandidates`), and a 7-day rolling average trend line. Uses the shared date-range control from #50. Rolling averages are computed from full history so the window isn't truncated at range boundaries.

- **#53 Dynamic micronutrient upper+lower bounds** — Added `position` field to `calculateMicronutrientMetrics()` with four states: **Low** (below DRI), **OK** (between DRI and UL), **Near UL** (≥80% of UL), **Over UL** (≥UL). Replaced the separate status badge + UL warning badge with a unified position indicator in `renderNutrientRow()`. UL value now shown in the target span (`target 15.0 · UL 45`) and as a red marker on the progress bar. ULs remain static NASEM constants — "dynamic" refers to the profile-driven DRI selection (already reactive via debounced path in `targetUI.js`).

Also reconciles #51 and #54 to completed (merged to main via PR #137).

## Checks

- `cd public/tools/CalorieTracker && npm test` — 575 tests, 9 files, all passing

## Files changed

- `public/tools/CalorieTracker/analysis/analysisUI.js` — corrections chart (`renderCorrectionsChart`, `drawCorrectionsChart`, `_getRecordedCalories`), date-range wiring, `isSyntheticItem` import
- `public/tools/CalorieTracker/ui/dashboard.js` — `position` field in metrics, unified position badge, UL in target span, UL bar marker
- `public/tools/CalorieTracker/styles.css` — `.nt-status-over` class, `.hbar-ul-marker` positioning
- `backlogs/calorie-tracker.md` — reconciled #51/#54, marked #52/#53 as `[p]` with commit SHAs
- `backlogs/calorie-tracker-completed.md` — archived #51 and #54 as completed

## Backlog reference

See `backlogs/calorie-tracker.md` for protocol and active items.

---
_Generated by [Claude Code](https://claude.ai/code/session_016JU7ppNrVpQQQAQzZK8U3g)_