### PR TITLE
CalorieTracker: min pre-weight rigor, estimate correction eligibility (#55, #56)

### DIFF
--- a/backlogs/calorie-tracker-completed.md
+++ b/backlogs/calorie-tracker-completed.md
@@ -203,6 +203,12 @@ For the active backlog (new items, protocol, invariants), see `backlogs/calorie-
 - [x] **#51 — New "Corrections & Gaps" tab (split from Energy)**
   > Resolved: added corrections tab with all 4 correction sections moved from Energy; updateDashboard renders on data load; candidate cache invalidated on save; merged via PR #137 (ffe15a9)
 
+- [x] **#52 — Recorded vs. corrected/imputed chart + trend**
+  > Resolved: corrections chart with recorded/corrected/trend lines using date-range control; codex review fixes for chart range anchoring and saved corrections visibility; merged via PR #138 (9520e8d)
+
+- [x] **#53 — Dynamic micronutrient upper+lower bounds**
+  > Resolved: position indicator (Low/OK/Near UL/Over UL), UL shown in target span and as bar marker, ULs static per NASEM; codex review fixes for sodium CDRR, DRI threshold, UL marker positioning, and filter alignment; merged via PR #138 (9520e8d)
+
 - [x] **#54 — Collapse long-form explanations**
   > Resolved: eating pattern notes, energy detail, TDEE horizons, PAL table, vacation/imputation explanations, info boxes all wrapped in collapsible details elements; merged via PR #137 (ffe15a9)
 

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -169,7 +169,7 @@ _(#52–#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   interval blocks for correction by default; remove or explicitly gate the current
   `inside_interval` fallback for sparse histories so circular evidence cannot silently drive
   wider-gap corrections. Add tests. Files: `analysis/engine.js`, `analysis/engine.test.js`.
-  > pushed — minPreWeights added to INTERVALS config, pre-candidate weight check enforced, inside_interval TDEE fallback removed, preWeightPoints surfaced in interval data; tests: 584 pass; commit: PENDING
+  > pushed — minPreWeights added to INTERVALS config, pre-candidate weight check enforced, inside_interval TDEE fallback removed, preWeightPoints surfaced in interval data; tests: 584 pass; commit: e3eed75
 - [p] **#56 Vacation days eligible for later weight-based correction** — *[larger refactor]*
   The one genuine model change: treat vacation/low-log quick-estimates (#49) as
   low-confidence priors that the centered-window true-up may later refine (respecting
@@ -179,7 +179,7 @@ _(#52–#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   even if they have top-level `calories`, so low-confidence priors cannot train the model they
   are later corrected against. Add tests for the no-circularity guarantee. Files:
   `analysis/engine.js`, `analysis/engine.test.js`.
-  > pushed — estimate entries eligible as 'estimate' type candidates, isEstimate flag in mergeDailyData excludes estimates from TDEE blocks, checkedByDefault=false for estimates; tests: 584 pass; commit: PENDING
+  > pushed — estimate entries eligible as 'estimate' type candidates, isEstimate flag in mergeDailyData excludes estimates from TDEE blocks, checkedByDefault=false for estimates; tests: 584 pass; commit: e3eed75
 
 ### LOW / NICE-TO-HAVE
 

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -159,31 +159,8 @@ _(#47–#50 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 ### MEDIUM
 
 _(#51 completed — moved to `backlogs/calorie-tracker-completed.md`)_
-- [p] **#52 Recorded vs. corrected/imputed chart + trend** — *[quick win; depends on #50,
-  #51]* Single Chart.js line chart on the Corrections tab showing, for the selected range:
-  recorded/logged calories, model-corrected/imputed calories, and a trend line — so the user
-  can visually evaluate whether the model's recommendation makes sense. Use `runAnalysis` rows
-  + `getTrueUpCandidates` for corrected/imputed values, but reconstruct recorded calories from
-  `dailyEntries.foodItems` excluding synthetic `est-` / `adj-` items (or another persisted
-  original-log source) so previously corrected days do not collapse recorded and corrected lines.
-  Uses the #50 date-range control. Files:
-  new `ui/correctionsChart.js` (or `analysis/analysisUI.js`).
-  > pushed — corrections chart with recorded/corrected/trend lines using date-range control; tests: 575 pass; commit: 04f625f
-- [p] **#53 Dynamic micronutrient upper+lower bounds** — *[larger refactor]* Show both the
-  lower bound (DRI/RDA) and the upper bound (`UL_TABLE`) where evidence exists, with a
-  position indicator (**Low / Within range / Near upper / Over**). Extend `renderNutrientRow`
-  (`ui/dashboard.js:1668`) and `calculateMicronutrientMetrics` (`ui/dashboard.js:485`).
-  Lower-bound selection is already profile-driven via age/sex bands (`getDRI`), but upper
-  bounds currently come from a nutrient-wide `UL_TABLE`; add profile-specific UL lookup data
-  where evidence exists, or narrow the UI/copy so only lower bounds are described as dynamic.
-  Preserve evidence-based scaling (protein g/kg, electrolyte sweat scaling) and confirm recompute
-  is reactive on profile change (debounced path in `targets/targetUI.js`). Note: DRI/UL
-  magnitudes are fixed scientific constants — "dynamic" means profile-driven selection and
-  scaling, not invented values. Files: `ui/dashboard.js`, `targets/nutritionReferences.js`,
-  `targets/targetEngine.js`, `styles.css`.
-  > pushed — position indicator (Low/OK/Near UL/Over UL), UL shown in target span and as bar marker, ULs static per NASEM; tests: 575 pass; commit: 86e7335
-_(#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
-- [ ] **#55 Larger-gap imputation with min-data-on-each-side rigor** — *[larger refactor]*
+_(#52–#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
+- [p] **#55 Larger-gap imputation with min-data-on-each-side rigor** — *[larger refactor]*
   `getTrueUpCandidates` (`analysis/engine.js:1644`) already uses centered windows
   `[-7,+6]/[-14,+13]/[-21,+20]` with ≥50% coverage + minimum future weights. Parameterize and
   document the minimum pre/post day counts and weight-point counts so wider gaps impute only
@@ -192,7 +169,8 @@ _(#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   interval blocks for correction by default; remove or explicitly gate the current
   `inside_interval` fallback for sparse histories so circular evidence cannot silently drive
   wider-gap corrections. Add tests. Files: `analysis/engine.js`, `analysis/engine.test.js`.
-- [ ] **#56 Vacation days eligible for later weight-based correction** — *[larger refactor]*
+  > pushed — minPreWeights added to INTERVALS config, pre-candidate weight check enforced, inside_interval TDEE fallback removed, preWeightPoints surfaced in interval data; tests: 584 pass; commit: PENDING
+- [p] **#56 Vacation days eligible for later weight-based correction** — *[larger refactor]*
   The one genuine model change: treat vacation/low-log quick-estimates (#49) as
   low-confidence priors that the centered-window true-up may later refine (respecting
   `manualLock` / `estimateMeta.locked`). Add the no-circularity exclusion in the TDEE/block
@@ -201,6 +179,7 @@ _(#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
   even if they have top-level `calories`, so low-confidence priors cannot train the model they
   are later corrected against. Add tests for the no-circularity guarantee. Files:
   `analysis/engine.js`, `analysis/engine.test.js`.
+  > pushed — estimate entries eligible as 'estimate' type candidates, isEstimate flag in mergeDailyData excludes estimates from TDEE blocks, checkedByDefault=false for estimates; tests: 584 pass; commit: PENDING
 
 ### LOW / NICE-TO-HAVE
 

--- a/public/tools/CalorieTracker/analysis/engine.js
+++ b/public/tools/CalorieTracker/analysis/engine.js
@@ -353,6 +353,7 @@ export function mergeDailyData(weightEntries, dailyEntries, weightEntriesMulti =
       carbs: nEntry ? (parseFloat(nEntry.carbs) || null) : null,
       fiber: nEntry ? (parseFloat(nEntry.fiber) || null) : null,
       trainingBump: nEntry ? (parseFloat(nEntry.trainingBump) || 0) : 0,
+      isEstimate: nEntry ? nEntry.entryType === 'estimate' : false,
       ...exFields,
     });
   }
@@ -533,7 +534,7 @@ export function estimateTDEE(rows) {
 
   for (let i = blockDays; i < result.length; i++) {
     const window = result.slice(i - blockDays, i + 1);
-    const cals = window.map(r => r.calories).filter(c => c != null);
+    const cals = window.filter(r => !r.isEstimate).map(r => r.calories).filter(c => c != null);
     if (cals.length < window.length * 0.7) continue;
 
     const wStart = window[0].wt_smooth_lb;
@@ -1676,9 +1677,9 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
 
   // Centered windows: candidate D is inside [D-preDays, D+postDays]
   const INTERVALS = [
-    { days: 14, preDays: 7,  postDays: 6,  name: '14d', minPostWeights: 3 },
-    { days: 28, preDays: 14, postDays: 13, name: '28d', minPostWeights: 5 },
-    { days: 42, preDays: 21, postDays: 20, name: '42d', minPostWeights: 7 },
+    { days: 14, preDays: 7,  postDays: 6,  name: '14d', minPostWeights: 3, minPreWeights: 3 },
+    { days: 28, preDays: 14, postDays: 13, name: '28d', minPostWeights: 5, minPreWeights: 4 },
+    { days: 42, preDays: 21, postDays: 20, name: '42d', minPostWeights: 7, minPreWeights: 5 },
   ];
   const MIN_CANDIDATE_AGE = 6; // at minimum 6 days old (smallest postDays)
 
@@ -1697,8 +1698,9 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
     const isLocked = entry && (entry.manualLock || entry.estimateMeta?.locked);
     if (isLocked) continue;
 
-    if (entry) {
-      if (entry.entryType === 'estimate') continue;
+    const isEstimateEntry = entry && entry.entryType === 'estimate';
+
+    if (entry && !isEstimateEntry) {
       const hasSynth = (entry.foodItems || []).some(fi =>
         fi.id?.startsWith('adj-') || fi.id?.startsWith('est-')
       );
@@ -1709,12 +1711,15 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
     let loggedCalories = 0;
     let realItemCount = 0;
 
-    if (!entry || (parseFloat(entry.calories) || 0) === 0) {
+    if (isEstimateEntry) {
+      type = 'estimate';
+      loggedCalories = 0;
+    } else if (!entry || (parseFloat(entry.calories) || 0) === 0) {
       if (row.calories_imputed || row.impute_status === 'pending') {
         type = 'blank';
         loggedCalories = 0;
       }
-    } else if (entry.entryType !== 'estimate') {
+    } else {
       const realItems = (entry.foodItems || []).filter(fi => !isSyntheticItem(fi));
       realItemCount = realItems.length;
       loggedCalories = realItems.length > 0
@@ -1746,7 +1751,7 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
     const intervalsUsed = [];
     let anyWindowNeedsFutureData = false;
 
-    for (const { days, preDays, postDays, name, minPostWeights } of INTERVALS) {
+    for (const { days, preDays, postDays, name, minPostWeights, minPreWeights } of INTERVALS) {
       // If candidate isn't old enough for this window's post-candidate span, skip
       if (age < postDays) {
         anyWindowNeedsFutureData = true;
@@ -1757,6 +1762,12 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
       const end   = dateOffset(candidateDate, postDays);
       const intervalRows = rows.filter(r => r.date >= start && r.date <= end);
       if (intervalRows.length < Math.max(7, Math.floor(days * 0.5))) continue;
+
+      // Require minimum weight readings BEFORE the candidate
+      const preWeightRows = intervalRows.filter(
+        r => r.date < candidateDate && r.wt_smooth_lb != null
+      );
+      if (preWeightRows.length < minPreWeights) continue;
 
       // Require minimum future weight readings AFTER the candidate
       const futureWeightRows = intervalRows.filter(
@@ -1796,21 +1807,18 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
       } else if (bmrModel?.tdee_current) {
         refTdee = bmrModel.tdee_current;
         tdeeRefSource = 'formula_tdee';
-      } else if (insideBlocks.length >= 3) {
-        refTdee = insideBlocks.reduce((s, r) => s + r.tdee_block, 0) / insideBlocks.length;
-        tdeeRefSource = 'inside_interval';
       } else {
         refTdee = 2000;
         tdeeRefSource = 'hardcoded_fallback';
       }
       if (!refTdee || refTdee <= 0) continue;
 
-      // Reported intake: blank candidates always contribute 0 (they have 0 logged);
+      // Reported intake: blank/estimate candidates contribute 0 (synthetic calories excluded);
       // partial candidates contribute their loggedCalories; non-candidates contribute normally.
       let reportedIntake = 0;
       for (const r of intervalRows) {
         const cand = candidateMap.get(r.date);
-        if (cand?.type === 'blank') {
+        if (cand?.type === 'blank' || cand?.type === 'estimate') {
           reportedIntake += 0;
         } else if (cand?.type === 'partial') {
           reportedIntake += cand.loggedCalories;
@@ -1837,7 +1845,7 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
         .map(r => candidateMap.get(r.date));
 
       const plausibleNeedOf = (c) =>
-        c.type === 'blank' ? refTdee : Math.max(0, refTdee - c.loggedCalories);
+        (c.type === 'blank' || c.type === 'estimate') ? refTdee : Math.max(0, refTdee - c.loggedCalories);
       const totalNeed = allCandsInWindow.reduce((s, c) => s + plausibleNeedOf(c), 0);
       const thisNeed = plausibleNeedOf({ type, loggedCalories });
       const allocFactor = totalNeed > 0 ? Math.min(1, Math.max(0, totalResidual) / totalNeed) : 0;
@@ -1858,6 +1866,7 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
         residualAfter,
         coverage: Math.round(coverage * 100),
         weightPoints: weightRows.length,
+        preWeightPoints: preWeightRows.length,
         futureWeightPoints: futureWeightRows.length,
         allocatedDelta,
         allocFactor: Math.round(allocFactor * 100) / 100,
@@ -1906,15 +1915,13 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
     let fullDayEstimate = null;
     let estimateSource = null;
     let imputedDiagnosticCalories = null;
-    if (type === 'blank') {
+    if (type === 'blank' || type === 'estimate') {
       const imputedCals = row.calories_imputed ? (row.calories || 0) : 0;
       if (imputedCals > 0) imputedDiagnosticCalories = Math.round(imputedCals);
-      // Centered-interval estimate is the primary source
       fullDayEstimate = avgTdeeForCandidate > 0
         ? Math.round(avgTdeeForCandidate)
         : (parseFloat(baselineTargets?.calories) || 2000);
       estimateSource = avgTdeeForCandidate > 0 ? 'centered_interval' : 'baseline_target';
-      // Cap by interval-aware allocation when multiple candidates share a window
       recommendedDelta = Math.max(600, Math.min(fullDayEstimate, minAllocDelta, 6000));
     } else {
       const maxDelta = Math.min(primary.perDayResidual, Math.round(avgTdeeForCandidate - loggedCalories));
@@ -1952,13 +1959,15 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
     const confidence = score >= 60 ? 'high' : score >= 35 ? 'medium' : 'low';
 
     const reviewManually = recommendedDelta > 1000 && !(confidence === 'high' && has28 && has42);
-    const checkedByDefault = !reviewManually && confidence !== 'low';
+    const checkedByDefault = type !== 'estimate' && !reviewManually && confidence !== 'low';
 
     const reason = type === 'blank'
       ? `No food logged — ${primary.days}-day centered window implies ~${expectedCalories} kcal (${primary.perDayResidual} kcal/day gap).`
-      : (primary.perDayResidual > 600
-        ? 'Large gap — likely missed meals or significantly under-logged.'
-        : 'Moderate gap — possible missed snacks or partial log.');
+      : type === 'estimate'
+        ? `Saved estimate — ${primary.days}-day centered window suggests refinement to ~${expectedCalories} kcal.`
+        : (primary.perDayResidual > 600
+          ? 'Large gap — likely missed meals or significantly under-logged.'
+          : 'Moderate gap — possible missed snacks or partial log.');
 
     candidates.push({
       date: candidateDate,

--- a/public/tools/CalorieTracker/analysis/engine.js
+++ b/public/tools/CalorieTracker/analysis/engine.js
@@ -1712,6 +1712,8 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
     let realItemCount = 0;
 
     if (isEstimateEntry) {
+      const method = entry.estimateMeta?.method;
+      if (method === 'blank_day_trueup' || method === 'partial_day_adjustment') continue;
       type = 'estimate';
       loggedCalories = 0;
     } else if (!entry || (parseFloat(entry.calories) || 0) === 0) {
@@ -1763,9 +1765,9 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
       const intervalRows = rows.filter(r => r.date >= start && r.date <= end);
       if (intervalRows.length < Math.max(7, Math.floor(days * 0.5))) continue;
 
-      // Require minimum weight readings BEFORE the candidate
+      // Require minimum actual weight observations BEFORE the candidate
       const preWeightRows = intervalRows.filter(
-        r => r.date < candidateDate && r.wt_smooth_lb != null
+        r => r.date < candidateDate && r.weight_corr != null
       );
       if (preWeightRows.length < minPreWeights) continue;
 
@@ -1824,9 +1826,13 @@ export function getTrueUpCandidates(rows, dailyEntries, bmrModel, baselineTarget
           reportedIntake += cand.loggedCalories;
         } else {
           const e = dailyEntries.get(r.date);
-          reportedIntake += e
-            ? parseFloat(e.calories) || 0
-            : (r.calories_imputed ? (r.calories || 0) : 0);
+          if (e?.entryType === 'estimate') {
+            reportedIntake += 0;
+          } else {
+            reportedIntake += e
+              ? parseFloat(e.calories) || 0
+              : (r.calories_imputed ? (r.calories || 0) : 0);
+          }
         }
       }
       reportedIntake = Math.round(reportedIntake);
@@ -2084,7 +2090,7 @@ export function buildBlankDayEstimateEntry(dateStr, candidate, analysisResults, 
     date: dateStr,
     schemaVersion: 2,
     entryType: 'estimate',
-    vacationDayType: null,
+    vacationDayType: prevEntry?.vacationDayType ?? null,
     calories: Math.round(estCals),
     protein: adjProtein,
     fat: adjFat,

--- a/public/tools/CalorieTracker/analysis/engine.test.js
+++ b/public/tools/CalorieTracker/analysis/engine.test.js
@@ -2349,3 +2349,283 @@ describe('runAnalysis — estimated current weight in summary', () => {
     expect(r.summary.estimatedWeightMethod).toBe('measured');
   });
 });
+
+// ── #55 Larger-gap imputation: min pre/post weight rigor ────────────────────
+
+describe('getTrueUpCandidates — min pre-weight rigor (#55)', () => {
+  it('interval data includes preWeightPoints', () => {
+    const startDate = '2023-10-01';
+    const blankDate = isoDate(startDate, 25);
+    const { weightEntries, dailyEntries, baseline, bmrModel } = makeDataForTrueUp({ blankDate, startDate, n: 80 });
+    const results = runAnalysis(weightEntries, dailyEntries);
+    expect(results.error).toBeFalsy();
+
+    const candidates = getTrueUpCandidates(results.rows, dailyEntries, bmrModel, baseline);
+    const found = candidates.find(c => c.date === blankDate);
+    expect(found).toBeDefined();
+    for (const interval of found.intervalsUsed) {
+      expect(typeof interval.preWeightPoints).toBe('number');
+      expect(interval.preWeightPoints).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it('candidate near data start with insufficient pre-weights is not actionable', () => {
+    const startDate = '2024-01-01';
+    const n = 60;
+    const blankDay = 2;
+    const blankDate = isoDate(startDate, blankDay);
+
+    const weightData = [];
+    const nutritionData = [];
+    for (let i = 0; i < n; i++) {
+      const date = isoDate(startDate, i);
+      if (i <= 1) {
+        // Only 2 weight points before the blank day — below minPreWeights=3
+        weightData.push({ date, weightLb: 185 - i * 0.05 });
+      } else if (i > blankDay) {
+        weightData.push({ date, weightLb: 185 - i * 0.05 });
+      }
+      if (i !== blankDay) {
+        nutritionData.push({ date, calories: 2000, protein: 150, fat: 60, carbs: 200 });
+      }
+    }
+    const weightEntries = makeWeightEntries(weightData);
+    const dailyEntries = makeNutritionEntries(nutritionData);
+    const baseline = { calories: '2000', protein: '150', fat: '60' };
+    const bmrModel = { source: 'formula', tdee_current: 2350, observedTdee: 2350, error: null };
+
+    const results = runAnalysis(weightEntries, dailyEntries);
+    if (results.error) return;
+
+    const candidates = getTrueUpCandidates(results.rows, dailyEntries, bmrModel, baseline);
+    const found = candidates.find(c => c.date === blankDate && !c.needsFutureData);
+    expect(found).toBeUndefined();
+  });
+
+  it('inside_interval TDEE reference is never used', () => {
+    const startDate = '2023-10-01';
+    const blankDate = isoDate(startDate, 25);
+    const { weightEntries, dailyEntries, baseline } = makeDataForTrueUp({ blankDate, startDate, n: 80 });
+    // bmrModel with no observedTdee and no tdee_current — forces fallback
+    const bmrModel = { source: 'formula', error: null };
+
+    const results = runAnalysis(weightEntries, dailyEntries);
+    if (results.error) return;
+
+    const candidates = getTrueUpCandidates(results.rows, dailyEntries, bmrModel, baseline);
+    for (const c of candidates) {
+      for (const interval of c.intervalsUsed) {
+        expect(interval.tdeeRefSource).not.toBe('inside_interval');
+      }
+    }
+  });
+});
+
+// ── #56 Vacation/estimate days eligible for correction ──────────────────────
+
+describe('getTrueUpCandidates — estimate entries as candidates (#56)', () => {
+  function makeDataWithEstimate(opts = {}) {
+    const {
+      n = 80,
+      startDate = '2023-10-01',
+      estimateDay = 25,
+      estimateCalories = 1800,
+      locked = false,
+    } = opts;
+
+    const weightData = [];
+    const nutritionData = [];
+
+    for (let i = 0; i < n; i++) {
+      const date = isoDate(startDate, i);
+      weightData.push({ date, weightLb: 185 - i * 0.05 });
+
+      if (i === estimateDay) {
+        // This day has a saved estimate (entryType: 'estimate')
+        nutritionData.push({
+          date,
+          calories: estimateCalories,
+          protein: 120,
+          carbs: 200,
+          fat: 50,
+          entryType: 'estimate',
+          estimateMeta: { locked },
+          foodItems: [{ id: 'est-vacation-001', name: "Estimated vacation day", calories: estimateCalories, quantity: 1 }],
+        });
+      } else {
+        nutritionData.push({ date, calories: 2000, protein: 150, carbs: 250, fat: 60 });
+      }
+    }
+
+    const weightEntries = makeWeightEntries(weightData);
+    // Build dailyEntries manually to preserve entryType and estimateMeta
+    const dailyEntries = new Map();
+    for (const d of nutritionData) {
+      dailyEntries.set(d.date, {
+        date: d.date,
+        calories: d.calories,
+        protein: d.protein ?? 150,
+        carbs: d.carbs ?? 200,
+        fat: d.fat ?? 60,
+        fiber: d.fiber ?? 25,
+        sodium: d.sodium ?? 2200,
+        trainingBump: 0,
+        exerciseSessions: [],
+        ...(d.entryType ? { entryType: d.entryType } : {}),
+        ...(d.estimateMeta ? { estimateMeta: d.estimateMeta } : {}),
+        ...(d.foodItems ? { foodItems: d.foodItems } : {}),
+      });
+    }
+    const baseline = { calories: '2000', protein: '150', fat: '60' };
+    const bmrModel = { source: 'formula', tdee_current: 2350, observedTdee: 2350, error: null };
+
+    return { weightEntries, dailyEntries, baseline, bmrModel, estimateDate: isoDate(startDate, estimateDay) };
+  }
+
+  it('estimate entry is returned as a candidate with type "estimate"', () => {
+    const { weightEntries, dailyEntries, baseline, bmrModel, estimateDate } = makeDataWithEstimate();
+    const results = runAnalysis(weightEntries, dailyEntries);
+    expect(results.error).toBeFalsy();
+
+    const candidates = getTrueUpCandidates(results.rows, dailyEntries, bmrModel, baseline);
+    const found = candidates.find(c => c.date === estimateDate);
+    expect(found).toBeDefined();
+    expect(found.type).toBe('estimate');
+    expect(found.loggedCalories).toBe(0);
+    expect(found.recommendedDelta).toBeGreaterThanOrEqual(600);
+  });
+
+  it('locked estimate entry is NOT returned as a candidate', () => {
+    const { weightEntries, dailyEntries, baseline, bmrModel, estimateDate } = makeDataWithEstimate({ locked: true });
+    const results = runAnalysis(weightEntries, dailyEntries);
+    expect(results.error).toBeFalsy();
+
+    const candidates = getTrueUpCandidates(results.rows, dailyEntries, bmrModel, baseline);
+    const found = candidates.find(c => c.date === estimateDate);
+    expect(found).toBeUndefined();
+  });
+
+  it('estimate candidates are not checked by default', () => {
+    const { weightEntries, dailyEntries, baseline, bmrModel, estimateDate } = makeDataWithEstimate();
+    const results = runAnalysis(weightEntries, dailyEntries);
+    expect(results.error).toBeFalsy();
+
+    const candidates = getTrueUpCandidates(results.rows, dailyEntries, bmrModel, baseline);
+    const found = candidates.find(c => c.date === estimateDate);
+    if (found) {
+      expect(found.checkedByDefault).toBe(false);
+    }
+  });
+
+  it('estimate reason string mentions refinement', () => {
+    const { weightEntries, dailyEntries, baseline, bmrModel, estimateDate } = makeDataWithEstimate();
+    const results = runAnalysis(weightEntries, dailyEntries);
+    expect(results.error).toBeFalsy();
+
+    const candidates = getTrueUpCandidates(results.rows, dailyEntries, bmrModel, baseline);
+    const found = candidates.find(c => c.date === estimateDate);
+    if (found) {
+      expect(found.reason).toContain('refinement');
+    }
+  });
+});
+
+describe('estimateTDEE — no-circularity for estimate entries (#56)', () => {
+  it('estimate days do not contribute calories to TDEE blocks', () => {
+    const startDate = '2024-01-01';
+    const n = 30;
+    const days = [];
+    for (let i = 0; i < n; i++) {
+      days.push({
+        date: isoDate(startDate, i),
+        weightLb: 185 - i * 0.05,
+        calories: 2000,
+      });
+    }
+
+    const weightEntries = makeWeightEntries(days);
+
+    // Run with all real entries to get baseline TDEE blocks
+    const realEntries = makeNutritionEntries(days);
+    const realRows = runAnalysis(weightEntries, realEntries).rows;
+    const realTdeeBlocks = realRows.filter(r => r.tdee_block != null);
+
+    // Now create entries where days 5-10 are estimates with wildly different calories
+    const mixedEntries = new Map();
+    for (const d of days) {
+      const dayNum = Math.round((new Date(d.date) - new Date(startDate)) / 86400000);
+      if (dayNum >= 5 && dayNum <= 10) {
+        mixedEntries.set(d.date, {
+          date: d.date,
+          calories: 5000,
+          protein: 150,
+          carbs: 200,
+          fat: 60,
+          fiber: 25,
+          sodium: 2200,
+          trainingBump: 0,
+          exerciseSessions: [],
+          entryType: 'estimate',
+        });
+      } else {
+        mixedEntries.set(d.date, {
+          date: d.date,
+          calories: d.calories,
+          protein: 150,
+          carbs: 200,
+          fat: 60,
+          fiber: 25,
+          sodium: 2200,
+          trainingBump: 0,
+          exerciseSessions: [],
+        });
+      }
+    }
+
+    const mixedRows = runAnalysis(weightEntries, mixedEntries).rows;
+    const mixedTdeeBlocks = mixedRows.filter(r => r.tdee_block != null);
+
+    // TDEE blocks that don't overlap with estimate days should be identical
+    // Blocks that do overlap will differ because estimate days are excluded
+    // from calorie averaging — the key guarantee is that the 5000-cal estimates
+    // do NOT inflate the TDEE values
+    for (const mixed of mixedTdeeBlocks) {
+      if (mixed.tdee_block != null) {
+        // With estimate days excluded, TDEE should not be artificially inflated
+        // by the 5000-cal fake estimates
+        expect(mixed.tdee_block).toBeLessThan(4000);
+      }
+    }
+  });
+
+  it('mergeDailyData sets isEstimate flag for estimate entries', () => {
+    const startDate = '2024-01-01';
+    const weightEntries = makeWeightEntries([
+      { date: startDate, weightLb: 185 },
+      { date: isoDate(startDate, 1), weightLb: 184.9 },
+    ]);
+    const dailyEntries = new Map();
+    dailyEntries.set(startDate, {
+      date: startDate,
+      calories: 2000,
+      protein: 150,
+      carbs: 200,
+      fat: 60,
+    });
+    dailyEntries.set(isoDate(startDate, 1), {
+      date: isoDate(startDate, 1),
+      calories: 1800,
+      protein: 120,
+      carbs: 200,
+      fat: 50,
+      entryType: 'estimate',
+    });
+
+    const rows = mergeDailyData(weightEntries, dailyEntries);
+    const realRow = rows.find(r => r.date === startDate);
+    const estRow = rows.find(r => r.date === isoDate(startDate, 1));
+
+    expect(realRow.isEstimate).toBe(false);
+    expect(estRow.isEstimate).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **#55 Larger-gap imputation with min-data-on-each-side rigor** — Added `minPreWeights` to the INTERVALS config (3/4/5 for 14d/28d/42d windows) so wider gaps impute only when **both** sides of the candidate are well-supported by weight readings. Removed the `inside_interval` TDEE-reference fallback — the correction pipeline now requires outside-interval blocks, observed TDEE, or formula TDEE; circular evidence from inside the candidate's own window can no longer silently drive corrections. Surfaced `preWeightPoints` in interval data alongside existing `futureWeightPoints`.

- **#56 Vacation days eligible for later weight-based correction** — Estimate/vacation entries (entryType='estimate') are now eligible as true-up candidates with type `'estimate'` instead of being skipped. Added `isEstimate` flag in `mergeDailyData` rows; `estimateTDEE` excludes these from calorie averaging so low-confidence priors cannot train the model they are later corrected against. Estimate candidates use `checkedByDefault=false` (user must opt in), show a refinement-specific reason string, and treat their synthetic calories as 0 for interval energy balance. Locked estimates (`manualLock` / `estimateMeta.locked`) remain excluded.

Also reconciles #52 and #53 to completed (merged to main via PR #138).

## Checks

- `cd public/tools/CalorieTracker && npm test` — 584 tests, 9 files, all passing (9 new tests)

## Files changed

- `public/tools/CalorieTracker/analysis/engine.js` — `mergeDailyData` isEstimate flag, `estimateTDEE` estimate exclusion, `getTrueUpCandidates` minPreWeights + estimate candidate support + inside_interval removal
- `public/tools/CalorieTracker/analysis/engine.test.js` — 9 new tests for pre-weight rigor, inside_interval removal, estimate candidates, no-circularity guarantee, isEstimate flag
- `backlogs/calorie-tracker.md` — reconciled #52/#53, marked #55/#56 as `[p]` with commit SHAs
- `backlogs/calorie-tracker-completed.md` — archived #52 and #53 as completed

## Backlog reference

See `backlogs/calorie-tracker.md` for protocol and active items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs3FpAxQWEKFwkSdpnD4hm)_