### PR TITLE
CalorieTracker: mobile viewport pass, large-import performance (#57, #58)

### DIFF
--- a/backlogs/calorie-tracker-completed.md
+++ b/backlogs/calorie-tracker-completed.md
@@ -212,6 +212,12 @@ For the active backlog (new items, protocol, invariants), see `backlogs/calorie-
 - [x] **#54 — Collapse long-form explanations**
   > Resolved: eating pattern notes, energy detail, TDEE horizons, PAL table, vacation/imputation explanations, info boxes all wrapped in collapsible details elements; merged via PR #137 (ffe15a9)
 
+- [x] **#55 — Larger-gap imputation with min-data-on-each-side rigor**
+  > Resolved: minPreWeights in INTERVALS config, pre-candidate weight check uses weight_corr, inside_interval TDEE fallback removed, preWeightPoints surfaced; codex review fixes for actual weight readings, estimate re-eligibility, non-candidate estimate intake, vacation metadata preservation; merged e3eed75, fix 11a2a37
+
+- [x] **#56 — Vacation days eligible for later weight-based correction**
+  > Resolved: estimate entries eligible as 'estimate' type candidates with checkedByDefault=false, isEstimate flag in mergeDailyData excludes estimates from TDEE blocks, locked estimates excluded; codex review fixes for true-up-produced estimate skip, all-estimate intake exclusion; merged e3eed75, fix 11a2a37
+
 ---
 
 ## What was already verified as correct (do not regress)

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -159,33 +159,15 @@ _(#47–#50 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 ### MEDIUM
 
 _(#51 completed — moved to `backlogs/calorie-tracker-completed.md`)_
-_(#52–#54 completed — moved to `backlogs/calorie-tracker-completed.md`)_
-- [p] **#55 Larger-gap imputation with min-data-on-each-side rigor** — *[larger refactor]*
-  `getTrueUpCandidates` (`analysis/engine.js:1644`) already uses centered windows
-  `[-7,+6]/[-14,+13]/[-21,+20]` with ≥50% coverage + minimum future weights. Parameterize and
-  document the minimum pre/post day counts and weight-point counts so wider gaps impute only
-  when **both** sides are well-supported, and surface the chosen interval + confidence drivers.
-  Preserve centered windows. Strengthen the TDEE-reference invariant by requiring outside-
-  interval blocks for correction by default; remove or explicitly gate the current
-  `inside_interval` fallback for sparse histories so circular evidence cannot silently drive
-  wider-gap corrections. Add tests. Files: `analysis/engine.js`, `analysis/engine.test.js`.
-  > pushed — minPreWeights added to INTERVALS config, pre-candidate weight check enforced, inside_interval TDEE fallback removed, preWeightPoints surfaced in interval data; tests: 584 pass; commit: e3eed75
-- [p] **#56 Vacation days eligible for later weight-based correction** — *[larger refactor]*
-  The one genuine model change: treat vacation/low-log quick-estimates (#49) as
-  low-confidence priors that the centered-window true-up may later refine (respecting
-  `manualLock` / `estimateMeta.locked`). Add the no-circularity exclusion in the TDEE/block
-  pipeline itself: saved estimate/vacation days (for example entries with estimate/vacation
-  metadata or synthetic estimate items) must be excluded from `estimateTDEE` regression blocks
-  even if they have top-level `calories`, so low-confidence priors cannot train the model they
-  are later corrected against. Add tests for the no-circularity guarantee. Files:
-  `analysis/engine.js`, `analysis/engine.test.js`.
-  > pushed — estimate entries eligible as 'estimate' type candidates, isEstimate flag in mergeDailyData excludes estimates from TDEE blocks, checkedByDefault=false for estimates; tests: 584 pass; commit: e3eed75
+_(#52–#56 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 
 ### LOW / NICE-TO-HAVE
 
-- [ ] **#57 Mobile narrow-viewport pass** — *[quick win]* Validate the 6-tab bar scroll
+- [p] **#57 Mobile narrow-viewport pass** — *[quick win]* Validate the 6-tab bar scroll
   affordance, macro-bar wrapping, expandable target rows, and the date-range control at
   ~390px (no horizontal scroll, usable touch targets). Files: `styles.css`, `index.html`.
-- [ ] **#58 Large-import performance check** — *[quick win]* Verify chart slicing and render
+  > pushed — ≤390px breakpoint with tighter padding, compact tabs/macro bar, viewport-constrained target breakdown, date-range custom row wrapping, settings button wrapping; tests: 584 pass; commit: pending
+- [p] **#58 Large-import performance check** — *[quick win]* Verify chart slicing and render
   budget with multi-year weight/log imports; cap series length / decimate if needed. Files:
   `ui/chart.js`, `analysis/analysisUI.js`.
+  > pushed — O(n²) indexOf replaced with Map lookup in chart averages, rolling avg loops avoid slice allocations, data table capped at 60 columns, weight chart point radius reduced for >365 days, x-axis maxTicksLimit added; tests: 584 pass; commit: pending

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -166,8 +166,8 @@ _(#52–#56 completed — moved to `backlogs/calorie-tracker-completed.md`)_
 - [p] **#57 Mobile narrow-viewport pass** — *[quick win]* Validate the 6-tab bar scroll
   affordance, macro-bar wrapping, expandable target rows, and the date-range control at
   ~390px (no horizontal scroll, usable touch targets). Files: `styles.css`, `index.html`.
-  > pushed — ≤390px breakpoint with tighter padding, compact tabs/macro bar, viewport-constrained target breakdown, date-range custom row wrapping, settings button wrapping; tests: 584 pass; commit: pending
+  > pushed — ≤390px breakpoint with tighter padding, compact tabs/macro bar, viewport-constrained target breakdown, date-range custom row wrapping, settings button wrapping; tests: 584 pass; commit: 649bf26
 - [p] **#58 Large-import performance check** — *[quick win]* Verify chart slicing and render
   budget with multi-year weight/log imports; cap series length / decimate if needed. Files:
   `ui/chart.js`, `analysis/analysisUI.js`.
-  > pushed — O(n²) indexOf replaced with Map lookup in chart averages, rolling avg loops avoid slice allocations, data table capped at 60 columns, weight chart point radius reduced for >365 days, x-axis maxTicksLimit added; tests: 584 pass; commit: pending
+  > pushed — O(n²) indexOf replaced with Map lookup in chart averages, rolling avg loops avoid slice allocations, data table capped at 60 columns, weight chart point radius reduced for >365 days, x-axis maxTicksLimit added; tests: 584 pass; commit: 649bf26

--- a/public/tools/CalorieTracker/analysis/analysisUI.js
+++ b/public/tools/CalorieTracker/analysis/analysisUI.js
@@ -814,13 +814,12 @@ function drawCorrectionsChart(rows) {
   const WINDOW = 7;
   const fullRolling = new Map();
   for (let i = 0; i < rows.length; i++) {
-    const slice = rows.slice(Math.max(0, i - WINDOW + 1), i + 1);
-    const calVals = slice
-      .map(r => _getRecordedCalories(r.date))
-      .filter(v => v != null);
-    fullRolling.set(rows[i].date, calVals.length >= 3
-      ? Math.round(calVals.reduce((a, b) => a + b, 0) / calVals.length)
-      : null);
+    let sum = 0, count = 0;
+    for (let j = Math.max(0, i - WINDOW + 1); j <= i; j++) {
+      const v = _getRecordedCalories(rows[j].date);
+      if (v != null) { sum += v; count++; }
+    }
+    fullRolling.set(rows[i].date, count >= 3 ? Math.round(sum / count) : null);
   }
 
   const labels    = [];
@@ -1070,14 +1069,13 @@ function drawEatingPatternChart(rows) {
   const fullRolling = new Map();
   for (let i = 0; i < rows.length; i++) {
     if (!firstNutritionDate || rows[i].date < firstNutritionDate) continue;
-    const slice = rows.slice(Math.max(0, i - WINDOW + 1), i + 1);
-    const calVals = slice
-      .filter(r => firstNutritionDate && r.date >= firstNutritionDate)
-      .map(r => _realCaloriesForDate(r.date, includeEstimates))
-      .filter(v => v != null);
-    fullRolling.set(rows[i].date, calVals.length >= 3
-      ? Math.round(calVals.reduce((a, b) => a + b, 0) / calVals.length)
-      : null);
+    let sum = 0, count = 0;
+    for (let j = Math.max(0, i - WINDOW + 1); j <= i; j++) {
+      if (firstNutritionDate && rows[j].date < firstNutritionDate) continue;
+      const v = _realCaloriesForDate(rows[j].date, includeEstimates);
+      if (v != null) { sum += v; count++; }
+    }
+    fullRolling.set(rows[i].date, count >= 3 ? Math.round(sum / count) : null);
   }
 
   const labels        = [];
@@ -1908,6 +1906,10 @@ function drawWeightChart(rows) {
   const smoothColor = chartColors[1] || '#f59e0b';
   const css = getComputedStyle(document.documentElement);
 
+  const largeDataset = labels.length > 365;
+  const rawPointRadius = largeDataset ? 0 : 1.5;
+  const rawHoverRadius = largeDataset ? 2 : 4;
+
   weightChartInstance = new Chart(canvas.getContext('2d'), {
     type: 'line',
     data: {
@@ -1919,8 +1921,8 @@ function drawWeightChart(rows) {
           borderColor: rawColor + '80',
           backgroundColor: rawColor + '20',
           borderWidth: 1,
-          pointRadius: 1.5,
-          pointHoverRadius: 4,
+          pointRadius: rawPointRadius,
+          pointHoverRadius: rawHoverRadius,
           fill: false,
           spanGaps: true,
           tension: 0,

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -1262,6 +1262,55 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
   /* Food item qty input: full width below the macros line */
   .food-item-bottom  { flex-direction: column; align-items: stretch; }
   .food-item-qty     { width: 100%; }
+
+  /* Date-range custom row: wrap From/To on narrow screens */
+  .date-range-custom { flex-wrap: wrap; }
+
+  /* Settings actions: ensure buttons wrap cleanly */
+  .settings-panel .flex.justify-between { flex-wrap: wrap; gap: .5rem; }
+}
+
+/* ============================================================
+   NARROW MOBILE  (≤ 390 px) — iPhone SE / compact Android
+   ============================================================ */
+@media (max-width: 390px) {
+  .app-header        { padding: .375rem .5rem; }
+  .today-layout      { padding: .5rem; gap: .75rem; }
+  .today-inputs      { padding: .75rem .5rem; }
+  .section-card      { padding: .75rem .5rem; }
+  .tab-content-inner { padding: .75rem .5rem; }
+  .settings-panel    { padding: .75rem .5rem; }
+  .settings-section  { padding: .75rem .5rem; }
+
+  /* Tab bar: minimum padding for 6 tabs */
+  .tab-btn { padding: .5rem .5rem; font-size: .75rem; }
+
+  /* Macro summary: more compact */
+  .macro-summary-bar { padding: .25rem .5rem; }
+  .macro-cal-remaining { font-size: 1rem; }
+  .macro-cell-label { font-size: .5rem; }
+  .macro-cell-value { font-size: .6875rem; }
+
+  /* Today hero */
+  .today-hero { padding: .75rem; }
+  .today-hero-number { font-size: 1.75rem; }
+  .today-hero-stat-val { font-size: 1rem; }
+
+  /* Target breakdown: constrain to viewport */
+  .target-breakdown-panel { min-width: 0; width: calc(100vw - 2rem); right: -.5rem; }
+
+  /* Vacation quick presets: tighter */
+  .vacation-quick-btn { padding: .375rem .125rem; font-size: .6875rem; }
+
+  /* Date-range chips: smaller touch targets still usable (36px) */
+  .date-range-chip { padding: .15rem .375rem; font-size: .625rem; }
+  .date-range-custom input[type="date"] { font-size: .6875rem; padding: .15rem .25rem; }
+
+  /* Modal padding tighter */
+  .modal-content { padding: .75rem !important; }
+
+  /* Food search row: tighter inline qty */
+  #food-inline-qty { width: 2.75rem; }
 }
 
 /* ── Undo toast ────────────────────────────────────────────── */

--- a/public/tools/CalorieTracker/styles.css
+++ b/public/tools/CalorieTracker/styles.css
@@ -1302,8 +1302,8 @@ details.collapsible > summary:hover { color: hsl(var(--text)); }
   /* Vacation quick presets: tighter */
   .vacation-quick-btn { padding: .375rem .125rem; font-size: .6875rem; }
 
-  /* Date-range chips: smaller touch targets still usable (36px) */
-  .date-range-chip { padding: .15rem .375rem; font-size: .625rem; }
+  /* Date-range chips: compact text but 32px min touch target */
+  .date-range-chip { padding: .15rem .375rem; font-size: .625rem; min-height: 32px; display: inline-flex; align-items: center; }
   .date-range-custom input[type="date"] { font-size: .6875rem; padding: .15rem .25rem; }
 
   /* Modal padding tighter */

--- a/public/tools/CalorieTracker/ui/chart.js
+++ b/public/tools/CalorieTracker/ui/chart.js
@@ -213,8 +213,11 @@ function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = fals
     const datasets = [];
     const tableData = {};
 
+    const allLabelIndex = new Map();
     for (let i = totalDaysNeeded - 1; i >= 0; i--) {
-      allLabels.push(formatDate(getPastDate(endDate, i)));
+      const d = formatDate(getPastDate(endDate, i));
+      allLabelIndex.set(d, allLabels.length);
+      allLabels.push(d);
     }
     for (let i = days - 1; i >= 0; i--) {
       const dateStr = formatDate(getPastDate(endDate, i));
@@ -298,9 +301,9 @@ function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = fals
       if (show3Day) {
         const avg3Data = [];
         const avg3Values = [];
-        
+
         displayLabels.forEach((dateStr, displayIdx) => {
-          const allIdx = allLabels.indexOf(dateStr);
+          const allIdx = allLabelIndex.get(dateStr) ?? -1;
           if (allIdx < 2) {
             avg3Data.push(null);
             avg3Values.push(null);
@@ -344,9 +347,9 @@ function getChartData(nutrientKeys, timeframe, show3Day = false, show7Day = fals
       if (show7Day) {
         const avg7Data = [];
         const avg7Values = [];
-        
+
         displayLabels.forEach((dateStr, displayIdx) => {
-          const allIdx = allLabels.indexOf(dateStr);
+          const allIdx = allLabelIndex.get(dateStr) ?? -1;
           if (allIdx < 6) {
             avg7Data.push(null);
             avg7Values.push(null);
@@ -503,9 +506,9 @@ export function updateChart() {
               color: 'rgba(0,0,0,0.1)'
             }
           },
-          x: { 
-            title: { 
-              display: true, 
+          x: {
+            title: {
+              display: true,
               text: 'Date',
               font: { weight: 'bold' }
             },
@@ -513,6 +516,7 @@ export function updateChart() {
               display: false
             },
             ticks: {
+              maxTicksLimit: 14,
               callback: function(value, index, values) {
                 const date = new Date(`${this.getLabelForValue(value)}T00:00:00`);
                 return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
@@ -619,7 +623,7 @@ export function updateChart() {
 
     debugLog('update-chart-success', 'Chart updated successfully');
 
-    updateChartTable(tableData, selectedNutrients, labels);
+    updateChartTable(tableData, selectedNutrients, labels, days);
 
   } catch (error) {
     handleChartError('update-chart', error);
@@ -630,13 +634,16 @@ export function updateChart() {
 // TABLE UPDATE FUNCTION
 // =========================
 
+const TABLE_MAX_COLUMNS = 60;
+
 /**
  * Update the data table below the chart
  * @param {Object} tableData - Data for the table
  * @param {string[]} nutrientKeys - Selected nutrients
  * @param {string[]} labels - Date labels
+ * @param {number} [totalDays] - Total days in range (for truncation message)
  */
-function updateChartTable(tableData, nutrientKeys, labels) {
+function updateChartTable(tableData, nutrientKeys, labels, totalDays) {
   try {
     const tableContainer = document.getElementById('chart-table');
     if (!tableContainer) {
@@ -649,14 +656,21 @@ function updateChartTable(tableData, nutrientKeys, labels) {
       return;
     }
 
-    let html = `
+    const truncated = labels.length > TABLE_MAX_COLUMNS;
+    const visibleLabels = truncated ? labels.slice(-TABLE_MAX_COLUMNS) : labels;
+
+    let html = truncated
+      ? `<p class="text-muted text-xs mb-2">Showing most recent ${TABLE_MAX_COLUMNS} of ${labels.length} days. Use a shorter date range for full detail.</p>`
+      : '';
+
+    html += `
       <div class="overflow-x-auto surface-1 rounded-lg border">
         <table class="min-w-full">
           <thead class="surface-2">
             <tr>
               <th class="px-4 py-3 text-left text-sm font-semibold text-secondary">Nutrient</th>`;
     
-    labels.forEach(dateStr => {
+    visibleLabels.forEach(dateStr => {
       const date = new Date(`${dateStr}T00:00:00`);
       const shortDate = date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
       html += `<th class="px-3 py-3 text-center text-sm font-semibold text-secondary">${shortDate}</th>`;
@@ -667,8 +681,8 @@ function updateChartTable(tableData, nutrientKeys, labels) {
     nutrientKeys.forEach(nutrient => {
       html += `<tr class="hover-surface-2">
         <td class="px-4 py-3 text-sm font-medium text-primary">${formatNutrientName(nutrient)}</td>`;
-      
-      labels.forEach(dateStr => {
+
+      visibleLabels.forEach(dateStr => {
         const data = tableData[dateStr][nutrient];
         if (data) {
           const colorClass = data.percentage >= 90 && data.percentage <= 110 ? 'text-positive' :


### PR DESCRIPTION
## Summary

- **#57 Mobile narrow-viewport pass** — Added `≤390px` breakpoint targeting iPhone SE / compact Android devices: tighter padding on header, today layout, inputs, section cards, settings panels; compact tab bar (`.75rem` font, `.5rem` padding); smaller macro summary bar; viewport-constrained target breakdown panel (`width: calc(100vw - 2rem)`); date-range custom row flex-wrap at `≤480px`; settings action button wrapping. Existing `≤480px` and `≤640px` rules preserved and extended.

- **#58 Large-import performance check** — Replaced O(n²) `allLabels.indexOf()` in nutrient chart 3-day/7-day moving average loops with O(1) `Map` lookup. Eliminated `Array.slice()` allocations in corrections chart and eating pattern chart rolling averages (index-based loop instead). Capped data table at 60 columns with truncation message for multi-year ranges. Reduced weight chart `pointRadius` to 0 for >365 data points. Added `maxTicksLimit: 14` to nutrient chart x-axis.

Also reconciles #55 and #56 to completed (merged to main via PR #139).

## Checks

- `cd public/tools/CalorieTracker && npm test` — 584 tests, 9 files, all passing

## Files changed

- `public/tools/CalorieTracker/styles.css` — ≤390px breakpoint, date-range custom wrap, settings button wrap
- `public/tools/CalorieTracker/ui/chart.js` — Map-based label index, table column cap, x-axis maxTicksLimit
- `public/tools/CalorieTracker/analysis/analysisUI.js` — rolling avg loop optimization, weight chart point radius reduction
- `backlogs/calorie-tracker.md` — reconciled #55/#56, marked #57/#58 as `[p]` with commit SHAs
- `backlogs/calorie-tracker-completed.md` — archived #55 and #56 as completed

## Backlog reference

See `backlogs/calorie-tracker.md` for protocol and active items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPYQ1R5yfhZV3R68dFZ5Yd)_