### PR TITLE
docs(backlog): add Recipe Standardizer nutrition-rollout backlog and shared session protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,11 @@ Canonical instruction entry point for Claude Code, Codex, and other coding agent
 1. Read `AGENTS.md` first.
 2. Read `ARCHITECTURE.md` only when changing structure, routing, data flow, major state management, shared UI patterns, or tool architecture.
 3. Read `SECURITY.md` only when changing auth, Firestore, Storage, secrets, PII, external scripts, data retention, model/API routes, or other sensitive data surfaces.
-4. Read root `BACKLOG.md` when the user asks about backlog work.
-5. Read `backlogs/calorie-tracker.md` only when the user asks to work on the CalorieTracker backlog or a CalorieTracker issue. Completed items are archived in `backlogs/calorie-tracker-completed.md`; read that only when reviewing past work.
+4. Read root `BACKLOG.md` when the user asks about backlog work — it lists active
+   backlogs and the dispatch rule for picking one.
+5. When working a backlog, read `backlogs/protocol.md` (shared session protocol) plus
+   the chosen backlog file only. Completed-item archives (`backlogs/*-completed.md`)
+   are read only when reviewing past work.
 6. Read tool-specific files only when editing that tool.
 
 ## Repo map
@@ -31,7 +34,7 @@ Canonical instruction entry point for Claude Code, Codex, and other coding agent
 - Moving functionality between `/public` and `/app`.
 - Large cross-cutting refactors of routing, styling tokens, or component structure.
 - Introducing server-side secrets or privileged operations.
-- Modifying CalorieTracker backlog item numbers, statuses, or commit references outside the backlog protocol.
+- Modifying backlog item ids, statuses, or commit references outside the backlog protocol (`backlogs/protocol.md`).
 
 ## Implementation rules
 
@@ -54,6 +57,7 @@ Use the smallest test scope that gives meaningful confidence for the files chang
 - Single pure logic module: run the nearest focused unit test first when useful, then the relevant package or tool test suite if behavior changed.
 - CalorieTracker logic, validation, parser, target, analysis, state, or UI behavior changes: run `cd public/tools/CalorieTracker && npm test`.
 - CalorieTracker docs, backlog, or pointer-file changes only: do not run CalorieTracker tests unless code, package config, or test files changed.
+- Recipe Standardizer lib/schema/logic changes: run `npm test` from the repo root (vitest); component or page changes also need `npm run lint` and `npm run build`.
 - React component or page changes: run `npm run lint` and `npm run build`.
 - Shared app config, routing, package scripts, TypeScript config, ESLint config, or dependency changes: run `npm run lint`, `npm run build`, and `npm test`.
 - Security rules, auth, or data model changes: run relevant tests if available, validate affected docs, and clearly note any rules that require manual Firebase validation.
@@ -78,13 +82,17 @@ Any fundamental change must update affected docs in the same PR:
 - `ARCHITECTURE.md` — structure, routing, data flow, and major tool architecture.
 - `SECURITY.md` — auth, Firestore, Storage, secrets, PII, external scripts, data retention, and sensitive data surfaces.
 - `AGENTS.md` — agent workflow, test expectations, and repo conventions.
-- `BACKLOG.md` — backlog index only.
-- `backlogs/calorie-tracker.md` — CalorieTracker backlog protocol and active items.
-- `backlogs/calorie-tracker-completed.md` — archive of completed CalorieTracker items.
+- `BACKLOG.md` — backlog index and dispatch rule only.
+- `backlogs/protocol.md` — shared backlog session protocol (status legend, reconcile, commit/PR format).
+- `backlogs/<name>.md` — per-backlog parameters, invariants, and active items.
+- `backlogs/<name>-completed.md` — per-backlog archive of completed items.
 
 ## Backlog workflow
 
-Active backlogs are indexed in root `BACKLOG.md`. When the user asks to start, continue, pick up, or work on the CalorieTracker backlog, read `backlogs/calorie-tracker.md` and follow its protocol exactly.
+Active backlogs are indexed in root `BACKLOG.md`, which also defines the dispatch rule
+for choosing a backlog when the user says "continue working on the backlog" (or similar)
+without naming one. Once chosen, read `backlogs/protocol.md` plus the backlog file and
+follow the protocol exactly.
 
 ## Security
 
@@ -93,7 +101,7 @@ Firestore Security Rules live in `firestore.rules` at the repo root. See `SECURI
 ## Commit and PR rules
 
 - Use Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`.
-- Use scopes when helpful: `docs(agents):`, `docs(backlog):`, `fix(calorie-tracker):`.
+- Use scopes when helpful: `docs(agents):`, `docs(backlog):`, `fix(calorie-tracker):`, `feat(recipe-standardizer):`.
 - Keep commits focused.
 - PR body should include summary, checks run, docs changed, and known follow-ups.
-- For CalorieTracker backlog work, follow `backlogs/calorie-tracker.md` exactly.
+- For backlog work, follow `backlogs/protocol.md` exactly.

--- a/AI_AGENTS.md
+++ b/AI_AGENTS.md
@@ -8,4 +8,4 @@ Additional context:
 - `ARCHITECTURE.md` for structure, routing, data flow, and shared UI patterns.
 - `SECURITY.md` for auth, Firestore, Storage, secrets, PII, external scripts, and sensitive data surfaces.
 - `BACKLOG.md` for the backlog index and active work queues.
-- `backlogs/calorie-tracker.md` for the CalorieTracker backlog protocol and item statuses.
+- `BACKLOG.md` for the backlog index and dispatch rule; `backlogs/protocol.md` for the shared backlog session protocol.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,8 +7,9 @@ backlog file supplies its own Parameters block (branch, scope, ids, tests).
 ## Active backlogs (priority order)
 
 1. `backlogs/recipe-standardizer.md` — Recipe Standardizer → Nutrition Tracker rollout
-   (items `R1`–`R6`: schema v2 nutrition data, ingredient/recipe export to the tracker,
-   recipe nutrition computation, link review, real-recipe QA gate).
+   (phase items `P0`–`P7`: rules deploy/smoke test, link management + grams basis,
+   ChatGPT paste-back nutrition intake, recipe nutrition computation, export to
+   tracker, docs/hardening; P6/P7 optional).
 2. `backlogs/calorie-tracker.md` — CalorieTracker (items `#N`; protocol, invariants,
    and any active items).
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,15 +1,32 @@
 # Backlog Index
 
-This file points to active and completed backlogs.
+Backlogs live under `backlogs/`. The shared session protocol — resume steps, reconcile,
+status legend, commit/PR format, branch strategy — is `backlogs/protocol.md`; each
+backlog file supplies its own Parameters block (branch, scope, ids, tests).
 
-## Active backlogs
+## Active backlogs (priority order)
 
-- `backlogs/calorie-tracker.md`: CalorieTracker backlog — protocol, invariants, branch/PR workflow, test requirements, and any active items.
+1. `backlogs/recipe-standardizer.md` — Recipe Standardizer → Nutrition Tracker rollout
+   (items `R1`–`R6`: schema v2 nutrition data, ingredient/recipe export to the tracker,
+   recipe nutrition computation, link review, real-recipe QA gate).
+2. `backlogs/calorie-tracker.md` — CalorieTracker (items `#N`; protocol, invariants,
+   and any active items).
 
-## Completed backlogs
+## Completed archives
 
-- `backlogs/calorie-tracker-completed.md`: Archive of all 46 completed CalorieTracker items with resolution summaries and merge SHAs.
+- `backlogs/recipe-standardizer-completed.md`
+- `backlogs/calorie-tracker-completed.md` — all 46 original CalorieTracker items plus
+  later batches, with resolution summaries and merge SHAs.
 
-## Agent instructions
+## Agent dispatch
 
-When the user asks to start, continue, pick up, or work on the CalorieTracker backlog, read `backlogs/calorie-tracker.md` and follow its protocol exactly.
+When the user asks to start, continue, pick up, or work on a backlog (exact wording not
+required — "continue working on backlog" and close paraphrases count):
+
+1. If they named a backlog (or the work clearly belongs to one tool), use that backlog.
+2. Otherwise: run the reconcile step (`backlogs/protocol.md` step 4) on **every** active
+   backlog, then work the first backlog in the priority list above that has actionable
+   items — a `[p]` item needing follow-up, or an unblocked `[ ]` item whose `Depends:`
+   are met. Items marked `[p] pushed` and merely awaiting merge are not actionable.
+3. Read `backlogs/protocol.md` plus the chosen backlog file end-to-end, then follow the
+   protocol exactly. Do not read the other backlogs or archives unless needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,5 +7,5 @@ Read `AGENTS.md` first.
 Additional context:
 - `ARCHITECTURE.md` for structure, routing, data flow, and shared UI patterns.
 - `SECURITY.md` for auth, Firestore, Storage, secrets, PII, external scripts, and sensitive data surfaces.
-- `BACKLOG.md` for the backlog index and active/completed work queues.
-- `backlogs/calorie-tracker.md` for the CalorieTracker backlog protocol and active items.
+- `BACKLOG.md` for the backlog index, dispatch rule, and active/completed work queues.
+- `backlogs/protocol.md` for the shared backlog session protocol; per-backlog files under `backlogs/` hold parameters, invariants, and items.

--- a/backlogs/calorie-tracker.md
+++ b/backlogs/calorie-tracker.md
@@ -5,6 +5,23 @@ Single source of truth for ongoing work on `public/tools/CalorieTracker/`.
 All items from the original 46-point review punch list have been completed and merged.
 See `backlogs/calorie-tracker-completed.md` for the full archive with resolution details.
 
+## Parameters (for `backlogs/protocol.md`)
+
+- **Working branch:** `working/calorie-tracker-backlog`
+- **Commit scope:** `calorie-tracker`; item ids `#N` (next new id: **#59**; never reuse ids)
+- **Archive:** `backlogs/calorie-tracker-completed.md`
+- **Tests:** for CalorieTracker code changes run `cd public/tools/CalorieTracker && npm test`
+  (584 tests as of the last pushed batch; the full suite must pass). Logic, validation,
+  state, parser, target, analysis, or UI behavior changes must keep the suite green;
+  pure docs/backlog/pointer changes need no suite run. If only one pure module changed,
+  run the nearest focused test first when useful, then the full suite before marking an
+  item pushed. Add or update tests for new validators, pure functions, regression
+  fixes, or behavior that could silently break calculations.
+
+## Session protocol
+
+Follow `backlogs/protocol.md` with the parameters above.
+
 ## CalorieTracker invariants
 
 Preserve these unless the user explicitly asks to change them:
@@ -15,126 +32,6 @@ Preserve these unless the user explicitly asks to change them:
 - `buildBlankDayEstimateEntry` spreads historical micronutrient averages onto both the entry and its synthetic food item, falling back to baseline targets.
 - `computeProteinTarget` auto basis priority is lean mass, then target weight, then current weight.
 - `getBlankDaysForPopulation` and `getPartialDaysForAdjustment` are legacy compatibility paths unless a live caller is reintroduced.
-
-## Resuming work across sessions
-
-Start (or resume) a session with any of these — exact wording is **not** required:
-**"start working on the backlog"**, **"continue working on the CalorieTracker backlog"**,
-**"work on the calorie tracker backlog"**, **"pick up the backlog"**, or a close paraphrase.
-
-When invoked that way, follow this protocol automatically, without needing further instruction:
-
-1. `git fetch origin`.
-2. Switch to the stable working branch: `git switch working/calorie-tracker-backlog`. If it
-   doesn't exist locally or on origin, create it from `origin/main`:
-   `git switch -c working/calorie-tracker-backlog origin/main`. In web/remote sessions the harness
-   may pin you to an auto-generated `claude/<adjective>-<noun>-<id>` branch you cannot switch off —
-   that is fine to work on; completion is detected from commits merged to `main`, not the branch
-   name.
-3. `git pull --ff-only origin working/calorie-tracker-backlog` (skip if just created).
-4. **Reconcile completed items (auto-mark `[x]`).** `git fetch origin main`. For every `[p]` item
-   whose note records a commit SHA, test whether it has merged to main:
-   `git merge-base --is-ancestor <sha> origin/main` (exit 0 = merged). Cross-check the backlog PR
-   via the GitHub MCP (`mcp__github__pull_request_read`). For each `[p]` item whose commit is on
-   `origin/main`, flip it to `[x]` and rewrite its note to `> Resolved: <summary>; merged <sha>`.
-   Move newly completed items to `backlogs/calorie-tracker-completed.md` in the appropriate
-   priority section. Leave pushed-but-unmerged items `[p]` here. **This is the only way items
-   reach `[x]`** — hands-off, but never before the user has actually merged the PR.
-5. Read this file end-to-end. Identify (a) any `[p]` items needing follow-up from review or a
-   prior session, then (b) the highest-priority `[ ]` items, in section order
-   (CRITICAL → HIGH → MEDIUM → LOW).
-6. Pick the next reasonable batch — usually one to three related items.
-7. Implement. Mark each touched item `[p]` with a one-line note (see status legend below).
-8. Run tests according to the Test command section below. CalorieTracker code changes must keep the relevant suite green.
-9. Commit with a **descriptive** Conventional-Commit message. Format:
-   `type(calorie-tracker): #N short description of the change`
-   The message must include: (a) the Conventional Commit type (`feat`, `fix`, `refactor`, etc.),
-   (b) the `(calorie-tracker)` scope so it's clear which part of the site changed, (c) the
-   backlog item number(s) (`#N`), and (d) a plain-English summary of what the commit does — not
-   just the item title.
-   Examples:
-   - `feat(calorie-tracker): #47 add weekly meal-prep summary view`
-   - `fix(calorie-tracker): #48 correct rounding in macro percentage display`
-   One commit per logical change. Multi-item commits list all numbers: `#47 #48 ...`.
-10. Push: `git push -u origin working/calorie-tracker-backlog` (or the pinned `claude/*` branch in
-    a web session).
-11. **Record the commit SHA** on every item you pushed (`commit: <short-sha>` in its `[p]` note,
-    plus the PR number when known). The next session's reconcile step keys off this SHA — an item
-    with no recorded SHA can never be auto-completed.
-12. **PR title and body must be descriptive.** If no open PR exists for the branch, create one
-    via the GitHub MCP tools. Format:
-    - **Title:** `CalorieTracker: <short summary of batch> (#N, #N, …)`
-      Example: `CalorieTracker: weekly meal-prep view, macro rounding fix (#47, #48)`
-    - **Body:** list every item addressed with its number and one-line summary, plus a pointer to
-      this file. Update the body on subsequent pushes when new items are added to the batch.
-    All subsequent pushes auto-update the same PR.
-
-## Status legend
-
-| Mark | Meaning |
-|------|---------|
-| `[ ]` | Not started. |
-| `[p]` | In progress / pushed / awaiting merge / blocked / needs follow-up. **Default state once code has been touched.** Records a `commit: <short-sha>` once pushed. |
-| `[x]` | Complete — the item's commit has merged to `main` (the user accepted the PR). Set automatically by the reconcile step (step 4); never set for merely-pushed code. Completed items are moved to `backlogs/calorie-tracker-completed.md`. |
-
-The note line under a `[p]` item begins with one of these sub-labels so the state is scannable:
-
-- `> pushed — <one-line summary>; tests: <pass/notes>; commit: <short-sha>` (awaiting merge)
-- `> in progress — <what's left>`
-- `> blocked — <reason>`
-- `> needs follow-up — <what the reviewer said>; commit: <short-sha>`
-
-When the item's commit merges to `main`, the next session's reconcile step moves it to the
-completed log with a single line:
-
-- `> Resolved: <one-line summary>; merged <short-sha>`
-
-## Editing rules
-
-- **Mark `[p]` when you push; let the reconcile step (step 4) flip `[p]`→`[x]` and move to the
-  completed log once the commit is merged to `main`.** Never mark `[x]` for code that is only
-  pushed, and never flip it manually mid-session — merge to `main` is the single signal that an
-  item is done.
-- Keep notes to **one line** per item. No pasted diffs, no multi-paragraph rationale — reference
-  the commit hash and let the diff speak.
-- If the same item is revised after review, **replace** the existing note line (don't append) so
-  the file doesn't grow.
-- New items the user asks to add get slotted into the most appropriate existing priority section
-  (CRITICAL → HIGH → MEDIUM → LOW) based on severity, dependencies, and impact — not appended at
-  the bottom.
-- Item numbering continues from #47. Do not reuse completed item numbers.
-
-## Branch and PR strategy
-
-- **Working branch:** `working/calorie-tracker-backlog`, long-lived, branched from `main`. One
-  PR is open against `main` at any time and is updated by every push. Preferred over the
-  ephemeral `claude/*` per-session branches when the environment lets you switch.
-- **Web/remote sessions:** the harness may pin a per-session `claude/*` branch you cannot switch
-  off. That is fine — open or append to a PR against `main` from it. Because completion is
-  detected from commits merged to `main` (step 4), the workflow does not depend on the branch
-  name being stable.
-- **Merging:** The user merges the PR when they want to lock in a batch of items. On the next
-  session, the reconcile step auto-marks the merged items `[x]` and moves them to the completed
-  log. After merge, the working branch is reset/rebased onto the new `main` (or deleted and
-  recreated) for the next round.
-
-## Test command
-
-For CalorieTracker code changes, run from repo root:
-
-```bash
-cd public/tools/CalorieTracker
-npm test
-```
-
-Baseline: **575 tests, 9 files, all passing.**
-
-Use targeted testing judgment:
-
-- Logic, validation, state, parser, target, analysis, or UI behavior changes must keep the CalorieTracker test suite green.
-- Pure documentation, backlog bookkeeping, or pointer-file changes do not require the CalorieTracker test suite.
-- If only one pure module changed, run the nearest focused test first when useful, then run the full CalorieTracker suite before marking the backlog item pushed.
-- Add or update tests for new validators, pure functions, regression fixes, or behavior that could silently break calculations.
 
 ---
 

--- a/backlogs/protocol.md
+++ b/backlogs/protocol.md
@@ -1,0 +1,111 @@
+# Backlog Session Protocol (shared)
+
+Applies to every backlog under `backlogs/`. Each backlog file defines a **Parameters**
+block (working branch, commit scope, item id format, archive file, test commands) that
+fills the placeholders below. Follow this protocol exactly; do not improvise a different
+workflow. Which backlog to work on is decided by the dispatch rule in root `BACKLOG.md`.
+
+## Session start
+
+1. `git fetch origin`.
+2. Switch to the backlog's working branch (see its Parameters). If it doesn't exist
+   locally or on origin, create it from `origin/main`:
+   `git switch -c <branch> origin/main`. In web/remote sessions the harness may pin you
+   to an auto-generated `claude/<adjective>-<noun>-<id>` branch you cannot switch off —
+   that is fine to work on; completion is detected from commits merged to `main`, not
+   the branch name.
+3. `git pull --ff-only origin <branch>` (skip if just created).
+4. **Reconcile completed items (auto-mark `[x]`).** `git fetch origin main`. For every
+   `[p]` item whose note records a commit SHA, test whether it has merged to main:
+   `git merge-base --is-ancestor <sha> origin/main` (exit 0 = merged). Cross-check the
+   backlog PR via the GitHub MCP (`mcp__github__pull_request_read`) when available. For
+   each `[p]` item whose commit is on `origin/main`, flip it to `[x]`, rewrite its note
+   to `> Resolved: <summary>; merged <short-sha>`, and move it to the backlog's archive
+   file in the appropriate priority section. Leave pushed-but-unmerged items `[p]`.
+   **This is the only way items reach `[x]`** — hands-off, but never before the user has
+   actually merged the PR.
+5. Read the backlog file end-to-end. Identify (a) any `[p]` items needing follow-up from
+   review or a prior session, then (b) the highest-priority `[ ]` items, in section
+   order (CRITICAL → HIGH → MEDIUM → LOW), respecting any `Depends:` lines.
+6. Pick the next reasonable batch — usually one to three related items.
+
+## Implement, test, push
+
+7. Implement. Mark each touched item `[p]` with a one-line note (status legend below).
+8. Run the backlog's test commands (see its Parameters). Code changes must keep the
+   relevant suite green.
+9. Commit with a **descriptive** Conventional-Commit message. Format:
+   `type(<scope>): <id> short description of the change`
+   The message must include: (a) the Conventional Commit type (`feat`, `fix`,
+   `refactor`, etc.), (b) the backlog's scope so it's clear which part of the site
+   changed, (c) the backlog item id(s), and (d) a plain-English summary of what the
+   commit does — not just the item title. Examples:
+   - `feat(calorie-tracker): #47 add weekly meal-prep summary view`
+   - `feat(recipe-standardizer): R2 export unlinked ingredients as tracker food items`
+   One commit per logical change. Multi-item commits list all ids: `#47 #48 ...`.
+10. Push: `git push -u origin <branch>` (or the pinned `claude/*` branch in a web
+    session). On network failure retry up to 4 times with exponential backoff.
+11. **Record the commit SHA** on every item you pushed (`commit: <short-sha>` in its
+    `[p]` note, plus the PR number when known). The next session's reconcile step keys
+    off this SHA — an item with no recorded SHA can never be auto-completed.
+12. **PR title and body must be descriptive.** If no open PR exists for the branch,
+    create one via the GitHub MCP tools. Format:
+    - **Title:** `<Scope>: <short summary of batch> (<ids>)`
+      Example: `Recipe Standardizer: schema v2 nutrition data, ingredient export (R1, R2)`
+    - **Body:** list every item addressed with its id and one-line summary, plus a
+      pointer to the backlog file. Update the body on subsequent pushes when new items
+      are added to the batch.
+    All subsequent pushes auto-update the same PR.
+
+## Status legend
+
+| Mark | Meaning |
+|------|---------|
+| `[ ]` | Not started. |
+| `[p]` | In progress / pushed / awaiting merge / blocked / needs follow-up. **Default state once code has been touched.** Records a `commit: <short-sha>` once pushed. |
+| `[x]` | Complete — the item's commit has merged to `main` (the user accepted the PR). Set automatically by the reconcile step (step 4); never set for merely-pushed code. Completed items move to the backlog's archive file. |
+
+The note line under a `[p]` item begins with one of these sub-labels so the state is
+scannable:
+
+- `> pushed — <one-line summary>; tests: <pass/notes>; commit: <short-sha>` (awaiting merge)
+- `> in progress — <what's left>`
+- `> blocked — <reason>`
+- `> needs follow-up — <what the reviewer said>; commit: <short-sha>`
+
+When the item's commit merges to `main`, the next session's reconcile step moves it to
+the archive with a single line:
+
+- `> Resolved: <one-line summary>; merged <short-sha>`
+
+## Editing rules
+
+- **Mark `[p]` when you push; let the reconcile step (step 4) flip `[p]`→`[x]` and move
+  to the archive once the commit is merged to `main`.** Never mark `[x]` for code that
+  is only pushed, and never flip it manually mid-session — merge to `main` is the single
+  signal that an item is done.
+- Keep notes to **one line** per item. No pasted diffs, no multi-paragraph rationale —
+  reference the commit hash and let the diff speak.
+- If the same item is revised after review, **replace** the existing note line (don't
+  append) so the file doesn't grow.
+- New items the user asks to add get slotted into the most appropriate existing priority
+  section (CRITICAL → HIGH → MEDIUM → LOW) based on severity, dependencies, and impact —
+  not appended at the bottom.
+- Item ids are never reused; numbering continues from the backlog's stated next id.
+- Any fundamental change ships its doc updates (`ARCHITECTURE.md`, `SECURITY.md`, etc.
+  per `AGENTS.md`) in the same PR as the code.
+
+## Branch and PR strategy
+
+- **Working branch:** each backlog names a long-lived working branch, branched from
+  `main`. One PR is open against `main` at any time and is updated by every push.
+  Preferred over the ephemeral `claude/*` per-session branches when the environment
+  lets you switch.
+- **Web/remote sessions:** the harness may pin a per-session `claude/*` branch you
+  cannot switch off. That is fine — open or append to a PR against `main` from it.
+  Because completion is detected from commits merged to `main` (step 4), the workflow
+  does not depend on the branch name being stable.
+- **Merging:** The user merges the PR when they want to lock in a batch of items. On the
+  next session, the reconcile step auto-marks the merged items `[x]` and moves them to
+  the archive. After merge, the working branch is reset/rebased onto the new `main` (or
+  deleted and recreated) for the next round.

--- a/backlogs/recipe-standardizer-completed.md
+++ b/backlogs/recipe-standardizer-completed.md
@@ -7,14 +7,6 @@ Pre-backlog context: the v1 tool itself shipped in PR #149 (merge `3dd5bd1`) bef
 backlog existed — strict-JSON import, workflow sections, gram-first scaling, Ingredients
 hub, per-user Firestore saves, and name-only nutrition links.
 
-## HIGH
-
-_(none yet)_
-
-## MEDIUM
-
-_(none yet)_
-
-## LOW
+## Completed phases (P0–P7, in order)
 
 _(none yet)_

--- a/backlogs/recipe-standardizer-completed.md
+++ b/backlogs/recipe-standardizer-completed.md
@@ -1,0 +1,20 @@
+# Recipe Standardizer — Completed Items Archive
+
+Completed items are moved here from `backlogs/recipe-standardizer.md` by the reconcile
+step in `backlogs/protocol.md` (only after their commits merge to `main`).
+
+Pre-backlog context: the v1 tool itself shipped in PR #149 (merge `3dd5bd1`) before this
+backlog existed — strict-JSON import, workflow sections, gram-first scaling, Ingredients
+hub, per-user Firestore saves, and name-only nutrition links.
+
+## HIGH
+
+_(none yet)_
+
+## MEDIUM
+
+_(none yet)_
+
+## LOW
+
+_(none yet)_

--- a/backlogs/recipe-standardizer.md
+++ b/backlogs/recipe-standardizer.md
@@ -1,191 +1,301 @@
-# Recipe Standardizer — Nutrition Rollout Backlog
+# Recipe Standardizer — Nutrition Integration Rollout Backlog
 
-Single source of truth for the Recipe Standardizer → Nutrition Tracker (CalorieTracker)
-integration rollout. The v1 tool (PR #149, merged) imports ChatGPT-converted recipes,
-scales gram-first, and *records* name-match links to CalorieTracker food items. This
-rollout makes those links useful end-to-end: nutrition data enters via the conversion
-prompt, ingredients can be pushed into the tracker, recipes compute their own nutrition,
-and whole recipes become loggable food items.
+Single source of truth for the Recipe Standardizer → CalorieTracker nutrition rollout.
+This is the plan of record supplied by the user on 2026-07-09; it supersedes the earlier
+R1–R6 draft (no R-item was ever started — ignore R-ids in old discussion).
+
+The v1 tool (PR #149, merged; `app/tools/recipe-standardizer/`, live at
+`/tools/recipe-standardizer`) imports ChatGPT-converted recipes as strict JSON, displays
+them workflow-first, scales, and saves per-user to Firestore. Each ingredient carries a
+`nutritionLink` stub (`linked | likely | unlinked`, food-item id + confidence) that
+name-matches the CalorieTracker's saved foods — but the link is recorded, not used. This
+rollout adds: confirming/managing links (P1), gathering nutrition for unlinked
+ingredients via ChatGPT paste-back (P2), computing full recipe nutrition (P3), exporting
+a finished recipe as a normal tracker food (P4), docs/hardening (P5), and two optional
+late phases (P6 diary logging, P7 in-site Gemini).
+
+**Constraint carried forward:** no AI API calls from the website in the core flow (P0–P5).
+The user runs prompts in ChatGPT manually and pastes strict JSON back — same pattern as
+recipe import. (The repo has Gemini Edge-route infra — `app/lib/aiConfig.ts`,
+`app/lib/aiModels.ts`, used by Show Tracker — which only optional P7 may reuse.)
 
 ## Parameters (for `backlogs/protocol.md`)
 
-- **Working branch:** `working/recipe-standardizer-backlog`
-- **Commit scope:** `recipe-standardizer`; item ids `R<N>` (next new id: **R7**; never reuse ids)
+- **Branch strategy (overrides the protocol's single long-lived branch; everything else
+  in the protocol applies unchanged):** one branch and one PR **per phase**, started
+  from fresh `origin/main` after the previous phase merges:
+  `working/recipe-standardizer-p<N>`. Web/remote sessions may be pinned to a `claude/*`
+  branch — fine, per protocol.
+- **Commit scope:** `recipe-standardizer`; item ids `P<N>` = phases 0–7 (next new id:
+  **P8**; never reuse ids). Work phases strictly in order; P6/P7 are optional — do not
+  start them unless the user explicitly asks.
 - **Archive:** `backlogs/recipe-standardizer-completed.md`
-- **Tests:**
-  - Pure lib / schema / logic changes: `npm test` from repo root (vitest; covers
-    `app/tools/recipe-standardizer/__tests__/`). Add or update tests for every new pure
-    function, validator change, or regression fix.
-  - Component / page changes: also `npm run lint` and `npm run build`.
-  - Never touches `public/tools/CalorieTracker/` code, so its suite is not required —
-    unless an item explicitly changes tracker code (none currently do).
+- **Tests:** `npm test` from repo root (Vitest — new pure libs get `__tests__/` coverage
+  like the existing 6 suites); component/page changes also `npm run lint` and
+  `npm run build`. Optional deploy-parity check: `npx --yes @cloudflare/next-on-pages@1`
+  (delete `.vercel/` afterward — it pollutes local vitest discovery). CalorieTracker
+  code is only touched in the possible P6 alternative — if so, also run
+  `cd public/tools/CalorieTracker && npm test`.
 
 ## Session protocol
 
 Follow `backlogs/protocol.md` with the parameters above.
 
-## Context facts (verified against the codebase — do not re-derive)
+## Interop contracts (read first — everything bridges through these)
 
-Read `ARCHITECTURE.md` § "Recipe Standardizer" for tool behavior. Key integration facts:
+### CalorieTracker food items (`artifacts/default-app-id/users/{uid}/foodItems/{foodId}`)
 
-- **Recipe storage:** one doc per recipe at
-  `artifacts/recipe-standardizer/users/{uid}/recipes/{recipeId}` shaped
-  `{ name, recipe, createdAt, updatedAt }` (`lib/db.ts`). Loads re-run the strict
-  validator (`lib/schema.ts` — pure, never throws, exact-path errors + non-fatal warnings).
-- **Tracker food storage:** `artifacts/default-app-id/users/{uid}/foodItems/{foodId}`.
-  Doc shape (see `public/tools/CalorieTracker/food/save.js`):
-  `{ name, quantity, <nutrient keys>, lastUpdated: <ISO string> }` — flat fields, no
-  nesting. Doc id = `name.toLowerCase().replace(/[^a-z0-9]/g, '_')`.
-- **Tracker semantics:** nutrient field values are **per 1 unit of `quantity`**; a log
-  entry adds `quantity × value` per nutrient (`food/manager.js`). `quantity` is a
-  unitless multiplier — the unit convention lives in the food's name.
-- **Nutrient keys:** `allNutrients` in `public/tools/CalorieTracker/constants.js` —
-  `calories, protein, carbs, fat, fiber, potassium, magnesium, sodium, calcium, choline,
-  vitaminB12, folate, vitaminC, vitaminB6, vitaminA, vitaminD, vitaminE, vitaminK,
-  selenium, iodine, phosphorus, iron, zinc, omega3`. Units follow the tracker's
-  `DEFAULT_BASELINE_TARGETS` conventions (standard US RDA units: kcal; g for
-  protein/carbs/fat/fiber/omega3; mg for potassium, magnesium, sodium, calcium, choline,
-  vitaminC, vitaminB6, vitaminE, iron, zinc, phosphorus; mcg for vitaminB12, folate,
-  vitaminA, vitaminD, vitaminK, selenium, iodine).
-- **Firestore rules:** the legacy wildcard `match /artifacts/{appId}/users/{userId}/{document=**}`
-  in `firestore.rules` already lets a signed-in user read/write **their own** foodItems
-  from any tool — no rules change needed for cross-tool writes, but `SECURITY.md` must
-  document each new write surface.
-- **Link model:** each ingredient carries `nutritionLink`
-  (`linked | likely | unlinked`, `lib/types.ts`). Matching (`lib/nutritionMatch.ts`):
-  exact normalized name → `linked`; token score ≥ 0.6 → `likely` + `needsUserReview`;
-  else `unlinked`. Re-matching (`applyNutritionMatches`) preserves only `linked` entries.
-- **No AI calls on the site:** nutrition data can only enter via the copyable ChatGPT
-  conversion prompt (`lib/prompt.ts`) + strict-JSON paste (`lib/schema.ts`), or manual
-  entry in the UI.
-- **Food list access:** `RecipeContext.loadFoodItems()` → `fetchFoodItems(uid)` in
-  `lib/db.ts` already reads the tracker's foodItems (id + name only today).
+Verified against source (file:line refs in `public/tools/CalorieTracker/`):
 
-## Invariants
+- Doc shape (`food/save.js:67`): `{ name, quantity, ...24 nutrient keys, lastUpdated }`.
+  No schemaVersion, no id field inside the doc.
+- Doc ID is a name slug (`food/save.js:65`):
+  `name.toLowerCase().replace(/[^a-z0-9]/g, '_')`. `setDoc` overwrites on collision —
+  collisions must be handled deliberately (getDoc-check first, then ask).
+- Nutrients are stored **per 1 quantity-unit, unit-agnostic**. `quantity` is a bare
+  numeric multiplier (default 1) with no physical basis — no grams/serving distinction
+  exists anywhere in the tracker. Logged amount = `quantity × storedNutrient`.
+- 24 canonical nutrient keys (`constants.js:50–77`), units implied by convention, values
+  assumed already canonical: `calories` (kcal); `protein, carbs, fat, fiber, omega3`
+  (g); `potassium, magnesium, sodium, calcium, choline, vitaminC, vitaminB6, vitaminE,
+  iron, zinc, phosphorus` (mg); `vitaminB12, folate, vitaminA, vitaminD, vitaminK,
+  selenium, iodine` (mcg).
+- Bounds: `NUTRIENT_MAX_BOUNDS` (`constants.js:135–143`), flat `{key: max}` map used to
+  clamp inputs.
+- ⚠️ **Do NOT add custom fields to foodItems docs.** CalorieTracker's save flow rebuilds
+  the whole doc (`setDoc`, no merge) from its fixed shape — any extra field is silently
+  dropped on the next edit/resave in the tracker. All recipe-side metadata (grams basis,
+  link info, export back-reference) lives on the **recipe** documents.
+- Daily entries (`dailyEntries/{YYYY-MM-DD}`, schemaVersion 2, `state/schema.js:71–125`)
+  embed copies of per-unit nutrients plus quantity; they never reference foodItem ids.
 
-Preserve these unless the user explicitly asks to change them:
+### The grams-basis bridge (core design decision)
 
-- Grams (`quantityG`) stay the source of truth for quantities; `equivalent` is
-  display-only text.
-- Import stays strict-JSON with exact-path errors; the site never calls an AI API.
-- Any change to an already-saved recipe routes through `SaveChoiceModal`
-  (update / save-as-new / cancel) — no silent overwrites. The same "no silent
-  overwrite" rule applies to writes into the tracker's `foodItems` (duplicate check +
-  confirm, mirroring `food/save.js`'s duplicate dialog behavior).
-- Nutrition matching/linking/data **never blocks** importing or saving a recipe —
-  missing data degrades to warnings and coverage notes.
-- Any recipe shape change bumps `RECIPE_SCHEMA_VERSION` and must still load existing
-  v1 Firestore docs and v1 pasted JSON (normalize with defaults + non-fatal warning;
-  never reject).
-- Shopping/grocery views stay derived from ingredients at render time; no stored
-  shopping list.
+Recipe ingredients are gram-based; tracker foods have no defined physical basis. Bridge
+it **on the recipe side**:
+
+- Extend `NutritionLink` (`lib/types.ts`) with `gramsPerUnit: number | null` = "grams of
+  this ingredient per 1 quantity-unit of the linked food". Per-gram nutrition =
+  `storedNutrient / gramsPerUnit`; an ingredient's contribution =
+  `ingredient.quantityG × storedNutrient / gramsPerUnit`.
+- Foods created BY the recipe tool are always **per-100 g** (`quantity: 1` = 100 g
+  edible portion), so `gramsPerUnit` auto-fills to 100.
+- Pre-existing tracker foods: the user supplies `gramsPerUnit` once at link-confirmation
+  time ("1 unit of 'Butter' = how many grams?"). A link without `gramsPerUnit` stays
+  usable for everything except nutrition math and counts as "not computable" in coverage.
+
+## Current state (what a fresh session inherits)
+
+- Tool code: `app/tools/recipe-standardizer/` — `lib/` (pure: `schema.ts`, `scaling.ts`,
+  `shoppingList.ts`, `nutritionMatch.ts`, `stepTextUpdate.ts`, `naming.ts`,
+  `display.ts`, `prompt.ts`; Firebase: `firebase.ts`, `db.ts`), `components/`,
+  `RecipeContext.tsx`, `__tests__/` (6 files, 60 tests).
+- `lib/db.ts` already has `fetchFoodItems(uid)` returning `{id, name}[]` from the
+  tracker's collection (`CALORIE_TRACKER_APP_ID = 'default-app-id'`).
+- `lib/nutritionMatch.ts`: exact normalized name ⇒ `linked` (confidence 1, no review);
+  token similarity ≥ 0.6 (capped 0.95) ⇒ `likely` + review flag; else `unlinked`.
+  `applyNutritionMatches` never downgrades a confirmed `linked`.
+- Recipes saved as `{name, recipe, createdAt, updatedAt}` at
+  `artifacts/recipe-standardizer/users/{uid}/recipes/{id}`; loads re-run the strict
+  import validator, so **any schema extension must be additive with defaults** (see
+  `parseRecipeJson`'s `readNutritionLink`).
+- Firestore rules: explicit owner-only block for the recipe path is in
+  `firestore.rules`; the legacy wildcard `artifacts/{appId}/users/{userId}/**`
+  (owner-only) already authorizes recipe-tool reads/writes of foodItems. No rules
+  changes needed for any phase except possibly P6/P7.
+- Conventions (`AGENTS.md`): TypeScript + Tailwind tokens, lucide-react, pure libs with
+  Vitest under `__tests__/`, Conventional Commits, update ARCHITECTURE/SECURITY/README
+  when fundamentals change.
+
+## Risk register / bridging notes
+
+- **Unit ambiguity is the #1 correctness risk.** Everything hangs on the per-100 g
+  convention for created foods and explicit `gramsPerUnit` for pre-existing ones. Never
+  infer a basis silently; "unknown basis" ⇒ excluded from math + surfaced.
+- **Slug collisions overwrite** in the tracker's own save flow — the recipe tool must
+  always getDoc-check before setDoc and ask.
+- **Never write extra fields to foodItems docs** (tracker resaves drop them). All
+  metadata lives on recipe docs.
+- **Linked-food drift:** tracker-side edits change nutrition under a link silently —
+  acceptable (that's how the tracker works), but show `matchedName` vs current name
+  mismatch as a soft "re-review" hint (cheap check during the P3 fetch).
+- **Raw-vs-cooked:** computed nutrition is raw-ingredient-based; per-100 g-cooked
+  requires final weight. Label accordingly; encourage filling `actualFinalWeightG`
+  (field already exists in Overview).
+- **Firestore rules deploys are manual** — any phase touching rules (only P6/P7 might)
+  must call this out in its PR.
+- Carried-over v1 invariants still apply: strict-JSON import with exact-path errors;
+  saved-recipe edits route through `SaveChoiceModal` (no silent overwrites); nutrition
+  linking never blocks importing or saving; shopping/grocery views stay derived from
+  ingredients.
+
+## Verification (every phase)
+
+- `npm test`, `npm run lint`, `npm run build`; optional
+  `npx --yes @cloudflare/next-on-pages@1` parity check (delete `.vercel/` afterward).
+- End-to-end against the Cloudflare Pages branch preview (each PR gets one): exercise
+  the phase's acceptance line with a real recipe import. Live-Firebase steps are
+  user-verified — list the manual steps in the PR body.
+- Cross-tool check for P2/P4/P6: open `/tools/CalorieTracker/index.html` as the same
+  user and confirm the created/exported food (and logged entry, P6) appears and
+  computes correctly in the tracker's own UI.
 
 ---
 
-## Active items
+## Active items (work strictly in order; P6/P7 only on explicit user request)
 
-Rollout goal: a user converts a recipe in ChatGPT (prompt now includes per-100 g
-nutrition), imports it, reviews/creates ingredient links, sees the recipe's computed
-nutrition, and can log either single ingredients or the whole recipe in the
-Nutrition Tracker. R1 → R2/R3 → R4/R5 is the dependency spine; R6 is the final
-real-data gate.
+### P0 — Post-merge housekeeping (do first, ~10 min, user-assisted)
 
-### HIGH
+- [ ] **P0 Deploy rules + production smoke test.** Deploy `firestore.rules` to Firebase
+  (manual, Firebase console/CLI — the repo file is source of truth but doesn't
+  auto-deploy; the tool currently works only via the legacy wildcard rule). Smoke-test
+  production: import a recipe, save, reload, run nutrition match. Agent's role: remind
+  the user, provide the exact steps, and record confirmation here; no code. Do not
+  block P1 coding on this, but flag it in every PR until confirmed.
 
-- [ ] **R1 Schema v2: per-ingredient nutrition data.** Add optional
-  `nutritionPer100g: Partial<Record<NutrientKey, number>> | null` to `RecipeIngredient`
-  (values per 100 g of the ingredient; `NutrientKey` = the 24 tracker keys listed in
-  Context facts, exported from a new shared constant in `lib/types.ts`). Bump
-  `RECIPE_SCHEMA_VERSION` to 2. Validator: v1 docs/JSON normalize to
-  `nutritionPer100g: null` (no error, no warning); reject non-numeric or negative
-  values with exact-path errors; unknown keys → non-fatal warning and dropped. Update
-  the ChatGPT prompt (`lib/prompt.ts`) to request best-estimate per-100 g values —
-  calories/protein/carbs/fat expected, micros optional, `null` when unknown — and
-  document the units. Show per-100 g data read-only in `IngredientEditModal` with
-  manual edit support.
-  Accept: v1 fixture still parses clean; v2 fixture round-trips; prompt text names the
-  exact keys and units; tests cover normalization, rejection, and unknown-key warning.
-  Files: `lib/types.ts`, `lib/schema.ts`, `lib/prompt.ts`,
-  `components/IngredientEditModal.tsx`, `__tests__/schema.test.ts`, `__tests__/fixtures.ts`.
+### P1 — Link management UI (confirm / pick / unlink + grams basis)
 
-- [ ] **R2 Ingredient → tracker food item export.** Depends: R1. New pure
-  `lib/foodItemExport.ts`: `buildFoodItemDoc(ingredient)` → `{ id, data }` where
-  `data = { name: '<Ingredient name> (100g)', quantity: 1, ...nutritionPer100g mapped
-  onto flat tracker keys (absent keys → 0), lastUpdated: ISO }` and id is derived from
-  the full name per the tracker's id rule. Convention (document in ARCHITECTURE.md):
-  exported ingredient foods are per-100 g, so tracker `quantity` 1.5 = 150 g. New
-  `createFoodItem(uid, id, data)` in `lib/db.ts` (setDoc). UI: "Add to Nutrition
-  Tracker" action on `unlinked`/`likely` ingredients (IngredientEditModal and/or
-  IngredientsView badge), enabled only when `nutritionPer100g` has at least `calories`;
-  confirm modal previews name + values; duplicate guard — if the id or a
-  case-insensitive name match exists in the fetched food list, require an explicit
-  overwrite-or-rename choice, never silent. On success, re-run matching so the link
-  flips to `linked` with the new `foodItemId`. Update `SECURITY.md`: recipe tool now
-  writes to the CalorieTracker foodItems path (own-uid only, existing wildcard rule).
-  Accept: builder unit-tested (id derivation, key mapping, zero-fill, name suffix);
-  export → link flip verified manually; duplicate path can't clobber without confirm.
-  Files: `lib/foodItemExport.ts` (new), `lib/db.ts`, `RecipeContext.tsx`,
-  `components/IngredientEditModal.tsx`, `components/IngredientsView.tsx`,
-  `__tests__/foodItemExport.test.ts` (new), `SECURITY.md`, `ARCHITECTURE.md`.
+- [ ] **P1 LinkEditor + `gramsPerUnit`.** Goal: the user can resolve every
+  `likely`/`unlinked` badge into a confirmed link or an explicit no-match, and record
+  `gramsPerUnit`.
+  - `lib/types.ts`: add `gramsPerUnit: number | null` to `NutritionLink`; update
+    `UNLINKED_NUTRITION`.
+  - `lib/schema.ts` → `readNutritionLink`: accept the new field (number > 0 or null) —
+    additive; old saved recipes parse with null.
+  - `lib/db.ts`: extend the food fetch to also return each food's `quantity` and
+    nutrient values (full doc read, same collection) — needed by P3–P5. Keep
+    `FoodItemRef` for matching; add `FoodItemFull`.
+  - New component `LinkEditor` (modal or inline expansion in Ingredients → Recipe
+    Workflow mode, launched from the nutrition badge): shows current status; **Confirm**
+    (`likely` → `linked`), **Pick from list** (searchable dropdown over fetched foods,
+    reuse `nameSimilarity` for sort), **Unlink / mark as no-match**, and a
+    grams-per-unit input (prefill 100 when the food was recipe-created; required before
+    "computable"). Confirming sets `status: 'linked'`, `needsUserReview: false`.
+  - Link edits mark the draft dirty → existing update/save-as-new/cancel flow already
+    guards persistence (no new save logic).
+  - Tests: schema round-trip of `gramsPerUnit`; pure `lib/linking.ts` helper if
+    non-trivial logic emerges (e.g. `isComputableLink` predicate).
+  - Accept: every badge is clickable; a confirmed link with grams basis survives
+    save/reload; old recipes still load.
 
-- [ ] **R3 Recipe nutrition computation + Overview display.** Depends: R1. New pure
-  `lib/nutrition.ts`: `computeRecipeNutrition(recipe)` sums
-  `quantityG × nutritionPer100g / 100` per ingredient into totals per nutrient key, and
-  returns `{ totals, perServing, perPortion, coverage }` — perServing from
-  `servings.currentServings ?? baselineServings`, perPortion from
-  `servings.portionCount` (else from total weight ÷ `portionSizeG`), and
-  `coverage = { includedCount, excluded: [{id, displayName, reason}] }` listing every
-  ingredient skipped for missing grams or missing nutrition data (never silently
-  pretend complete). Compute from the **scaled working copy** the UI renders, not the
-  baseline. UI: "Nutrition" block in the Overview accordion — macro line
-  (kcal / P / C / F) prominent, expandable micros table, coverage warning listing
-  excluded ingredients. Update the ARCHITECTURE.md line that says computing recipe
-  nutrition "is a documented follow-up, not in v1".
-  Accept: math unit-tested incl. null grams, null nutrition, zero servings/portions
-  (no division blowups), scaling factor applied; coverage list exact.
-  Files: `lib/nutrition.ts` (new), `components/RecipeWorkspace.tsx` (Overview),
-  `__tests__/nutrition.test.ts` (new), `ARCHITECTURE.md`.
+### P2 — Ingredient nutrition intake via external AI (paste-back)
 
-### MEDIUM
+- [ ] **P2 Nutrition prompt + import + food creation.** Depends: P1. Goal:
+  batch-generate a ChatGPT prompt for all unlinked ingredients, paste strict JSON back,
+  create real tracker foods (per-100 g), auto-link.
+  - `lib/nutritionPrompt.ts` (pure): `buildNutritionPrompt(ingredients: {name, prepNote}[])`
+    — instructs ChatGPT to return strict JSON only:
+    `{ "schemaVersion": 1, "foods": [{ "ingredientName": "", "per100g": { <all 24 canonical keys, numbers> }, "confidence": "high|medium|low", "notes": "" }] }`,
+    values per 100 g edible portion, canonical units listed explicitly (embed the
+    kcal/g/mg/mcg unit table per key), estimate-and-flag when uncertain, no commentary.
+    Include the ingredient list verbatim.
+  - `lib/nutritionImport.ts` (pure, mirrors `schema.ts` style): `parseNutritionJson(raw)`
+    → exact-path errors; clamp each value to a local copy of the tracker's
+    `NUTRIENT_MAX_BOUNDS`. Duplicate the 24-key bounds + canonical-keys list into
+    `lib/trackerNutrients.ts` with a pointer comment to
+    `public/tools/CalorieTracker/constants.js` — the static tool is a separate JS
+    package, don't import across.
+  - `lib/db.ts`: `createFoodItem(uid, name, per100g)` — writes
+    `{ name, quantity: 1, ...nutrients, lastUpdated: new Date().toISOString() }` with
+    the slug doc id. **Collision handling:** getDoc first; if the slug exists, do not
+    overwrite — offer "link to existing food instead" or "rename and create".
+  - New component `NutritionIntakePanel` (entry points: the unlinked summary in
+    Ingredients mode, and P3's coverage warning): step 1 copy prompt (unlinked
+    ingredient names auto-included), step 2 paste JSON, step 3 review table (name →
+    matched ingredient, calories sanity column, confidence) with per-row accept/skip,
+    then create foods + auto-link (`status: 'linked'`, `gramsPerUnit: 100`,
+    `matchConfidence: 1`). Rows whose `ingredientName` matches no current unlinked
+    ingredient: show and let the user assign or skip (don't hard-fail the batch).
+  - Tests: prompt content (units table present, names embedded), parser
+    errors/clamping, slug collision logic (pure part).
+  - Accept: recipe with N unlinked ingredients → one prompt → one paste → N new tracker
+    foods visible in CalorieTracker's own search, ingredients linked with grams basis,
+    recipe saved with links.
 
-- [ ] **R4 Batch link-review panel.** Depends: R2. One place to clear all
-  `needsUserReview` flags: a "Review links" surface in the Ingredients panel (workflow
-  mode) listing every `likely`/`unlinked` ingredient with per-row actions —
-  **accept** suggested match (→ `linked`, review flag off), **choose** from a
-  searchable list of fetched foods, **create** in tracker (reuse R2 flow), or
-  **dismiss** (stays `unlinked`, review flag off so it stops nagging). Pure
-  state-transition helpers for each action. Edits mark the recipe dirty and route
-  through the normal save flow — no new persistence path.
-  Accept: transitions unit-tested; review badge count reaches zero after a full pass;
-  dismissed items survive re-match (extend `applyNutritionMatches` to also preserve
-  dismissed links — note: today it only preserves `linked`).
-  Files: `lib/nutritionMatch.ts`, `components/IngredientsView.tsx` (or new
-  `components/LinkReviewPanel.tsx`), `__tests__/nutritionMatch.test.ts`.
+### P3 — Recipe nutrition computation & display
 
-- [ ] **R5 Recipe → tracker food item export ("log this recipe").** Depends: R2, R3.
-  Button in Overview/Scaling area: writes ONE foodItems doc for the whole recipe —
-  name = recipe name, nutrient values = R3's `perPortion` (fallback `perServing`;
-  if neither is derivable, disable with an explanatory tooltip), `quantity: 1` = one
-  portion. Same confirm + duplicate guard as R2. If coverage is incomplete, the confirm
-  modal must show the excluded-ingredient list and require explicit "export partial"
-  acknowledgement. Document the per-portion convention in ARCHITECTURE.md.
-  Accept: builder path unit-tested (portion fallback chain, partial-coverage flag);
-  exported doc loggable in the tracker.
-  Files: `lib/foodItemExport.ts`, `components/RecipeWorkspace.tsx` and/or
-  `components/ScalingPanel.tsx`, `__tests__/foodItemExport.test.ts`, `ARCHITECTURE.md`.
+- [ ] **P3 `lib/nutrition.ts` + Nutrition panel.** Depends: P1 (P2 for full coverage).
+  Goal: show what the recipe actually contains, honestly scoped to link coverage.
+  - `computeRecipeNutrition(recipe, foods: Map<foodItemId, FoodItemFull>, factor)` →
+    `{ totals: Record<nutrientKey, number>, coveredGrams, totalGrams, uncomputable:
+    {ingredientId, reason: 'unlinked'|'no-grams-basis'|'no-weight'|'food-missing'}[] }`.
+    Contribution = `quantityG × factor × nutrient / gramsPerUnit`. Optional ingredients
+    included by default with a toggle.
+  - Derivations: per serving (`baselineServings`), per portion
+    (`portionCount`/`portionSizeG`), per 100 g cooked
+    (÷ `actualFinalWeightG ?? estimatedFinalWeightG`, labeled "estimated" when using
+    the estimate — note in UI that nutrition is computed from raw ingredient weights;
+    water loss is why per-100 g-cooked needs the final weight).
+  - New **Nutrition** accordion panel in `RecipeWorkspace` (nav becomes Overview /
+    Ingredients / Prep / Cook / Nutrition / Scaling / JSON): coverage banner ("87% of
+    ingredient grams linked — 2 ingredients missing", CTA → P2 panel / P1 editor),
+    compact macro row + expandable full 24-nutrient table, per-total/serving/portion/
+    100 g toggle. Respects the live scale factor.
+  - Stale-food handling: if a linked `foodItemId` no longer exists, surface it in
+    `uncomputable` and flag the badge for re-review (don't crash, don't silently zero).
+    Cheap drift hint: show `matchedName` vs current food name mismatch as "re-review".
+  - Fetch foods once per recipe session via `RecipeContext` (reuse P1's `FoodItemFull`
+    fetch); recompute pure-side on draft/factor changes.
+  - Tests: contribution math incl. `gramsPerUnit` division, coverage accounting, per-X
+    derivations, missing-food and no-basis paths.
+  - Accept: fully-linked recipe shows plausible totals that scale with the working-copy
+    factor; partially-linked recipe clearly shows coverage and never presents partial
+    totals as complete.
 
-### ROLLOUT GATE (work last)
+### P4 — "Linking off": export recipe as a tracker food
 
-- [ ] **R6 Real-recipe rollout QA.** Depends: R1–R5 merged. The user converts their real
-  recipe collection in ChatGPT with the updated prompt and imports each recipe. Agent's
-  role per session: take the user's reported friction (validation errors, prompt
-  misses, bad matches, unit mistakes), fix `lib/prompt.ts` / `lib/schema.ts` /
-  matcher thresholds accordingly, and keep a one-line running friction note on this
-  item. Do not start R6 work unless the user supplies recipes or reports friction.
-  Accept (user-confirmed): their collection imports cleanly with nutrition data, links
-  reviewed to zero flags, and at least one recipe logged in the tracker end-to-end.
+- [ ] **P4 Recipe export.** Depends: P3. Goal: one click turns the finished recipe into
+  a normal CalorieTracker food so portions are logged inside the tracker.
+  - Export button in the Nutrition panel (enabled when coverage = 100% of weighed,
+    non-optional grams — otherwise confirm with an "exports partial nutrition" warning).
+  - Basis: per portion when portion data exists (nutrients = totals / portionCount,
+    food name `"{Recipe Name} (1 portion)"`), else per 100 g cooked (needs final
+    weight; name `"{Recipe Name} (100 g)"`). `quantity: 1`. Same slug + collision
+    handling as P2 (re-export of the same recipe → offer overwrite — the natural
+    "update the food after editing the recipe" path).
+  - Store a back-reference **on the recipe doc** (never on the food doc):
+    `export: { foodItemId, basis, exportedAt, nutritionSnapshotHash }` → UI shows
+    "exported / recipe changed since export — re-export?".
+  - `lib/schema.ts`: accept the optional `export` block additively.
+  - Tests: per-portion vs per-100 g basis math, snapshot-hash staleness detection.
+  - Accept: exported recipe appears in CalorieTracker's food search; logging
+    `quantity: 2` there yields 2 portions' nutrients; editing the recipe shows the
+    stale-export indicator; re-export updates the same food doc.
 
-### LOW / NICE-TO-HAVE
+### P5 — Docs, polish, and hardening pass (small; before optional phases)
 
-_(empty — slot future ideas here, e.g. gramsPerUnit on links to compute nutrition from
-already-saved tracker foods that predate R1 data)_
+- [ ] **P5 Docs + migration sanity + UX debt.** Depends: P4.
+  - Update `ARCHITECTURE.md` (Recipe Standardizer section: link management, nutrition
+    pipeline, export contract, the do-not-add-fields-to-foodItems rule), `SECURITY.md`
+    (recipe tool now writes foodItems — same-user only), `README.md`, and the
+    tools-page card description.
+  - Migration sanity: load every pre-existing saved recipe shape in tests (fixture
+    without `gramsPerUnit`/`export`).
+  - UX debt: persist Ingredients-mode checkbox ticks per recipe (localStorage, keyed by
+    recipe id — follow `app/tools/transcriber/lib/settings.ts` versioned-object
+    pattern); confirm P1's pick-list closed the old "likely match review" gap.
+
+### P6 — OPTIONAL: direct diary logging from the recipe tool
+
+- [ ] **P6 "Log a portion to today."** Do NOT build unless the user explicitly asks
+  (deliberately last: duplicates tracker-owned logic). Writes
+  `dailyEntries/{YYYY-MM-DD}` exactly per v2 schema (`state/schema.js:71–125`): append
+  `{id: crypto.randomUUID(), name, quantity, timestamp, ...perUnitNutrients}` to
+  `foodItems[]`, add `quantity × nutrient` into top-level totals, set
+  `schemaVersion: 2`, preserve all other fields (read-modify-write of the whole doc).
+  Risks: schema drift with the tracker, concurrent same-day edits. Recommendation:
+  only build if logging inside the tracker (P4 flow) proves annoying in practice;
+  prefer a small CalorieTracker-side "import from recipe" instead if drift worries
+  grow (that alternative touches tracker code → run its test suite).
+
+### P7 — OPTIONAL: in-site Gemini enrichment
+
+- [ ] **P7 Edge route for nutrition enrichment.** Do NOT build unless the user
+  explicitly asks (relaxes the no-AI-calls stance — ship only if the manual round trip
+  proves tedious). One Edge route (`app/api/recipe-nutrition/route.ts`) reusing
+  `app/lib/aiConfig.ts` + `AVAILABLE_GEMINI_MODELS`, returning the exact same JSON
+  contract as P2's paste-back so it's just a second entry point into
+  `parseNutritionJson` → review table → create foods. Gate the button on key
+  availability (mirror Show Tracker's pattern). Update `SECURITY.md` (new API
+  surface); the route must not be admin-gated but should require Firebase auth if any
+  server secret is spent per call (follow `app/lib/verifyFirebaseAuth.ts` precedent).

--- a/backlogs/recipe-standardizer.md
+++ b/backlogs/recipe-standardizer.md
@@ -1,0 +1,191 @@
+# Recipe Standardizer — Nutrition Rollout Backlog
+
+Single source of truth for the Recipe Standardizer → Nutrition Tracker (CalorieTracker)
+integration rollout. The v1 tool (PR #149, merged) imports ChatGPT-converted recipes,
+scales gram-first, and *records* name-match links to CalorieTracker food items. This
+rollout makes those links useful end-to-end: nutrition data enters via the conversion
+prompt, ingredients can be pushed into the tracker, recipes compute their own nutrition,
+and whole recipes become loggable food items.
+
+## Parameters (for `backlogs/protocol.md`)
+
+- **Working branch:** `working/recipe-standardizer-backlog`
+- **Commit scope:** `recipe-standardizer`; item ids `R<N>` (next new id: **R7**; never reuse ids)
+- **Archive:** `backlogs/recipe-standardizer-completed.md`
+- **Tests:**
+  - Pure lib / schema / logic changes: `npm test` from repo root (vitest; covers
+    `app/tools/recipe-standardizer/__tests__/`). Add or update tests for every new pure
+    function, validator change, or regression fix.
+  - Component / page changes: also `npm run lint` and `npm run build`.
+  - Never touches `public/tools/CalorieTracker/` code, so its suite is not required —
+    unless an item explicitly changes tracker code (none currently do).
+
+## Session protocol
+
+Follow `backlogs/protocol.md` with the parameters above.
+
+## Context facts (verified against the codebase — do not re-derive)
+
+Read `ARCHITECTURE.md` § "Recipe Standardizer" for tool behavior. Key integration facts:
+
+- **Recipe storage:** one doc per recipe at
+  `artifacts/recipe-standardizer/users/{uid}/recipes/{recipeId}` shaped
+  `{ name, recipe, createdAt, updatedAt }` (`lib/db.ts`). Loads re-run the strict
+  validator (`lib/schema.ts` — pure, never throws, exact-path errors + non-fatal warnings).
+- **Tracker food storage:** `artifacts/default-app-id/users/{uid}/foodItems/{foodId}`.
+  Doc shape (see `public/tools/CalorieTracker/food/save.js`):
+  `{ name, quantity, <nutrient keys>, lastUpdated: <ISO string> }` — flat fields, no
+  nesting. Doc id = `name.toLowerCase().replace(/[^a-z0-9]/g, '_')`.
+- **Tracker semantics:** nutrient field values are **per 1 unit of `quantity`**; a log
+  entry adds `quantity × value` per nutrient (`food/manager.js`). `quantity` is a
+  unitless multiplier — the unit convention lives in the food's name.
+- **Nutrient keys:** `allNutrients` in `public/tools/CalorieTracker/constants.js` —
+  `calories, protein, carbs, fat, fiber, potassium, magnesium, sodium, calcium, choline,
+  vitaminB12, folate, vitaminC, vitaminB6, vitaminA, vitaminD, vitaminE, vitaminK,
+  selenium, iodine, phosphorus, iron, zinc, omega3`. Units follow the tracker's
+  `DEFAULT_BASELINE_TARGETS` conventions (standard US RDA units: kcal; g for
+  protein/carbs/fat/fiber/omega3; mg for potassium, magnesium, sodium, calcium, choline,
+  vitaminC, vitaminB6, vitaminE, iron, zinc, phosphorus; mcg for vitaminB12, folate,
+  vitaminA, vitaminD, vitaminK, selenium, iodine).
+- **Firestore rules:** the legacy wildcard `match /artifacts/{appId}/users/{userId}/{document=**}`
+  in `firestore.rules` already lets a signed-in user read/write **their own** foodItems
+  from any tool — no rules change needed for cross-tool writes, but `SECURITY.md` must
+  document each new write surface.
+- **Link model:** each ingredient carries `nutritionLink`
+  (`linked | likely | unlinked`, `lib/types.ts`). Matching (`lib/nutritionMatch.ts`):
+  exact normalized name → `linked`; token score ≥ 0.6 → `likely` + `needsUserReview`;
+  else `unlinked`. Re-matching (`applyNutritionMatches`) preserves only `linked` entries.
+- **No AI calls on the site:** nutrition data can only enter via the copyable ChatGPT
+  conversion prompt (`lib/prompt.ts`) + strict-JSON paste (`lib/schema.ts`), or manual
+  entry in the UI.
+- **Food list access:** `RecipeContext.loadFoodItems()` → `fetchFoodItems(uid)` in
+  `lib/db.ts` already reads the tracker's foodItems (id + name only today).
+
+## Invariants
+
+Preserve these unless the user explicitly asks to change them:
+
+- Grams (`quantityG`) stay the source of truth for quantities; `equivalent` is
+  display-only text.
+- Import stays strict-JSON with exact-path errors; the site never calls an AI API.
+- Any change to an already-saved recipe routes through `SaveChoiceModal`
+  (update / save-as-new / cancel) — no silent overwrites. The same "no silent
+  overwrite" rule applies to writes into the tracker's `foodItems` (duplicate check +
+  confirm, mirroring `food/save.js`'s duplicate dialog behavior).
+- Nutrition matching/linking/data **never blocks** importing or saving a recipe —
+  missing data degrades to warnings and coverage notes.
+- Any recipe shape change bumps `RECIPE_SCHEMA_VERSION` and must still load existing
+  v1 Firestore docs and v1 pasted JSON (normalize with defaults + non-fatal warning;
+  never reject).
+- Shopping/grocery views stay derived from ingredients at render time; no stored
+  shopping list.
+
+---
+
+## Active items
+
+Rollout goal: a user converts a recipe in ChatGPT (prompt now includes per-100 g
+nutrition), imports it, reviews/creates ingredient links, sees the recipe's computed
+nutrition, and can log either single ingredients or the whole recipe in the
+Nutrition Tracker. R1 → R2/R3 → R4/R5 is the dependency spine; R6 is the final
+real-data gate.
+
+### HIGH
+
+- [ ] **R1 Schema v2: per-ingredient nutrition data.** Add optional
+  `nutritionPer100g: Partial<Record<NutrientKey, number>> | null` to `RecipeIngredient`
+  (values per 100 g of the ingredient; `NutrientKey` = the 24 tracker keys listed in
+  Context facts, exported from a new shared constant in `lib/types.ts`). Bump
+  `RECIPE_SCHEMA_VERSION` to 2. Validator: v1 docs/JSON normalize to
+  `nutritionPer100g: null` (no error, no warning); reject non-numeric or negative
+  values with exact-path errors; unknown keys → non-fatal warning and dropped. Update
+  the ChatGPT prompt (`lib/prompt.ts`) to request best-estimate per-100 g values —
+  calories/protein/carbs/fat expected, micros optional, `null` when unknown — and
+  document the units. Show per-100 g data read-only in `IngredientEditModal` with
+  manual edit support.
+  Accept: v1 fixture still parses clean; v2 fixture round-trips; prompt text names the
+  exact keys and units; tests cover normalization, rejection, and unknown-key warning.
+  Files: `lib/types.ts`, `lib/schema.ts`, `lib/prompt.ts`,
+  `components/IngredientEditModal.tsx`, `__tests__/schema.test.ts`, `__tests__/fixtures.ts`.
+
+- [ ] **R2 Ingredient → tracker food item export.** Depends: R1. New pure
+  `lib/foodItemExport.ts`: `buildFoodItemDoc(ingredient)` → `{ id, data }` where
+  `data = { name: '<Ingredient name> (100g)', quantity: 1, ...nutritionPer100g mapped
+  onto flat tracker keys (absent keys → 0), lastUpdated: ISO }` and id is derived from
+  the full name per the tracker's id rule. Convention (document in ARCHITECTURE.md):
+  exported ingredient foods are per-100 g, so tracker `quantity` 1.5 = 150 g. New
+  `createFoodItem(uid, id, data)` in `lib/db.ts` (setDoc). UI: "Add to Nutrition
+  Tracker" action on `unlinked`/`likely` ingredients (IngredientEditModal and/or
+  IngredientsView badge), enabled only when `nutritionPer100g` has at least `calories`;
+  confirm modal previews name + values; duplicate guard — if the id or a
+  case-insensitive name match exists in the fetched food list, require an explicit
+  overwrite-or-rename choice, never silent. On success, re-run matching so the link
+  flips to `linked` with the new `foodItemId`. Update `SECURITY.md`: recipe tool now
+  writes to the CalorieTracker foodItems path (own-uid only, existing wildcard rule).
+  Accept: builder unit-tested (id derivation, key mapping, zero-fill, name suffix);
+  export → link flip verified manually; duplicate path can't clobber without confirm.
+  Files: `lib/foodItemExport.ts` (new), `lib/db.ts`, `RecipeContext.tsx`,
+  `components/IngredientEditModal.tsx`, `components/IngredientsView.tsx`,
+  `__tests__/foodItemExport.test.ts` (new), `SECURITY.md`, `ARCHITECTURE.md`.
+
+- [ ] **R3 Recipe nutrition computation + Overview display.** Depends: R1. New pure
+  `lib/nutrition.ts`: `computeRecipeNutrition(recipe)` sums
+  `quantityG × nutritionPer100g / 100` per ingredient into totals per nutrient key, and
+  returns `{ totals, perServing, perPortion, coverage }` — perServing from
+  `servings.currentServings ?? baselineServings`, perPortion from
+  `servings.portionCount` (else from total weight ÷ `portionSizeG`), and
+  `coverage = { includedCount, excluded: [{id, displayName, reason}] }` listing every
+  ingredient skipped for missing grams or missing nutrition data (never silently
+  pretend complete). Compute from the **scaled working copy** the UI renders, not the
+  baseline. UI: "Nutrition" block in the Overview accordion — macro line
+  (kcal / P / C / F) prominent, expandable micros table, coverage warning listing
+  excluded ingredients. Update the ARCHITECTURE.md line that says computing recipe
+  nutrition "is a documented follow-up, not in v1".
+  Accept: math unit-tested incl. null grams, null nutrition, zero servings/portions
+  (no division blowups), scaling factor applied; coverage list exact.
+  Files: `lib/nutrition.ts` (new), `components/RecipeWorkspace.tsx` (Overview),
+  `__tests__/nutrition.test.ts` (new), `ARCHITECTURE.md`.
+
+### MEDIUM
+
+- [ ] **R4 Batch link-review panel.** Depends: R2. One place to clear all
+  `needsUserReview` flags: a "Review links" surface in the Ingredients panel (workflow
+  mode) listing every `likely`/`unlinked` ingredient with per-row actions —
+  **accept** suggested match (→ `linked`, review flag off), **choose** from a
+  searchable list of fetched foods, **create** in tracker (reuse R2 flow), or
+  **dismiss** (stays `unlinked`, review flag off so it stops nagging). Pure
+  state-transition helpers for each action. Edits mark the recipe dirty and route
+  through the normal save flow — no new persistence path.
+  Accept: transitions unit-tested; review badge count reaches zero after a full pass;
+  dismissed items survive re-match (extend `applyNutritionMatches` to also preserve
+  dismissed links — note: today it only preserves `linked`).
+  Files: `lib/nutritionMatch.ts`, `components/IngredientsView.tsx` (or new
+  `components/LinkReviewPanel.tsx`), `__tests__/nutritionMatch.test.ts`.
+
+- [ ] **R5 Recipe → tracker food item export ("log this recipe").** Depends: R2, R3.
+  Button in Overview/Scaling area: writes ONE foodItems doc for the whole recipe —
+  name = recipe name, nutrient values = R3's `perPortion` (fallback `perServing`;
+  if neither is derivable, disable with an explanatory tooltip), `quantity: 1` = one
+  portion. Same confirm + duplicate guard as R2. If coverage is incomplete, the confirm
+  modal must show the excluded-ingredient list and require explicit "export partial"
+  acknowledgement. Document the per-portion convention in ARCHITECTURE.md.
+  Accept: builder path unit-tested (portion fallback chain, partial-coverage flag);
+  exported doc loggable in the tracker.
+  Files: `lib/foodItemExport.ts`, `components/RecipeWorkspace.tsx` and/or
+  `components/ScalingPanel.tsx`, `__tests__/foodItemExport.test.ts`, `ARCHITECTURE.md`.
+
+### ROLLOUT GATE (work last)
+
+- [ ] **R6 Real-recipe rollout QA.** Depends: R1–R5 merged. The user converts their real
+  recipe collection in ChatGPT with the updated prompt and imports each recipe. Agent's
+  role per session: take the user's reported friction (validation errors, prompt
+  misses, bad matches, unit mistakes), fix `lib/prompt.ts` / `lib/schema.ts` /
+  matcher thresholds accordingly, and keep a one-line running friction note on this
+  item. Do not start R6 work unless the user supplies recipes or reports friction.
+  Accept (user-confirmed): their collection imports cleanly with nutrition data, links
+  reviewed to zero flags, and at least one recipe logged in the tracker end-to-end.
+
+### LOW / NICE-TO-HAVE
+
+_(empty — slot future ideas here, e.g. gramsPerUnit on links to compute nutrition from
+already-saved tracker foods that predate R1 data)_

--- a/public/tools/CalorieTracker/BACKLOG.md
+++ b/public/tools/CalorieTracker/BACKLOG.md
@@ -4,4 +4,4 @@ The canonical CalorieTracker backlog now lives at:
 
 `../../../backlogs/calorie-tracker.md`
 
-Agents should read that file for the resume protocol, branch and PR workflow, item statuses, and test requirements.
+Agents should read `../../../backlogs/protocol.md` for the shared resume protocol, branch and PR workflow, and status legend; the file above holds CalorieTracker parameters, invariants, and item statuses.

--- a/public/tools/CalorieTracker/README.md
+++ b/public/tools/CalorieTracker/README.md
@@ -2,7 +2,7 @@
 
 A Firebase-backed, client-side nutrition tracker built with plain JavaScript ES modules and Chart.js. Runs as a standalone static app under `/public/tools/CalorieTracker/` and is linked from the main site's Tools page.
 
-> **Active work:** See [`backlogs/calorie-tracker.md`](../../../backlogs/calorie-tracker.md) at the repo root — the single source of truth for ongoing CalorieTracker work, including the session-continuation protocol, branch/PR strategy, status legend, and the prioritized item list. To pick up where a prior session left off, start a new session with any of _"start working on the backlog"_, _"continue working on the CalorieTracker backlog"_, or a close paraphrase — the protocol (reconcile merged items, then work the top-priority items) runs automatically.
+> **Active work:** See [`backlogs/calorie-tracker.md`](../../../backlogs/calorie-tracker.md) at the repo root — the single source of truth for ongoing CalorieTracker work (parameters, invariants, and the prioritized item list; the shared session protocol lives in [`backlogs/protocol.md`](../../../backlogs/protocol.md)). To pick up where a prior session left off, start a new session with any of _"start working on the backlog"_, _"continue working on the CalorieTracker backlog"_, or a close paraphrase — the protocol (reconcile merged items, then work the top-priority items) runs automatically.
 
 ---
 


### PR DESCRIPTION
- backlogs/recipe-standardizer.md: new backlog with verified context facts
  (Firestore paths, CalorieTracker foodItems doc shape and per-quantity
  semantics, the 24 nutrient keys/units, rules coverage, link model) plus
  rollout items R1-R6 with pre-made design decisions, acceptance criteria,
  file lists, and dependencies.
- backlogs/protocol.md: shared session protocol extracted from the
  CalorieTracker backlog (resume steps, reconcile-to-[x] rule, status
  legend, commit/PR format, branch strategy), parameterized per backlog.
- backlogs/calorie-tracker.md: slimmed to Parameters + invariants + active
  items; items #57/#58 and their notes unchanged.
- backlogs/recipe-standardizer-completed.md: empty archive stub.
- BACKLOG.md: priority-ordered index plus the dispatch rule so 'continue
  working on backlog' resolves deterministically without naming a backlog.
- AGENTS.md, CLAUDE.md, AI_AGENTS.md, CalorieTracker README/BACKLOG
  pointers updated to the new structure; Recipe Standardizer test-selection
  line added to the testing policy.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AT6EhuUvJr19WE1U1ihfDp